### PR TITLE
[#1016] Change the order of execution to hide the loading first

### DIFF
--- a/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
+++ b/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
@@ -120,8 +120,8 @@ DS.FLOWRESTAdapter = DS.RESTAdapter.extend({
   },
 
   didFindAll: function (store, type, json) {
-    this._super(store, type, json);
     FLOW.savingMessageControl.numLoadingChange(-1);
+    this._super(store, type, json);
   },
 
   didFindQuery: function (store, type, json, recordArray) {


### PR DESCRIPTION
- If the _super.didFindAll raises an exception, we keep the loading icon
  forever
