### PR TITLE
[#559] Implement APK download as Dashboard url

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/ApkRedirectServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/ApkRedirectServlet.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2014 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.app.web;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.waterforpeople.mapping.dao.DeviceApplicationDao;
+import org.waterforpeople.mapping.domain.DeviceApplication;
+
+public class ApkRedirectServlet extends HttpServlet {
+
+	private static final long serialVersionUID = 8394168365501522124L;
+	private static final String ANDROID = "androidPhone";
+	private static final String FIELDSURVEY = "fieldSurvey";
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
+			IOException {
+		final DeviceApplicationDao dao = new DeviceApplicationDao();
+		final List<DeviceApplication> apps = dao
+				.listByDeviceTypeAndAppCode(ANDROID, FIELDSURVEY, 1);
+
+		if (apps == null || apps.size() == 0 || apps.get(0).getFileName() == null) {
+			resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			resp.getWriter().append("NOT FOUND");
+			return;
+		}
+
+		resp.sendRedirect(apps.get(0).getFileName());
+	}
+}

--- a/GAE/war/WEB-INF/web.xml
+++ b/GAE/war/WEB-INF/web.xml
@@ -55,6 +55,15 @@
 		<servlet-name>EnvServlet</servlet-name>
 		<url-pattern>/flowenv.js</url-pattern>
 	</servlet-mapping>
+		<servlet>
+
+	<servlet-name>ApkRedirectServlet</servlet-name>
+		<servlet-class>org.waterforpeople.mapping.app.web.ApkRedirectServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>ApkRedirectServlet</servlet-name>
+		<url-pattern>/app</url-pattern>
+	</servlet-mapping>
 
 	<servlet>
         <servlet-name>StringsServlet</servlet-name>

--- a/GAE/war/robots.txt
+++ b/GAE/war/robots.txt
@@ -11,3 +11,4 @@ Disallow: /devicefilesrestapi
 Disallow: /placemarkrestapi
 Disallow: /rawdatarestapi
 Disallow: /remote_api
+Disallow: /app


### PR DESCRIPTION
- Visiting the http://instance.akvoflow.org/app redirects the browser to
  the S3 location where the APK is stored
- The redirection is to the latest published APK for that instance
- If the instance doesn't have any published APK, a "NOT FOUND" (HTTP
  404) is replied
