### PR TITLE
[#556] Solve NPE when SurveyedLocale has no geocells set

### DIFF
--- a/GAE/src/com/gallatinsystems/gis/map/MapUtils.java
+++ b/GAE/src/com/gallatinsystems/gis/map/MapUtils.java
@@ -62,7 +62,7 @@ public class MapUtils {
         Long surveyId = null;
         String surveyIdString = "";
 
-        if (locale.getGeocells() == null) {
+        if (locale.getGeocells() == null || locale.getGeocells().size() == 0) {
             // nothing to do
             return;
         }

--- a/GAE/src/org/waterforpeople/mapping/app/web/TestHarnessServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/TestHarnessServlet.java
@@ -155,7 +155,7 @@ public class TestHarnessServlet extends HttpServlet {
 
                 deleteSurveyResponses(
                         Long.parseLong(req.getParameter("surveyId")),
-                        Integer.parseInt(req.getParameter("count")));
+                        req.getParameter("count") != null ? Integer.parseInt(req.getParameter("count")) : null);
             }
         } else if ("changeLocaleType".equals(action)) {
             String surveyId = req


### PR DESCRIPTION
The `/webapp/testharness?action=deleteSurveyResponses` results in an NPE when there are no geocells for a SurveyedLocale.  This is observed when testing issue #613.
