### PR TITLE
[#1187] disable moving/copying across forms

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -558,6 +558,11 @@ FLOW.surveyControl = Ember.ArrayController.create({
 
   selectForm: function(evt) {
     FLOW.selectedControl.set('selectedSurvey', evt.context);
+    //  we don't allow copying or moving between forms
+    FLOW.selectedControl.set('selectedForMoveQuestionGroup',null);
+    FLOW.selectedControl.set('selectedForCopyQuestionGroup',null);
+    FLOW.selectedControl.set('selectedForMoveQuestion',null);
+    FLOW.selectedControl.set('selectedForCopyQuestion',null);
   }
 });
 


### PR DESCRIPTION
* This was never implemented, the fix just fixes the UI
to be consistent with that.

* A proper implementation of copying across forms 
will need to be done later.