### PR TITLE
[#749] Deprecate UploadConstants.properties, sync property names

### DIFF
--- a/Config/instanceConfigurator/src/org/akvo/flow/InstanceConfigurator.java
+++ b/Config/instanceConfigurator/src/org/akvo/flow/InstanceConfigurator.java
@@ -192,25 +192,13 @@ public class InstanceConfigurator {
         Map<String, Object> apkData = new HashMap<String, Object>();
         apkData.put("awsBucket", bucketName);
         apkData.put("awsAccessKeyId", accessKeys.get(apkUser).getAccessKeyId());
-        apkData.put("awsSecretAccessKey", accessKeys.get(apkUser).getSecretAccessKey());
+        apkData.put("awsSecretKey", accessKeys.get(apkUser).getSecretAccessKey());
         apkData.put("serverBase", "https://" + gaeId + ".appspot.com");
         apkData.put("restApiKey", apiKey);
 
         Template t3 = cfg.getTemplate("survey.properties.ftl");
         FileWriter fw = new FileWriter(new File(out, "/survey.properties"));
         t3.process(apkData, fw);
-
-        // UploadConstants.properties
-        Map<String, Object> gaeData = new HashMap<String, Object>();
-        gaeData.put("awsBucket", bucketName);
-        gaeData.put("awsAccessKeyId", accessKeys.get(gaeUser).getAccessKeyId());
-        gaeData.put("awsSecretAccessKey", accessKeys.get(gaeUser).getSecretAccessKey());
-        gaeData.put("serverBase", "https://" + gaeId + ".appspot.com");
-        gaeData.put("apiKey", apiKey);
-
-        Template t4 = cfg.getTemplate("UploadConstants.properties.ftl");
-        FileWriter fw2 = new FileWriter(new File(out, "/UploadConstants.properties"));
-        t4.process(gaeData, fw2);
 
         // appengine-web.xml
         Map<String, Object> webData = new HashMap<String, Object>();

--- a/Config/instanceConfigurator/src/org/akvo/flow/templates/UploadConstants.properties.ftl
+++ b/Config/instanceConfigurator/src/org/akvo/flow/templates/UploadConstants.properties.ftl
@@ -1,4 +1,0 @@
-awsBucket = ${awsBucket}
-awsAccessKeyId = ${awsAccessKeyId}
-awsSecretAccessKey = ${awsSecretAccessKey}
-apiKey = ${apiKey}

--- a/Config/instanceConfigurator/src/org/akvo/flow/templates/survey.properties.ftl
+++ b/Config/instanceConfigurator/src/org/akvo/flow/templates/survey.properties.ftl
@@ -1,5 +1,5 @@
 awsBucket = ${awsBucket}
 awsAccessKeyId = ${awsAccessKeyId}
-awsSecretAccessKey = ${awsSecretAccessKey}
+awsSecretKey = ${awsSecretKey}
 serverBase = ${serverBase}
 apiKey = ${restApiKey}


### PR DESCRIPTION
- UploadConstant.properties is not needed anymore as the configuration
  data is already in appengine-web.xml
- Use awsAccessKeyId and awsSecretKey property names
