### PR TITLE
[#725] Property signingKey is required

### DIFF
--- a/Config/instanceConfigurator/src/org/akvo/flow/InstanceConfigurator.java
+++ b/Config/instanceConfigurator/src/org/akvo/flow/InstanceConfigurator.java
@@ -80,6 +80,7 @@ public class InstanceConfigurator {
         String emailFrom = cli.getOptionValue("ef");
         String emailTo = cli.getOptionValue("et");
         String orgName = cli.getOptionValue("on");
+        String signingKey = cli.getOptionValue("sk");
 
         File out = new File(outFolder);
 
@@ -215,6 +216,7 @@ public class InstanceConfigurator {
         webData.put("emailFrom", emailFrom);
         webData.put("emailTo", emailTo);
         webData.put("organization", orgName);
+        webData.put("signingKey", signingKey);
 
         Template t5 = cfg.getTemplate("appengine-web.xml.ftl");
         FileWriter fw3 = new FileWriter(new File(out, "/appengine-web.xml"));
@@ -279,6 +281,11 @@ public class InstanceConfigurator {
         alias.setArgs(1);
         alias.setRequired(true);
 
+        Option signingKey = new Option("sk", "Signing Key");
+        signingKey.setLongOpt("signingKey");
+        signingKey.setArgs(1);
+        signingKey.setRequired(true);
+
         options.addOption(orgName);
         options.addOption(awsId);
         options.addOption(awsSecret);
@@ -289,6 +296,7 @@ public class InstanceConfigurator {
         options.addOption(outputFolder);
         options.addOption(flowServices);
         options.addOption(alias);
+        options.addOption(signingKey);
 
         return options;
     }

--- a/Config/instanceConfigurator/src/org/akvo/flow/templates/appengine-web.xml.ftl
+++ b/Config/instanceConfigurator/src/org/akvo/flow/templates/appengine-web.xml.ftl
@@ -32,6 +32,7 @@
         <property name="mapiconimageroot" value="${s3url}/images/mapicons"/>
         <property name="scoreAPFlag" value="true"/>
         <property name="organization" value="${organization}"/>
+        <property name="signingKey" value="${signingKey}" />
         <property name="allowUnsignedData" value="true" />
         <property name="defaultOrg" value="${organization}" />
         <property name="domainType" value="locale" />

--- a/GAE/src/org/waterforpeople/mapping/app/web/TaskServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/TaskServlet.java
@@ -103,7 +103,7 @@ public class TaskServlet extends AbstractRestApiServlet {
 
     /**
      * Retrieve the file from S3 storage and persist the data to the data store
-     * 
+     *
      * @param fileName
      * @param phoneNumber
      * @param imei
@@ -367,8 +367,11 @@ public class TaskServlet extends AbstractRestApiServlet {
             }
             zis.closeEntry();
         }
+
         // check the signature if we have it
-        if (surveyDataOnly != null && dataSig != null) {
+        String allowUnsigned = PropertyUtil.getProperty(ALLOW_UNSIGNED);
+
+        if ("false".equalsIgnoreCase(allowUnsigned) && surveyDataOnly != null && dataSig != null) {
             try {
                 MessageDigest sha1Digest = MessageDigest.getInstance("SHA1");
                 byte[] digest = sha1Digest.digest(surveyDataOnly
@@ -383,30 +386,17 @@ public class TaskServlet extends AbstractRestApiServlet {
                 String encodedHmac = com.google.gdata.util.common.util.Base64
                         .encode(hmac);
                 if (!encodedHmac.trim().equals(dataSig.trim())) {
-                    String allowUnsigned = PropertyUtil
-                            .getProperty(ALLOW_UNSIGNED);
-                    if (allowUnsigned != null
-                            && allowUnsigned.trim().equalsIgnoreCase("false")) {
-                        throw new SignedDataException(
-                                "Computed signature does not match the one submitted with the data");
-                    } else {
-                        log.warning("Signatures don't match. Processing anyway since allow unsigned is true");
-                    }
+                    throw new SignedDataException(
+                            "Computed signature does not match the one submitted with the data");
                 }
             } catch (GeneralSecurityException e) {
-                throw new SignedDataException("Could not calculate signature",
-                        e);
+                throw new SignedDataException("Could not calculate signature", e);
             }
 
         } else if (surveyDataOnly != null) {
             // if there is no signature, check the configuration to see if we
             // are allowed to proceed
-            String allowUnsigned = PropertyUtil.getProperty(ALLOW_UNSIGNED);
-            if (allowUnsigned != null
-                    && allowUnsigned.trim().equalsIgnoreCase("false")) {
-                throw new SignedDataException(
-                        "Datafile does not have a signature");
-            }
+            throw new SignedDataException("Datafile does not have a signature");
         }
 
         return lines;
@@ -467,7 +457,7 @@ public class TaskServlet extends AbstractRestApiServlet {
      * handles the callback from the device indicating that a new data file is available. This
      * method will call processFile to retrieve the file and persist the data to the data store it
      * will then add access points for each water point in the survey responses.
-     * 
+     *
      * @param req
      */
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
- The signingKey property is required for calculating and comparing the
  value in .sig file produced by the device
- Recover the option in the InstanceConfigurator
- Optimize the code for not executing the signature calculation if
  `allowUnsignedData` is true
