### PR TITLE
[#1217] Fix dependent question resolution

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -20,7 +20,6 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,7 +95,7 @@ public class SurveyUtils {
     }
 
     public static QuestionGroup copyQuestionGroup(QuestionGroup source,
-            Long newSurveyId, Map<Long, Long> qMap) {
+            Long newSurveyId, boolean isCopyingSingleQuestionGroup) {
 
         final QuestionGroupDao qgDao = new QuestionGroupDao();
         final QuestionGroup tmp = new QuestionGroup();
@@ -122,7 +121,9 @@ public class SurveyUtils {
                 .param(DataProcessorRequest.QUESTION_GROUP_ID_PARAM,
                         String.valueOf(newQuestionGroup.getKey().getId()))
                 .param(DataProcessorRequest.SOURCE_PARAM,
-                        String.valueOf(source.getKey().getId()));
+                        String.valueOf(source.getKey().getId()))
+                .param(DataProcessorRequest.IS_COPYING_SINGLE_QUESTION_GROUP_PARAM,
+                        String.valueOf(isCopyingSingleQuestionGroup));
 
         queue.add(options);
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/DataProcessorRequest.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/DataProcessorRequest.java
@@ -52,6 +52,7 @@ public class DataProcessorRequest extends RestRequest {
     public static final String COUNTRY_PARAM = "country";
     public static final String SURVEY_ID_PARAM = "surveyId";
     public static final String QUESTION_GROUP_ID_PARAM = "questionGroupId";
+    public static final String IS_COPYING_SINGLE_QUESTION_GROUP_PARAM = "isCopyingSingleQuestionGroup";
     public static final String COUNTER_ID_PARAM = "summaryCounterId";
     public static final String SURVEY_INSTANCE_PARAM = "surveyInstanceId";
     public static final String QAS_ID_PARAM = "qasId";
@@ -79,6 +80,7 @@ public class DataProcessorRequest extends RestRequest {
     private Long surveyId;
     private Long surveyInstanceId;
     private Long questionGroupId;
+    private boolean isCopyingSingleQuestionGroup = false;
     private Long qasId;
     private Integer delta;
     private String apiKey;
@@ -109,6 +111,13 @@ public class DataProcessorRequest extends RestRequest {
                 addError(new RestError(RestError.BAD_DATATYPE_CODE,
                         RestError.BAD_DATATYPE_MESSAGE, QUESTION_GROUP_ID_PARAM
                                 + " must be a number"));
+            }
+        }
+        if (req.getParameter(IS_COPYING_SINGLE_QUESTION_GROUP_PARAM) != null) {
+            if ("true".equals(req.getParameter(IS_COPYING_SINGLE_QUESTION_GROUP_PARAM))) {
+                isCopyingSingleQuestionGroup = true;
+            } else {
+                isCopyingSingleQuestionGroup = false;
             }
         }
         if (req.getParameter(SURVEY_INSTANCE_PARAM) != null) {
@@ -243,6 +252,10 @@ public class DataProcessorRequest extends RestRequest {
 
     public void setQuestionGroupId(Long questionGroupId) {
         this.questionGroupId = questionGroupId;
+    }
+
+    public boolean getIsCopyingSingleQuestionGroup() {
+        return isCopyingSingleQuestionGroup;
     }
 
     public Long getQasId() {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -279,11 +279,10 @@ public class QuestionGroupRestService {
         if (questionGroupDto.getSourceId() != null) {
             // copy question group
             final QuestionGroupDao qgDao = new QuestionGroupDao();
-            final Map<Long, Long> qMap = new HashMap<Long, Long>();
 
             QuestionGroup sourceQuestionGroup = qgDao.getByKey(questionGroupDto.getSourceId());
             questionGroup = SurveyUtils.copyQuestionGroup(sourceQuestionGroup,
-                    sourceQuestionGroup.getSurveyId(), qMap);
+                    sourceQuestionGroup.getSurveyId(), true);
             questionGroup.setOrder(questionGroupDto.getOrder());
             questionGroup.setStatus(QuestionGroup.Status.COPYING);
         } else {


### PR DESCRIPTION
* If we are copying a single question group and the target option question
  is in some previous group (i.e. not in the same group) we look up the dependant
  question id via the original question (using the sourceQuestionId property).