### PR TITLE
[#1016] Monitoring survey creation

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/survey-group-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-group-views.js
@@ -55,6 +55,7 @@ FLOW.Project = FLOW.View.extend({
   }.property("FLOW.projectControl.formCount"),
 
   updateSelectedRegistrationForm: function() {
+    if (!this.get('selectedRegistrationForm')) return;
     FLOW.projectControl.currentProject.set('newLocaleSurveyId', this.selectedRegistrationForm.get('keyId'));
   }.observes('selectedRegistrationForm')
 

--- a/Dashboard/app/js/templates/navSurveys/project.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/project.handlebars
@@ -62,31 +62,33 @@
                       optionValuePath="content.value"}}
                   </li>
                 </ul>
-                <span class="monitoringAndvanced">
-                  <a {{action "toggleShowAdvancedSettings" target="this"}} class="showCollapse">
-                    {{#if view.showAdvancedSettings}}
-                      {{t _collapse}}
-                    {{else}}
-                      {{t _show_advanced_settings}}
-                    {{/if}}
-                  </a>
-                </span>
-                {{#if view.showAdvancedSettings}}
-                  {{#if view.showMonitoringGroupCheckbox}}
-                    <label for="enableMonitoring" class="labelcheckbox">
-                      {{view Ember.Checkbox checkedBinding="FLOW.projectControl.currentProject.monitoringGroup" id="enableMonitoring"}}{{t _enable_monitoring_features}}
-                    </label>
-                  {{/if}}
-                  {{#if FLOW.projectControl.currentProject.monitoringGroup}}
-                    <p class="monitoringHint">{{t _choose_the_registration_form}}:</p>
-                    {{view Ember.Select
-                      contentBinding="FLOW.surveyControl.arrangedContent"
-                      selectionBinding="view.selectedRegistrationForm"
-                      optionLabelPath="content.code"
-                      optionValuePath="content.keyId"}}
-                  {{/if}}
-                {{else}}
+                {{#if FLOW.projectControl.hasForms}}
+                  <span class="monitoringAndvanced">
+                    <a {{action "toggleShowAdvancedSettings" target="this"}} class="showCollapse">
+                      {{#if view.showAdvancedSettings}}
+                        {{t _collapse}}
+                      {{else}}
+                        {{t _show_advanced_settings}}
+                      {{/if}}
+                    </a>
+                  </span>
 
+                  {{#if view.showAdvancedSettings}}
+                    {{#if view.showMonitoringGroupCheckbox}}
+                      <label for="enableMonitoring" class="labelcheckbox">
+                        {{view Ember.Checkbox checkedBinding="FLOW.projectControl.currentProject.monitoringGroup" id="enableMonitoring"}}{{t _enable_monitoring_features}}
+                      </label>
+                    {{/if}}
+                    {{#if FLOW.projectControl.currentProject.monitoringGroup}}
+
+                      <p class="monitoringHint">{{t _choose_the_registration_form}}:</p>
+                      {{view Ember.Select
+                        contentBinding="FLOW.surveyControl.arrangedContent"
+                        selectionBinding="view.selectedRegistrationForm"
+                        optionLabelPath="content.code"
+                        optionValuePath="content.keyId"}}
+                    {{/if}}
+                  {{/if}}
                 {{/if}}
               </form>
             {{/if}}

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -185,6 +185,9 @@ public class SurveyGroupRestService {
 
                     // Make sure that code and name are the same
                     s.setCode(s.getName());
+                    if (Boolean.FALSE.equals(s.getMonitoringGroup())) {
+                        s.setNewLocaleSurveyId(null);
+                    }
 
                     s = surveyGroupDao.save(s);
 


### PR DESCRIPTION
- Only show advanced settings when the survey has one or more forms
- Make sure (on the backend) that newLocaleSurveyId is null if the survey is not a monitoringGroup.
