### PR TITLE
Feature/1570 strip test

### DIFF
--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -170,14 +170,16 @@ FLOW.QuestionAnswerView = Ember.View.extend({
 	result=Ember.A();
 	if (c && c.get('value')) {
 	  striptestJson = JSON.parse(c.get('value'));
-	  striptestJson.result.forEach(function(item){
-		  image = 'data:image/png;base64,' + item.img;
-		  newResult = {"name":item.name,
+	  if (striptestJson.result && !Ember.empty(striptestJson.result)){
+		  striptestJson.result.forEach(function(item){
+			  image = 'data:image/png;base64,' + item.img;
+			  newResult = {"name":item.name,
 				  "value":item.value,
 				  "unit":item.unit,
 				  "image":image};
-		  result.push(newResult);
-	  });
+			  result.push(newResult);
+		  });
+	   }
 	}
 	this.set('striptestResult',result);
   },

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -166,7 +166,7 @@ FLOW.QuestionAnswerView = Ember.View.extend({
    * parse the strip test JSON result
    */
   parseStriptestJson: function(){
-	var c = this.content, signatureJson, newResult, image;
+	var c = this.content, striptestJson, newResult, image;
 	result=Ember.A();
 	if (c && c.get('value')) {
 	  striptestJson = JSON.parse(c.get('value'));
@@ -188,7 +188,7 @@ FLOW.QuestionAnswerView = Ember.View.extend({
    * Get out the strip test name
    */
   striptestName: function(){
-	var c = this.content, signatureJson;
+	var c = this.content, striptestJson;
 	if (c && c.get('value')) {
 	  striptestJson = JSON.parse(c.get('value'));
 	  if (!Ember.empty(striptestJson.result))

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -170,7 +170,6 @@ FLOW.QuestionAnswerView = Ember.View.extend({
 	result=Ember.A();
 	if (c && c.get('value')) {
 	  striptestJson = JSON.parse(c.get('value'));
-	  console.log(striptestJson.result);
 	  striptestJson.result.forEach(function(item){
 		  image = 'data:image/png;base64,' + item.img;
 		  newResult = {"name":item.name,
@@ -194,7 +193,9 @@ FLOW.QuestionAnswerView = Ember.View.extend({
 	  {
 		  this.parseStriptestJson();
 	  }
-	  return striptestJson.name.trim();
+	  if (!Ember.empty(striptestJson.name)){
+		  return striptestJson.name.trim();
+	  }
 	}
     return null;
   }.property('this.content'),

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -13,8 +13,12 @@ function sortByOrder(a , b) {
 FLOW.QuestionAnswerView = Ember.View.extend({
 
   isTextType: function(){
-    return this.get('questionType') === 'FREE_TEXT';
+    return (this.get('questionType') === 'FREE_TEXT' && !this.get('isAllowExternalSources'));
   }.property('this.questionType'),
+
+  isExternalSourceType: function(){
+	return (this.get('questionType') === 'FREE_TEXT' && this.get('isAllowExternalSources'));
+  }.property('this.questionType','isAllowExternalSources'),
 
   isCascadeType: function(){
     return this.get('questionType') === 'CASCADE';
@@ -120,7 +124,9 @@ FLOW.QuestionAnswerView = Ember.View.extend({
 
   isEditable: function () {
     var isEditableQuestionType, canEditFormResponses;
-    isEditableQuestionType = this.nonEditableQuestionTypes.indexOf(this.get('questionType')) < 0;
+    // we check the isExternalSourceType explicitly, because at the moment
+    // the Free text type is used to hold those answers.
+    isEditableQuestionType = this.nonEditableQuestionTypes.indexOf(this.get('questionType')) < 0 && !this.get('isExternalSourceType');
     if (!isEditableQuestionType) {
       return false; // no need to check permissions
     }
@@ -153,6 +159,43 @@ FLOW.QuestionAnswerView = Ember.View.extend({
       signatureJson = JSON.parse(c.get('value'));
       return signatureJson.name.trim();
     }
+    return null;
+  }.property('this.content'),
+
+  /*
+   * parse the strip test JSON result
+   */
+  parseStriptestJson: function(){
+	var c = this.content, signatureJson, newResult, image;
+	result=Ember.A();
+	if (c && c.get('value')) {
+	  striptestJson = JSON.parse(c.get('value'));
+	  console.log(striptestJson.result);
+	  striptestJson.result.forEach(function(item){
+		  image = 'data:image/png;base64,' + item.img;
+		  newResult = {"name":item.name,
+				  "value":item.value,
+				  "unit":item.unit,
+				  "image":image};
+		  result.push(newResult);
+	  });
+	}
+	this.set('striptestResult',result);
+  },
+
+  /*
+   * Get out the strip test name
+   */
+  striptestName: function(){
+	var c = this.content, signatureJson;
+	if (c && c.get('value')) {
+	  striptestJson = JSON.parse(c.get('value'));
+	  if (!Ember.empty(striptestJson.result))
+	  {
+		  this.parseStriptestJson();
+	  }
+	  return striptestJson.name.trim();
+	}
     return null;
   }.property('this.content'),
 
@@ -340,6 +383,10 @@ FLOW.QuestionAnswerView = Ember.View.extend({
   isOtherOptionEnabled: function () {
     return this.get('isOptionType') && this.get('question').get('allowOtherFlag');
   }.property('this.isOptionType'),
+
+  isAllowExternalSources: function(){
+	  return this.get('question').get('allowExternalSources');
+  }.property('this.question'),
 
   isOtherOptionSelected: function () {
     var selectedOption = this.get('optionValue') && this.get('optionValue').get('lastObject');

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -153,9 +153,15 @@
                             {{else}}
                                 {{t _no_signature_found}}
                             {{/if}}
-                        {{else}}
+                        {{else}}{{#if view.isExternalSourceType}}
+                			<div class=""><strong>{{t _strip_test_type}}: {{view.striptestName}}</strong></div>
+                			{{#each result in view.striptestResult}}<br>
+                			<div>{{result.name}} : {{result.value}} {{result.unit}}</div>
+                			<div class=""><img {{bindAttr src="result.image"}} /></div>
+                			{{/each}}
+                		{{else}}
                           <span>{{QA.value}} {{#with QA}}{{if_blank value}}{{/with}}</span>
-                        {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}}
+                        {{/if}}{{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}}
                     </td>
                     </tr>
                     {{/view}}

--- a/Dashboard/app/js/templates/navData/question-answer.handlebars
+++ b/Dashboard/app/js/templates/navData/question-answer.handlebars
@@ -52,8 +52,7 @@
                     {{else}}
                         {{t _no_signature_found}}
                     {{/if}}
-                {{else}}
-                 {{#if view.isExternalSourceType}}
+                {{else}} {{#if view.isExternalSourceType}}
                 	<div class=""><strong>{{t _strip_test_type}}: {{view.striptestName}}</strong></div>
                 	{{#each result in view.striptestResult}}<br>
                 	<div>{{result.name}} : {{result.value}} {{result.unit}}</div>

--- a/Dashboard/app/js/templates/navData/question-answer.handlebars
+++ b/Dashboard/app/js/templates/navData/question-answer.handlebars
@@ -53,8 +53,15 @@
                         {{t _no_signature_found}}
                     {{/if}}
                 {{else}}
+                 {{#if view.isExternalSourceType}}
+                	<div class=""><strong>{{t _strip_test_type}}: {{view.striptestName}}</strong></div>
+                	{{#each result in view.striptestResult}}<br>
+                	<div>{{result.name}} : {{result.value}} {{result.unit}}</div>
+                	<div class=""><img {{bindAttr src="result.image"}} /></div>
+                	{{/each}}
+                {{else}}
                     {{value}}
-                {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}}
+                {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}}{{/if}}
             {{else}}
                 {{#if view.isDateType}}
                     <a {{action doEdit target="this" }}>{{date3 value}}</a>

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -432,6 +432,7 @@ Something\ else\ is\ being\ saved\ or\ loaded.\ Please\ wait\ until\ the\ previo
 Start\ date = Start date
 Statistics = Statistics
 Status = Status
+Strip\ test\ type = Strip test type
 Submitter = Submitter
 Submitter\ name = Submitter name
 Super\ Admin\ role\ can\ only\ be\ set\ by\ Akvo\ staff = Super Admin role can only be set by Akvo staff

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -463,6 +463,7 @@ _smallest_items = Smallest items
 _start_date = Start date
 _statistics = Statistics
 _status = Status
+_strip_test_type = Strip test type
 _submitter = Submitter
 _submitter_name = Submitter name
 _support = Support

--- a/GAE/src/org/akvo/flow/domain/DataUtils.java
+++ b/GAE/src/org/akvo/flow/domain/DataUtils.java
@@ -23,12 +23,19 @@ import java.util.Map;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.mortbay.util.ajax.JSON;
+
 
 /**
  * Utilities class for performing transformations on survey data, i.e. response values
  */
 public class DataUtils {
 
+	public static final String STRIP_TEST_TYPE = "caddisfly-strip";
+	public static final String STRIP_TEST_IMAGE_KEY = "img";
     public static final ObjectMapper JSON_OBJECT_MAPPER = new ObjectMapper();
 
     public static String[] optionResponsesTextArray(String optionResponse) {
@@ -114,5 +121,31 @@ public class DataUtils {
             // ignore
         }
         return signatory;
+    }
+    
+    /**
+     * Process the JSON formatted string value of a strip test response, and return the string representing the
+     * results.
+     * 
+     * @param value
+     * @return JSON object
+     */
+    
+    public static String removeImagesInStripTestJSON(String value) {
+    	String error = "{\"error\":\"cannot parse json\"}";
+    	JSONObject json = null;
+    	try {
+			json = new JSONObject(value);
+			String type = json.getString("type");
+			if (type.equals(STRIP_TEST_TYPE)){
+				JSONArray result = json.getJSONArray("result");
+				for (int i = 0; i < result.length(); i++) {
+					  result.getJSONObject(i).remove(STRIP_TEST_IMAGE_KEY);
+				}
+			}
+			return json.toString();
+    	} catch (JSONException e) {
+			return error;
+		}
     }
 }

--- a/GAE/src/org/akvo/flow/domain/DataUtils.java
+++ b/GAE/src/org/akvo/flow/domain/DataUtils.java
@@ -26,7 +26,6 @@ import org.codehaus.jackson.type.TypeReference;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.mortbay.util.ajax.JSON;
 
 
 /**

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataBackoutServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataBackoutServlet.java
@@ -62,7 +62,7 @@ import com.google.appengine.api.datastore.Entity;
 public class DataBackoutServlet extends AbstractRestApiServlet {
 
     private static final long serialVersionUID = 4608959174864994769L;
-
+    private static final String QAS_TYPE_VALUE = "VALUE";
     private QuestionDao qDao;
     private SurveyQuestionSummaryDao questionSummaryDao;
     private SurveyInstanceDAO instanceDao;
@@ -194,14 +194,14 @@ public class DataBackoutServlet extends AbstractRestApiServlet {
                     iteration = iteration == null ? 0 : iteration;
                     String value = qas.getValue();
 
-                    // strip image data that will not be used in the excel export
+                    // signature image data that will not be used in the excel export
                     if (Question.Type.SIGNATURE.toString().equals(qas.getType())) {
                         value = DataUtils.parseSignatory(value);
                     }
 
-                    // check if the free text is a strip test result
+                    // check if the response is of type 'value' and is a strip test result
                     // in that case, we need to strip out the images
-                    if (Question.Type.FREE_TEXT.toString().equals(qas.getType())) {
+                    if (qas.getType().equals(QAS_TYPE_VALUE)) {
                     	if (isStriptestJSON(value)){
                     		value = DataUtils.removeImagesInStripTestJSON(value);
                     	}

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -312,6 +312,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
 
             QuestionDto questionDto = questionIdToQuestionDto.get(questionId);
             QuestionType questionType = questionDto.getQuestionType();
+            Boolean isExternalSource = questionDto.getAllowExternalSources();
 
             for (int iter = 0; iter < iterations; iter++) {
 
@@ -439,6 +440,15 @@ public class RawDataSpreadsheetImporter implements DataImporter {
                             val = null;
                             break;
 
+                        case FREE_TEXT:
+                        	if (isExternalSource){
+                        		// we do not allow importing / overwriting external source results.
+                        		// at the moment, these are stored in FREE_TEXT question answers.
+                        		val = null;
+                        	} else {
+                        		val = ExportImportUtils.parseCellAsString(cell);
+                        	}
+                        	break;
                         default:
                             val = ExportImportUtils.parseCellAsString(cell);
                             break;

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -770,7 +770,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
 
     public static void main(String[] args) throws Exception {
         if (args.length != 4) {
-            log.error("Error.\nUsage:\n\tjava org.waterforpeople.mapping.dataexport.RawDataSpreadsheetImporter <file> <serverBase> <surveyId>");
+            log.error("Error.\nUsage:\n\tjava org.waterforpeople.mapping.dataexport.RawDataSpreadsheetImporter <file> <serverBase> <surveyId> <apiKey>");
             System.exit(1);
         }
         File file = new File(args[0].trim());


### PR DESCRIPTION
This code takes care of the following things:
1) correctly show strip-test data in the inspect data tab
2) correctly show strip-test data in the monitoring tab
3) not export img key values (base64 image data) when exporting
4) ignore strip test results when reading in an excel file

I've had some trouble testing point 4 on my machine, so this needs particular attention. 

I also didn't understand how the digest is computed - it seems like this is done on all columns in GraphicalSurveySummaryExporter, while I suppose Signature and Strip test values need to be exempt., so this will need some checking as well.

This is actually a temporary implementation: what is really needed is that Caddisfly gets its own question type. This will allow us to clean up the code, and follow the way it is done for the Signature question type.