### PR TITLE
[#667] Updated RubyGems source URL to clear deprecation warnings

### DIFF
--- a/Dashboard/Gemfile
+++ b/Dashboard/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org/'
 
 gem 'colored'
 

--- a/Dashboard/Gemfile.lock
+++ b/Dashboard/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
       rake-pipeline (~> 0.6)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     POpen4 (0.1.4)
       Platform (>= 0.4.0)


### PR DESCRIPTION
The older :rubygems and HTTP sources are now considered insecure.
