### PR TITLE
[#487] Add survey group columns to survey header response

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyManagerServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyManagerServlet.java
@@ -61,8 +61,8 @@ public class SurveyManagerServlet extends AbstractRestApiServlet {
 	 * always send this values to enable APK backwards compatibility
 	 */
 	private final static String IS_IN_MONITORING_GROUP = "false";
-	private final static String NEW_LOCALE_SURVEYID    = "null";
-	private final static String UNKNOWN                = "unknown";
+	private final static String NEW_LOCALE_SURVEYID = "null";
+	private final static String UNKNOWN = "unknown";
 
 	private DeviceDAO deviceDao;
 


### PR DESCRIPTION
- Add survey group id and name, plus constants false (monitored) and
  null registration survey id
- Include this info in both survey header response and surveys-for-phone
  response
