### PR TITLE
[#797] Display name and locale identifiers missing in RAW DATA report

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -364,8 +364,10 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
             SurveyedLocaleDao slDao = new SurveyedLocaleDao();
             SurveyedLocale sl = slDao.getById(instance.getSurveyedLocaleId());
             if (sl != null) {
-                dto.setSurveyedLocaleIdentifier(sl.getIdentifier());
-                dto.setSurveyedLocaleDisplayName(sl.getDisplayName());
+                dto.setSurveyedLocaleIdentifier(sl.getIdentifier() == null ? "" : sl
+                        .getIdentifier());
+                dto.setSurveyedLocaleDisplayName(sl.getDisplayName() == null ? "" : sl
+                        .getDisplayName());
             }
 
         }


### PR DESCRIPTION
Always retrieve these two elements from the corresponding  `SurveyedLocale` when generating the report
