### PR TITLE
[#828] Set questionId for options before creating default options

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -240,7 +240,7 @@ FLOW.QuestionView = FLOW.View.extend({
   loadQuestionOptions: function () {
     var c = this.content;
     FLOW.questionOptionsControl.set('content', []);
-    FLOW.questionOptionsControl.set('questionId', null);
+    FLOW.questionOptionsControl.set('questionId', c.get('keyId'));
 
     options = FLOW.store.filter(FLOW.QuestionOption, function (optionItem) {
         return optionItem.get('questionId') === c.get('keyId');
@@ -249,7 +249,6 @@ FLOW.QuestionView = FLOW.View.extend({
     if (options.get('length')) {
       optionArray = Ember.A(options.toArray().sort(sortByOrder));
       FLOW.questionOptionsControl.set('content', optionArray);
-      FLOW.questionOptionsControl.set('questionId', c.get('keyId'));
     } else {
       FLOW.questionOptionsControl.loadDefaultOptions();
     }


### PR DESCRIPTION
* The default options were saved but not associated with their respective questions because they had no questionId set