### PR TITLE
[#814] Move the Question Id form field down

### DIFF
--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -3,6 +3,8 @@
 <div class="innerContent" id="innerContent_01">
   {{#if view.amOpenQuestion}}
     <h1 class="questionNbr"><span>{{view.content.order}}} </span>{{view.content.text}}</h1>
+    <label>{{t _question_text}}: {{view Ember.TextField valueBinding="view.text" size=100 }}</label>
+    <label>{{t _question_help_tooltip}}: <span class="fadedText">({{t _optional}})</span> {{view Ember.TextField valueBinding="view.tip" size=100 }} </label>
     <label>
       {{t _question_id}}: {{tooltip _question_id_tooltip}}
       {{#if view.questionIdValidationFailure }}
@@ -10,9 +12,6 @@
       {{/if}}
       {{view Ember.TextField valueBinding="view.questionId" size=100}}
     </label>
-    <label>{{t _question_text}}: {{view Ember.TextField valueBinding="view.text" size=100 }}</label>
-    <label>{{t _question_help_tooltip}}: <span class="fadedText">({{t _optional}})</span> {{view Ember.TextField valueBinding="view.tip" size=100 }} </label>
-
     <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.mandatoryFlag"}}{{t _mandatory}}</label>
   {{#if FLOW.Env.showStatisticsFeature}}
     <label class="selectinLabel"><span>{{t _tag}} {{tooltip _what_is_tag}}:</span> {{view Ember.Select


### PR DESCRIPTION
I moved the question Id form field down two steps so now the order is
- Question title
- Question tooltip
- Question id
- ...
