### PR TITLE
[#653] Fixes issue when generating reports on non monitoring group

### DIFF
--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -64,7 +64,7 @@ FLOW.ReportLoader = Ember.Object.create({
       criteria.opts.locale = FLOW.reportLanguageControl.get('selectedLanguage').get('value');
     }
 
-    criteria.opts.lastCollection = '' + (exportType === 'RAW_DATA' && !!FLOW.editControl.lastCollection);
+    criteria.opts.lastCollection = '' + (exportType === 'RAW_DATA' && FLOW.selectedControl.get('selectedSurveyGroup').get('monitoringGroup') && !!FLOW.editControl.lastCollection);
 
     this.set('criteria', criteria);
     FLOW.savingMessageControl.numLoadingChange(1);
@@ -84,7 +84,7 @@ FLOW.ReportLoader = Ember.Object.create({
       FLOW.savingMessageControl.numLoadingChange(-1);
       this.set('processing', false);
       this.set('criteria', null);
-      $('#downloader').attr('src', FLOW.Env.flowServices.split(":3001")[0] + '/report/' + resp.file);
+      $('#downloader').attr('src', FLOW.Env.flowServices + '/report/' + resp.file);
     }
   },
 

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -512,10 +512,15 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             SummaryModel model) throws Exception {
         int col = 0;
         MessageDigest digest = MessageDigest.getInstance("MD5");
-        createCell(row, col++, dto.getSurveyedLocaleIdentifier(), null);
-        createCell(row, col++, dto.getSurveyedLocaleDisplayName(), null);
+
+        if (monitoringGroup) {
+            createCell(row, col++, dto.getSurveyedLocaleIdentifier(), null);
+            createCell(row, col++, dto.getSurveyedLocaleDisplayName(), null);
+        }
+
         createCell(row, col++, instanceId, null);
         createCell(row, col++, dateString, null);
+
         if (dto != null) {
             String name = dto.getSubmitterName();
             if (name != null) {
@@ -654,7 +659,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
         List<String> nonSummarizableList = new ArrayList<String>();
 
         if (questionMap != null) {
-            int offset = columnIdx + 1;
+            int offset = columnIdx;
             for (QuestionGroupDto group : orderedGroupList) {
                 if (questionMap.get(group) != null) {
                     for (QuestionDto q : questionMap.get(group)) {


### PR DESCRIPTION
- The RAW DATA report was generating the content (rows 1...) with some
  columns off
- The `lastCollection` property should be set to `true` only in
  monitoring groups
