### PR TITLE
[#363] Save reference to surveyedLocale when reingesting instance

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
+++ b/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
@@ -460,6 +460,8 @@ public class SurveyalRestServlet extends AbstractRestApiServlet {
 						}
 					}
 				}
+				surveyedLocaleDao.save(locale);
+				surveyInstanceDao.save(instance);
 			}
 		}
 	}


### PR DESCRIPTION
In the code path, we set the reference using `instance.setSurveyedLocaleId` but we don't save it
