### PR TITLE
[#656] Use a Text property for values longer than 500 chars

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/TestHarnessServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/TestHarnessServlet.java
@@ -19,6 +19,7 @@ package org.waterforpeople.mapping.app.web;
 import static com.gallatinsystems.common.util.MemCacheUtils.initCache;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,8 +34,10 @@ import org.waterforpeople.mapping.app.web.dto.DataProcessorRequest;
 import org.waterforpeople.mapping.app.web.rest.security.AppRole;
 import org.waterforpeople.mapping.app.web.test.DeleteObjectUtil;
 import org.waterforpeople.mapping.dao.AccessPointDao;
+import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
 import org.waterforpeople.mapping.dao.SurveyInstanceDAO;
 import org.waterforpeople.mapping.domain.AccessPoint;
+import org.waterforpeople.mapping.domain.QuestionAnswerStore;
 import org.waterforpeople.mapping.domain.SurveyInstance;
 
 import com.beoui.geocell.GeocellManager;
@@ -155,7 +158,8 @@ public class TestHarnessServlet extends HttpServlet {
 
                 deleteSurveyResponses(
                         Long.parseLong(req.getParameter("surveyId")),
-                        req.getParameter("count") != null ? Integer.parseInt(req.getParameter("count")) : null);
+                        req.getParameter("count") != null ? Integer.parseInt(req
+                                .getParameter("count")) : null);
             }
         } else if ("changeLocaleType".equals(action)) {
             String surveyId = req
@@ -388,6 +392,59 @@ public class TestHarnessServlet extends HttpServlet {
                 // so we fire the task without the surveyId parameter.
                 queue.add(to);
             }
+        } else if ("testTextQAS".equals(action)) {
+
+            final StringBuffer sb = new StringBuffer();
+            final QuestionAnswerStoreDao dao = new QuestionAnswerStoreDao();
+
+            for (int i = 0; i < 16; i++) {
+                sb.append(java.util.UUID.randomUUID().toString());
+            }
+
+            final String val1 = sb.toString();
+            final String val2 = "TEST";
+
+            QuestionAnswerStore qas1 = new QuestionAnswerStore();
+            qas1.setArbitratyNumber(0L);
+            qas1.setQuestionID("0");
+            qas1.setSurveyId(0L);
+            qas1.setSurveyInstanceId(0L);
+            qas1.setValue(val1);
+
+            qas1 = dao.save(qas1);
+
+            QuestionAnswerStore qas2 = new QuestionAnswerStore();
+            qas2.setArbitratyNumber(1L);
+            qas2.setQuestionID("1");
+            qas2.setSurveyId(1L);
+            qas2.setSurveyInstanceId(1L);
+            qas2.setValue(val2);
+
+            qas2 = dao.save(qas2);
+
+            assert dao.listBySurveyInstance(0L, 0L, "0").get(0).getValue().equals(val1);
+            assert dao.listBySurveyInstance(1L, 1L, "1").get(0).getValue().equals(val2);
+
+            qas1.setValue(val2);
+            qas2.setValue(val1);
+
+            qas1 = dao.save(qas1);
+            qas2 = dao.save(qas2);
+
+            assert dao.listBySurveyInstance(0L, 0L, "0").get(0).getValue().equals(val2);
+            assert dao.listBySurveyInstance(1L, 1L, "1").get(0).getValue().equals(val1);
+
+            dao.delete(qas1);
+            dao.delete(qas2);
+
+            try {
+                PrintWriter w = resp.getWriter();
+                w.write("OK");
+                w.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
         }
     }
 

--- a/GAE/src/org/waterforpeople/mapping/domain/QuestionAnswerStore.java
+++ b/GAE/src/org/waterforpeople/mapping/domain/QuestionAnswerStore.java
@@ -24,10 +24,12 @@ import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 
 import com.gallatinsystems.framework.domain.BaseDomain;
+import com.google.appengine.api.datastore.Text;
 
 @PersistenceCapable(identityType = IdentityType.APPLICATION)
 public class QuestionAnswerStore extends BaseDomain {
     private static final long serialVersionUID = 3726562582080475960L;
+    private static final int MAX_LENGTH = 500;
 
     @Persistent
     private Long arbitratyNumber;
@@ -37,6 +39,12 @@ public class QuestionAnswerStore extends BaseDomain {
     private String type;
     @Persistent
     private String value;
+    /**
+     * This property holds the value response value when exceeds 500 characters<br>
+     * See: https://developers
+     * .google.com/appengine/docs/java/javadoc/com/google/appengine/api/datastore/Text
+     */
+    private Text valueText;
     private Date collectionDate;
     private Long surveyId;
     private Long surveyInstanceId;
@@ -100,11 +108,25 @@ public class QuestionAnswerStore extends BaseDomain {
     }
 
     public String getValue() {
-        return value;
+        if (value != null) {
+            return value;
+        }
+        if (valueText != null) {
+            return valueText.getValue();
+        }
+        return null;
     }
 
     public void setValue(String value) {
-        this.value = value;
+        // Explicitly set the non used property to null
+        // to avoid problems when reading the value
+        if (value != null && value.length() > MAX_LENGTH) {
+            this.value = null;
+            this.valueText = new Text(value);
+        } else {
+            this.valueText = null;
+            this.value = value;
+        }
     }
 
     public String getQuestionID() {


### PR DESCRIPTION
- Introduce a new property `valueText` that is used to store the
  response value for large strings (more than 500 chars)
- The `setValue` and `getValue` methods check for the properties `value`
  and `valueText` for storing and reading the value
