### PR TITLE
[#1059] Don't set since cursor parameter

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -23,7 +23,6 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
 	  var ident = this.get('identifier'),
 	      displayName = this.get('displayName'),
 	      sgId = this.get('selectedSurveyGroup'),
-        since = FLOW.metaControl.get('since');
 	      cursorType = FLOW.metaControl.get('cursorType');
         criteria = {};
 
@@ -38,10 +37,6 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
 	  if (sgId) {
 		  criteria.surveyGroupId = sgId.get('keyId');
 	  }
-
-    if (since && cursorType === FLOW.SurveyedLocale) {
-      criteria.since = since;
-    }
 
 	  FLOW.surveyedLocaleControl.set('content', FLOW.store.findQuery(FLOW.SurveyedLocale, criteria));
   },


### PR DESCRIPTION
* When 'Find' is clicked, we don't need to set the cursor (the 'since' parameter).