### PR TITLE
[#641] Clear viewport when creating new survey group

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -195,6 +195,8 @@ FLOW.surveyControl = Ember.ArrayController.create({
       this.set('content', FLOW.store.findQuery(FLOW.Survey, {
         surveyGroupId: id
       }));
+    } else {
+      this.set('content', null);
     }
   }.observes('FLOW.selectedControl.selectedSurveyGroup'),
 

--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -203,11 +203,11 @@ FLOW.Router = Ember.Router.extend({
         route: '/current-devices',
         connectOutlets: function (router, context) {
           router.get('navDevicesController').connectOutlet('currentDevices');
+          router.resetState();
           FLOW.deviceGroupControl.populate();
           FLOW.deviceControl.populate();
           FLOW.surveyAssignmentControl.populate();
           FLOW.surveyGroupControl.populate();
-          router.resetState();
           router.set('devicesSubnavController.selected', 'currentDevices');
         }
       }),


### PR DESCRIPTION
- Clear surveys from the view port when creating a new survey group
- Reset router state when navigating to devices tab _before_ populating controls
