### PR TITLE
[#1161] Merge permissions that are for the same path

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/CurrentUserServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/CurrentUserServlet.java
@@ -117,7 +117,11 @@ public class CurrentUserServlet extends HttpServlet {
         for (UserAuthorization auth : authorizationList) {
             UserRole role = roleMap.get(auth.getRoleId());
             if (role != null) {
-                permissions.put(auth.getObjectPath(), role.getPermissions());
+                if (permissions.containsKey(auth.getObjectPath())) {
+                    permissions.get(auth.getObjectPath()).addAll(role.getPermissions());
+                } else {
+                    permissions.put(auth.getObjectPath(), role.getPermissions());
+                }
             }
         }
 


### PR DESCRIPTION
* When multiple roles are assigned to a single folder, ensure that all permissions are transmitted correctly to the dashboard