### PR TITLE
Add K'iche' as a language on the dashboard for translations

### DIFF
--- a/Dashboard/app/js/lib/controllers/languages.js
+++ b/Dashboard/app/js/lib/controllers/languages.js
@@ -315,6 +315,10 @@ FLOW.isoLanguagesDict = {
     "name": "Khmer",
     "nativeName": "ភាសាខ្មែរ"
   },
+  "quc": {
+    "name":"K'iche', Quiché",
+    "nativeName": "K'iche', Quiché"
+  },
   "ki": {
     "name": "Kikuyu, Gikuyu",
     "nativeName": "Gĩkũyũ"


### PR DESCRIPTION
The same addition has been made in akvo-flow-mobile
