### PR TITLE
[#1115] User authorisation for surveyed locales and survey instances

### DIFF
--- a/GAE/src/com/gallatinsystems/user/dao/UserAuthorizationDAO.java
+++ b/GAE/src/com/gallatinsystems/user/dao/UserAuthorizationDAO.java
@@ -32,6 +32,7 @@ public class UserAuthorizationDAO extends BaseDAO<UserAuthorization> {
             return Collections.emptyList();
         }
         List<String> paths = SurveyUtils.listParentPaths(objectPath, true);
+        paths.add(objectPath); // include path of the object when checking for authorizations
         PersistenceManager pm = PersistenceFilter.getManager();
         String queryString = "userId == :p1 && :p2.contains(objectPath)";
         javax.jdo.Query query = pm.newQuery(UserAuthorization.class, queryString);

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/security/RequestUriVoter.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/security/RequestUriVoter.java
@@ -41,6 +41,8 @@ import com.gallatinsystems.survey.dao.SurveyDAO;
 import com.gallatinsystems.survey.dao.SurveyGroupDAO;
 import com.gallatinsystems.survey.domain.Survey;
 import com.gallatinsystems.survey.domain.SurveyGroup;
+import com.gallatinsystems.surveyal.dao.SurveyedLocaleDao;
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
 import com.gallatinsystems.user.dao.UserAuthorizationDAO;
 import com.gallatinsystems.user.dao.UserRoleDao;
 import com.gallatinsystems.user.domain.Permission;
@@ -74,6 +76,9 @@ public class RequestUriVoter implements AccessDecisionVoter<FilterInvocation> {
 
     @Inject
     private SurveyDAO surveyDao;
+
+    @Inject
+    private SurveyedLocaleDao surveyedLocaleDao;
 
     @Override
     public boolean supports(ConfigAttribute attribute) {
@@ -172,6 +177,11 @@ public class RequestUriVoter implements AccessDecisionVoter<FilterInvocation> {
             entityKind = "Survey";
         } else if (httpRequest.getParameter("surveyGroupId") != null) {
             objectIdStr = httpRequest.getParameter("surveyGroupId");
+            entityKind = "SurveyGroup";
+        } else if (httpRequest.getParameter("surveyedLocaleId") != null) {
+            Long surveyedLocaleId = Long.parseLong(httpRequest.getParameter("surveyedLocaleId"));
+            SurveyedLocale sl = surveyedLocaleDao.getByKey(surveyedLocaleId);
+            objectIdStr = sl.getSurveyGroupId().toString();
             entityKind = "SurveyGroup";
         } else if (requestUri.startsWith(PROJECT_FOLDER_URI_PREFIX)
                 || requestUri.startsWith(FORM_URI_PREFIX)) {


### PR DESCRIPTION
* Fix the 403 error for `/rest/survey_instances?surveyedLocaleId=xxx` requests. User with permission should be able to make these requests
* Fix 403 error when the folder/survey is at root level and user does not have access to `All Folders and Surveys` permission 
* Filter `GET` request for `/rest/survey_instances` based on user authorisation