### PR TITLE
[#959] Use name instead of code for Surveys/Forms

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/survey-group-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-group-views.js
@@ -64,16 +64,16 @@ FLOW.Project = FLOW.View.extend({
 FLOW.ProjectMainView = FLOW.View.extend({
 
   doSave: function() {
-    currentProject = FLOW.projectControl.get('currentProject');
-    currentForm = FLOW.selectedControl.get('selectedSurvey');
+    var currentProject = FLOW.projectControl.get('currentProject');
+    var currentForm = FLOW.selectedControl.get('selectedSurvey');
 
     if (currentProject && currentProject.get('isDirty')) {
-      currentProject.set('name', currentProject.get('code'));
+      currentProject.set('code', currentProject.get('name'));
       currentProject.set('path', FLOW.projectControl.get('currentProjectPath'));
     }
 
     if (currentForm && currentForm.get('isDirty')) {
-      currentForm.set('name', currentForm.get('code'));
+      currentForm.set('code', currentForm.get('name'));
       path = FLOW.projectControl.get('currentProjectPath') + "/" + currentForm.get('name');
       currentForm.set('path', path);
     }

--- a/Dashboard/app/js/templates/navSurveys/form.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/form.handlebars
@@ -19,7 +19,7 @@
 			{{/unless}}
 			<form class="surveyDetailForm">
 				<label>{{t _form_title}}</label>
-				{{view Ember.TextField valueBinding="form.code"}}
+				{{view Ember.TextField valueBinding="form.name"}}
 				<label>{{t _form_description}}</label>
 				{{view Ember.TextField valueBinding="form.description"}}
 				<label>{{t _manage}}</label>

--- a/Dashboard/app/js/templates/navSurveys/project.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/project.handlebars
@@ -4,7 +4,7 @@
     <div id="pageWrap" class="widthConstraint belowHeader">
       <section id="main" class="projectSection floats-in middleSection" role="main">
         <section id="" class="projectDetailsPanel">
-          <span class="fontInfo">{{t _survey}}:</span><h2>{{FLOW.projectControl.currentProject.code}}</h2>
+          <span class="fontInfo">{{t _survey}}:</span><h2>{{FLOW.projectControl.currentProject.name}}</h2>
           <ul class="projectSummary">
             <li>{{t _forms}}<span class="projectForm">{{FLOW.projectControl.formCount}}</span>
             </li>
@@ -43,7 +43,7 @@
             {{/unless}}
             {{#if view.visibleProjectBasics}}
               <form class="projectDetailForm">
-                <label>{{t _survey_title}}</label>{{view Ember.TextField id="projectTitle" valueBinding="FLOW.projectControl.currentProject.code"}}
+                <label>{{t _survey_title}}</label>{{view Ember.TextField id="projectTitle" valueBinding="FLOW.projectControl.currentProject.name"}}
                 <label>{{t _survey_description}}</label>{{view Ember.TextField id="projectDescription" valueBinding="FLOW.projectControl.currentProject.description"}}
 
                 <ul class="projectSelect floats-in">
@@ -108,7 +108,7 @@
                   <ul>
                     {{#each form in FLOW.surveyControl}}
                       {{#view FLOW.FormTabView contentBinding="form"}}
-                        <a {{action "selectForm" form target="FLOW.surveyControl"}}>{{form.code}}</a></li>
+                        <a {{action "selectForm" form target="FLOW.surveyControl"}}>{{form.name}}</a></li>
                       {{/view}}
                     {{/each}}
                     {{#if FLOW.projectControl.currentProject.monitoringGroup}}
@@ -119,7 +119,7 @@
                 <section class="formsContainer">
                     <div id="form01">
                     {{#if FLOW.selectedControl.selectedSurvey}}
-                      <h3>{{FLOW.selectedControl.selectedSurvey.code}}</h3>
+                      <h3>{{FLOW.selectedControl.selectedSurvey.name}}</h3>
                       {{view FLOW.FormView}}
                     {{/if}}
                     </div>

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -173,6 +173,10 @@ public class SurveyGroupRestService {
                             "createdDateTime", "lastUpdateDateTime",
                             "displayName", "questionGroupList"
                     });
+
+                    // Make sure that code and name are the same
+                    s.setCode(s.getName());
+
                     s = surveyGroupDao.save(s);
 
                     dto = new SurveyGroupDto();
@@ -210,6 +214,9 @@ public class SurveyGroupRestService {
                     "createdDateTime", "lastUpdateDateTime", "displayName",
                     "questionGroupList"
             });
+
+            // Make sure that code and name are the same
+            s.setCode(s.getName());
             s = surveyGroupDao.save(s);
 
             dto = new SurveyGroupDto();

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -261,6 +261,8 @@ public class SurveyRestService {
                     });
 
                     s.setDesc(surveyDto.getDescription());
+                    // Make sure that code and name are the same
+                    s.setCode(s.getName());
 
                     if (surveyDto.getStatus() != null) {
                         // increment version for surveys already published
@@ -365,6 +367,9 @@ public class SurveyRestService {
 
         // ignore version number sent by Dashboard and initialise
         s.getVersion();
+
+        // Make sure that code and name are the same
+        s.setCode(s.getName());
 
         return s;
     }


### PR DESCRIPTION
- Make sure that 'code' == 'name' by enforcing it on the backend when
  creating a new Survey (SurveyGroup) or Form (Survey)
- Bind and display the 'name' property for Surveys and Forms instead of 'code'
