### PR TITLE
[#1527] adding check for IMAGE type as well as PHOTO

### DIFF
--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -3,7 +3,7 @@
 function formatDate(date) {
   if (date && !isNaN(date.getTime())) {
     return date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
-  } 
+  }
   return null;
 }
 
@@ -38,7 +38,7 @@ FLOW.QuestionAnswerView = Ember.View.extend({
   }.property('this.questionType'),
 
   isPhotoType: function(){
-    return this.get('questionType') === 'PHOTO';
+    return (this.get('questionType') === 'PHOTO' || (this.content && this.content.get('type') === 'IMAGE'));
   }.property('this.questionType'),
 
   isVideoType: function(){


### PR DESCRIPTION
it seems that sometimes we have photo question answers which don't have PHOTO as their type - instead IMAGE. When this happens the logic for displaying lat/lon and parsing the JSON responses breaks down.