### PR TITLE
[#665] Updated rake build call for Dashboard

### DIFF
--- a/GAE/build.xml
+++ b/GAE/build.xml
@@ -169,9 +169,12 @@
 
 		<echo message="Rebuilding Dashboard..." />
 
-		<exec dir="../Dashboard" executable="rake" failonerror="true">
+		<exec dir="../Dashboard" executable="bundle" failonerror="true">
 		    <env key="RAKEP_MODE" value="production" />
+		    <arg value="exec" />
+		    <arg value="rake" />
 		    <arg value="build" />
+		    <arg value="--trace" />
 		</exec>
 
 		<exec dir="../" executable="git" outputproperty="app.version">


### PR DESCRIPTION
This ensures the bundled version of rake is called so that the expected
rake-pipeline and other bundled gems are accessible, which may not always
be the case esp. in a virtual Ruby environment.
Also added --trace parameter to show all Ember build output.
