### PR TITLE
[#1124] Ignore `since` meta property for all other request types

### DIFF
--- a/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
+++ b/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
@@ -118,6 +118,8 @@ DS.FLOWRESTAdapter = DS.RESTAdapter.extend({
       cursorArray = FLOW.surveyedLocaleControl.get('sinceArray');
     } else if (type === FLOW.SurveyInstance) {
       cursorArray = FLOW.surveyInstanceControl.get('sinceArray');
+    } else {
+      return;
     }
 
     cursorStart = this.extractSince(json);


### PR DESCRIPTION
* We only consider the `since` property for SurveyInstance and SurveyedLocale entities for pagination