### PR TITLE
Add K'iche' as a language on the dashboard for translations

### DIFF
--- a/Dashboard/app/js/lib/controllers/languages.js
+++ b/Dashboard/app/js/lib/controllers/languages.js
@@ -317,7 +317,7 @@ FLOW.isoLanguagesDict = {
   },
   "quc": {
     "name":"K'iche', Quiché",
-    "nativeName": "K'iche', Quiché"
+    "nativeName": "K'iche'"
   },
   "ki": {
     "name": "Kikuyu, Gikuyu",


### PR DESCRIPTION
The same addition has been made in akvo-flow-mobile
