### PR TITLE
[#1453] Render signature question type on monitoring tab

### DIFF
--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -49,7 +49,7 @@ FLOW.QuestionAnswerView = Ember.View.extend({
   }.property('this.questionType'),
 
   isSignatureType: function(){
-    return this.get('questionType') === 'SIGNATURE';
+    return this.get('questionType') === 'SIGNATURE' || (this.content && this.content.get('type') === 'SIGNATURE');
   }.property('this.questionType'),
 
   nonEditableQuestionTypes: ['GEO', 'PHOTO', 'VIDEO', 'GEOSHAPE', 'SIGNATURE'],


### PR DESCRIPTION
* This is specifically for monitoring forms.  We use the response type value to render since the questions for monitoring forms are *not* yet loaded when browsing the monitoring tab and its therefore not possible to use the question.type property.