### PR TITLE
[#1009] Trigger status update on edit

### DIFF
--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -108,7 +108,7 @@ FLOW.cascadeResourceControl = Ember.ArrayController.create({
 	}.observes('FLOW.selectedControl.selectedCascadeResource'),
 
 	triggerStatusUpdate: function(){
-		this.set('statusUpdateTrigger',!this.get('statusUpdateTrigger'));
+		this.toggleProperty('statusUpdateTrigger');
 	},
 
 	currentStatus: function () {

--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -44,6 +44,7 @@ FLOW.attributeControl = Ember.ArrayController.create({
 FLOW.cascadeResourceControl = Ember.ArrayController.create({
 	content:null,
 	published:null,
+	statusUpdateTrigger:false,
 	levelNames:null,
 	displayLevelName1: null, displayLevelName2: null, displayLevelName3: null,
 	displayLevelNum1: null, displayLevelNum2: null, displayLevelNum3: null,
@@ -106,6 +107,10 @@ FLOW.cascadeResourceControl = Ember.ArrayController.create({
 		FLOW.store.findQuery(FLOW.Question, {cascadeResourceId: FLOW.selectedControl.selectedCascadeResource.get('keyId')});
 	}.observes('FLOW.selectedControl.selectedCascadeResource'),
 
+	triggerStatusUpdate: function(){
+		this.set('statusUpdateTrigger',!this.get('statusUpdateTrigger'));
+	},
+
 	currentStatus: function () {
 		// hack to get translation keys, don't delete them
 		// {{t _not_published}}
@@ -117,14 +122,14 @@ FLOW.cascadeResourceControl = Ember.ArrayController.create({
 		}
 		status = ('_' + FLOW.selectedControl.selectedCascadeResource.get('status')).toLowerCase();
 		return Ember.String.loc(status);
-	}.property('FLOW.selectedControl.selectedCascadeResource'),
+	}.property('FLOW.selectedControl.selectedCascadeResource','this.statusUpdateTrigger'),
 
 	isPublished: function () {
 		if (!FLOW.selectedControl.selectedCascadeResource) {
 			return false;
 		}
 		return FLOW.selectedControl.selectedCascadeResource.get('status') === 'PUBLISHED';
-	}.property('FLOW.selectedControl.selectedCascadeResource')
+	}.property('FLOW.selectedControl.selectedCascadeResource','this.statusUpdateTrigger')
 });
 
 FLOW.cascadeNodeControl = Ember.ArrayController.create({
@@ -183,6 +188,10 @@ FLOW.cascadeNodeControl = Ember.ArrayController.create({
 			"parentNodeId": parentNodeId,
 			"cascadeResourceId": cascadeResourceId
         });
+		if (FLOW.selectedControl.selectedCascadeResource.get('status') == 'PUBLISHED'){
+			FLOW.selectedControl.selectedCascadeResource.set('status','NOT_PUBLISHED');
+			FLOW.cascadeResourceControl.triggerStatusUpdate();
+		}
 		FLOW.store.commit();
 		this.populate(cascadeResourceId, level, parentNodeId);
 	},

--- a/Dashboard/app/js/lib/views/data/cascade-resources-view.js
+++ b/Dashboard/app/js/lib/views/data/cascade-resources-view.js
@@ -101,6 +101,8 @@ FLOW.CascadeResourceView = FLOW.View.extend({
 
 		selectedCascade.set('numLevels', numLevels);
 		selectedCascade.set('levelNames', nameLevels);
+		selectedCascade.set('status', 'NOT_PUBLISHED');
+		FLOW.cascadeResourceControl.triggerStatusUpdate();
 		FLOW.store.commit();
 		FLOW.cascadeResourceControl.setLevelNamesArray();
 		FLOW.cascadeResourceControl.setDisplayLevelNames();
@@ -259,6 +261,8 @@ FLOW.CascadeLevelNameView = FLOW.View.extend({
 		// this is needed, as in this version of Ember, changes in an array do
 		// not make an object dirty, apparently
 		FLOW.selectedControl.selectedCascadeResource.send('becomeDirty');
+		FLOW.selectedControl.selectedCascadeResource.set('status', 'NOT_PUBLISHED');
+		FLOW.cascadeResourceControl.triggerStatusUpdate();
 		FLOW.store.commit();
 
 		// put the names in the array again.


### PR DESCRIPTION
* Updating the status of a cascade resource is
triggered manually.