### PR TITLE
[#325] Add a day to the end date search

### DIFF
--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -36,7 +36,9 @@ FLOW.inspectDataTableView = FLOW.View.extend({
 
   doInstanceQuery: function () {
     this.set('beginDate', Date.parse(FLOW.dateControl.get('fromDate')));
-    this.set('endDate', Date.parse(FLOW.dateControl.get('toDate')));
+    // we add 24 hours to the date, in order to make the date search inclusive.
+    dayInMilliseconds = 24 * 60 * 60 * 1000;
+    this.set('endDate', Date.parse(FLOW.dateControl.get('toDate')) + dayInMilliseconds);
 
     // we shouldn't be sending NaN
     if (isNaN(this.get('beginDate'))) {


### PR DESCRIPTION
* by default, when you pick a day using the 
date picker, it has a time of 00:00. This means
that searching for the period 2014-1-1 to 2014-1-5
will actually search 2014-1-1 to 2014-1-4 inclusive.
As this is counter intuitive, we make the end date 
inclusive by adding 24 hours.