### PR TITLE
[#1020] Fix reversed `path`

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -273,8 +273,9 @@ FLOW.projectControl = Ember.ArrayController.create({
       var currentProjectAncestors = this.get('breadCrumbs').slice();
       currentProjectAncestors.reverse();// reversed to start matching from the most specific path.
       var i;
+      var path;
       for(i = 0; i < currentProjectAncestors.length; i++) {
-          var path = currentProjectAncestors[i].get('path');
+          path = currentProjectAncestors[i].get('path');
           if(path in FLOW.currentUser.pathPermissions){
               return FLOW.currentUser.pathPermissions[path];
           }


### PR DESCRIPTION
Fix to prevent contents of the `path` property from being reversed
