### PR TITLE
[#1354] Fix survey copying regression

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -457,7 +457,6 @@ public class SurveyUtils {
         BeanUtils.copyProperties(source, copy, Constants.EXCLUDED_PROPERTIES);
         String kind = source.getKey().getKind();
         log.log(Level.INFO, "Copying `" + kind + "` " + source.getKey().getId());
-        log.log(Level.INFO, "New `" + kind + "` ID: " + copy.getKey().getId());
     }
 
     /**

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -553,8 +553,10 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
 
         List<QuestionGroup> qgCopyList = new ArrayList<QuestionGroup>();
         for (final QuestionGroup sourceGroup : qgList) {
-            QuestionGroup copyGroup = qgDao.save(new QuestionGroup());
-            SurveyUtils.shallowCopy(sourceGroup, copyGroup);
+            // need a temp group to avoid state sharing exception
+            QuestionGroup tmpGroup = new QuestionGroup();
+            SurveyUtils.shallowCopy(sourceGroup, tmpGroup);
+            final QuestionGroup copyGroup = qgDao.save(tmpGroup);
             SurveyUtils.copyQuestionGroup(sourceGroup, copyGroup, copiedSurveyId,
                     qDependencyResolutionMap);
             copyGroup.setStatus(QuestionGroup.Status.READY); // copied

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -315,6 +315,8 @@ public class QuestionGroupRestService {
     private QuestionGroup copyGroup(QuestionGroupDto questionGroupDto) {
         final QuestionGroupDao qgDao = new QuestionGroupDao();
         QuestionGroup sourceGroup = qgDao.getByKey(questionGroupDto.getSourceId());
+
+        // need a temp group to avoid state sharing exception
         QuestionGroup tmpGroup = new QuestionGroup();
 
         SurveyUtils.shallowCopy(sourceGroup, tmpGroup);

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -315,9 +315,10 @@ public class QuestionGroupRestService {
     private QuestionGroup copyGroup(QuestionGroupDto questionGroupDto) {
         final QuestionGroupDao qgDao = new QuestionGroupDao();
         QuestionGroup sourceGroup = qgDao.getByKey(questionGroupDto.getSourceId());
-        final QuestionGroup copyGroup = qgDao.save(new QuestionGroup());
+        QuestionGroup tmpGroup = new QuestionGroup();
 
-        SurveyUtils.shallowCopy(sourceGroup, copyGroup);
+        SurveyUtils.shallowCopy(sourceGroup, tmpGroup);
+        final QuestionGroup copyGroup = qgDao.save(tmpGroup);
         copyGroup.setOrder(questionGroupDto.getOrder());
         copyGroup.setStatus(QuestionGroup.Status.COPYING);
 


### PR DESCRIPTION
* Use temporary `QuestionGroup` object when copying to avoid state sharing exception
* Remove logging line that throws *NPE* due to absence of a `keyId` in the temporary object