### PR TITLE
[#483] Updated Dashboard build properties template for GAE SDK 1.9.7

### DIFF
--- a/GAE/build.properties.template
+++ b/GAE/build.properties.template
@@ -1,4 +1,4 @@
-sdk.dir=/usr/local/sdk/gae/java-sdk-1.7.6
+sdk.dir=/usr/local/sdk/gae/java-sdk-1.9.7
 gwtlibs.dir=/usr/local/sdk/gwt/2.5.1
 email.address=some_user@gmail.com
 keystore.password=[some_password]


### PR DESCRIPTION
Tested a build with the 1.9.7 SDK and deployed to akvoflow-dev1, which seems to be operating as expected.
