### PR TITLE
[#987] Improve performance of loading dashboard

### DIFF
--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -70,7 +70,6 @@ FLOW.Router = Ember.Router.extend({
       connectOutlets: function (router, event) {
         router.get('applicationController').connectOutlet('navSurveys');
         router.set('navigationController.selected', 'navSurveys');
-        FLOW.cascadeResourceControl.populate();
       },
 
       doNewSurvey: function (router, event) {

--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -104,8 +104,6 @@ FLOW.Router = Ember.Router.extend({
           FLOW.selectedControl.set('selectedSurvey', null);
           FLOW.selectedControl.set('selectedQuestion', null);
           FLOW.questionControl.set('OPTIONcontent', null);
-          FLOW.attributeControl.populate();
-
         }
       }),
 
@@ -136,7 +134,6 @@ FLOW.Router = Ember.Router.extend({
           });
           // all questions should be closed when we enter
           FLOW.selectedControl.set('selectedQuestion', null);
-          FLOW.attributeControl.populate();
         },
 
         doEditQuestions: function (router, event) {

--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -104,6 +104,7 @@ FLOW.Router = Ember.Router.extend({
           FLOW.selectedControl.set('selectedSurvey', null);
           FLOW.selectedControl.set('selectedQuestion', null);
           FLOW.questionControl.set('OPTIONcontent', null);
+          FLOW.cascadeResourceControl.populate();
         }
       }),
 

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
@@ -44,7 +44,7 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     private Boolean published;
     private List<Long> ancestorIds;
 
-    private ArrayList<SurveyDto> surveyList = null;
+    private ArrayList<Long> surveyList = null;
 
     public String getDescription() {
         return description;
@@ -86,19 +86,19 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
         this.lastUpdateDateTime = lastUpdateDateTime;
     }
 
-    public void setSurveyList(ArrayList<SurveyDto> surveyList) {
+    public void setSurveyList(ArrayList<Long> surveyList) {
         this.surveyList = surveyList;
     }
 
-    public ArrayList<SurveyDto> getSurveyList() {
+    public ArrayList<Long> getSurveyList() {
         return surveyList;
     }
 
-    public void addSurvey(SurveyDto item) {
+    public void addSurvey(Long surveyId) {
         if (surveyList == null) {
-            surveyList = new ArrayList<SurveyDto>();
+            surveyList = new ArrayList<Long>();
         }
-        surveyList.add(item);
+        surveyList.add(surveyId);
     }
 
     @Override

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
@@ -231,4 +231,11 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
         this.ancestorIds = ancestorIds;
     }
 
+    @Override
+    public Long getKeyId() {
+        if (surveyGroup != null && surveyGroup.getKey() != null) {
+            return surveyGroup.getKey().getId();
+        }
+        return super.getKeyId();
+    }
 }

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.gallatinsystems.framework.gwt.dto.client.BaseDto;
 import com.gallatinsystems.framework.gwt.dto.client.NamedObject;
+import com.gallatinsystems.survey.domain.SurveyGroup;
 import com.gallatinsystems.survey.domain.SurveyGroup.PrivacyLevel;
 import com.gallatinsystems.survey.domain.SurveyGroup.ProjectType;
 
@@ -46,7 +47,19 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
 
     private ArrayList<Long> surveyList = null;
 
+    private SurveyGroup surveyGroup;
+
+    public SurveyGroupDto() {
+    }
+
+    public SurveyGroupDto(SurveyGroup sg) {
+        this.surveyGroup = sg;
+    }
+
     public String getDescription() {
+        if (surveyGroup != null) {
+            return surveyGroup.getDescription();
+        }
         return description;
     }
 
@@ -55,6 +68,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public String getCode() {
+        if (surveyGroup != null) {
+            return surveyGroup.getCode();
+        }
         return code;
     }
 
@@ -63,6 +79,10 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public String getPath() {
+        if (surveyGroup != null) {
+            return surveyGroup.getPath();
+        }
+
         return path;
     }
 
@@ -71,6 +91,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public Date getCreatedDateTime() {
+        if (surveyGroup != null) {
+            return surveyGroup.getCreatedDateTime();
+        }
         return createdDateTime;
     }
 
@@ -79,6 +102,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public Date getLastUpdateDateTime() {
+        if (surveyGroup != null) {
+            return surveyGroup.getLastUpdateDateTime();
+        }
         return lastUpdateDateTime;
     }
 
@@ -111,10 +137,16 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public String getName() {
+        if (surveyGroup != null) {
+            return surveyGroup.getName();
+        }
         return name;
     }
 
     public Boolean getMonitoringGroup() {
+        if (surveyGroup != null) {
+            return surveyGroup.getMonitoringGroup();
+        }
         return monitoringGroup;
     }
 
@@ -123,6 +155,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public Long getNewLocaleSurveyId() {
+        if (surveyGroup != null) {
+            return surveyGroup.getNewLocaleSurveyId();
+        }
         return newLocaleSurveyId;
     }
 
@@ -131,6 +166,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public ProjectType getProjectType() {
+        if (surveyGroup != null) {
+            return surveyGroup.getProjectType();
+        }
         return projectType;
     }
 
@@ -139,6 +177,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public Long getParentId() {
+        if (surveyGroup != null) {
+            return surveyGroup.getParentId();
+        }
         return parentId;
     }
 
@@ -147,6 +188,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public String getDefaultLanguageCode() {
+        if (surveyGroup != null) {
+            return surveyGroup.getDefaultLanguageCode();
+        }
         return defaultLanguageCode;
     }
 
@@ -155,6 +199,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public PrivacyLevel getPrivacyLevel() {
+        if (surveyGroup != null) {
+            return surveyGroup.getPrivacyLevel();
+        }
         return privacyLevel;
     }
 
@@ -163,6 +210,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public Boolean getPublished() {
+        if (surveyGroup != null) {
+            return surveyGroup.getPublished();
+        }
         return published;
     }
 
@@ -171,6 +221,9 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
     }
 
     public List<Long> getAncestorIds() {
+        if (surveyGroup != null) {
+            return surveyGroup.getAncestorIds();
+        }
         return ancestorIds;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyService.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto.QuestionType;
 
-import com.gallatinsystems.framework.gwt.dto.client.ResponseDto;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
@@ -38,10 +37,6 @@ public interface SurveyService extends RemoteService {
     public QuestionDto[] listSurveyQuestionByType(Long surveyId,
             QuestionType type, boolean loadTranslations);
 
-    public ResponseDto<ArrayList<SurveyGroupDto>> listSurveyGroups(
-            String cursorString, Boolean loadSurveyFlag,
-            Boolean loadQuestionGroupFlag, Boolean loadQuestionFlag);
-
     /**
      * lists all surveys for a group
      */
@@ -53,11 +48,9 @@ public interface SurveyService extends RemoteService {
     public ArrayList<QuestionDto> listQuestionsByQuestionGroup(
             String questionGroupId, boolean needDetails);
 
-    public SurveyGroupDto save(SurveyGroupDto value);
-
     /**
      * fully hydrates a survey object
-     * 
+     *
      * @param surveyId
      * @return
      */
@@ -117,7 +110,7 @@ public interface SurveyService extends RemoteService {
      * returns a surveyDto populated from the published xml. This domain graph lacks many keyIds so
      * it is not suitable for updating the survey structure. It is, however, suitable for rendering
      * the survey and collecting responses.
-     * 
+     *
      * @param surveyId
      * @return
      */
@@ -125,7 +118,7 @@ public interface SurveyService extends RemoteService {
 
     /**
      * fires an async request to generate a bootstrap xml file
-     * 
+     *
      * @param surveyIdList
      * @param dbInstructions
      * @param notificationEmail
@@ -135,7 +128,7 @@ public interface SurveyService extends RemoteService {
 
     /**
      * returns a survey (core info only, not fully populated) based on its id
-     * 
+     *
      * @param id
      * @return
      */
@@ -143,14 +136,14 @@ public interface SurveyService extends RemoteService {
 
     /**
      * marks that a set of changes to a survey are done so we can publish a notification
-     * 
+     *
      * @param id
      */
     public void markSurveyChangesComplete(Long id);
 
     /**
      * lists the base question info for all questions that depend on the questionId passed in
-     * 
+     *
      * @param questionId
      * @return
      */

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
@@ -184,58 +184,6 @@ public class SurveyServiceImpl extends RemoteServiceServlet implements
         return surveyDtos;
     }
 
-    @Override
-    public ResponseDto<ArrayList<SurveyGroupDto>> listSurveyGroups(
-            String cursorString, Boolean loadSurveyFlag,
-            Boolean loadQuestionGroupFlag, Boolean loadQuestionFlag) {
-        ResponseDto<ArrayList<SurveyGroupDto>> response = new ResponseDto<ArrayList<SurveyGroupDto>>();
-        ArrayList<SurveyGroupDto> surveyGroupDtoList = new ArrayList<SurveyGroupDto>();
-        SurveyGroupDAO surveyGroupDao = new SurveyGroupDAO();
-        List<SurveyGroup> groupList = surveyGroupDao.list(cursorString);
-        for (SurveyGroup canonical : groupList) {
-            SurveyGroupDto dto = new SurveyGroupDto();
-            DtoMarshaller.copyToDto(canonical, dto);
-            dto.setSurveyList(null);
-            if (canonical.getSurveyList() != null
-                    && canonical.getSurveyList().size() > 0) {
-                for (Survey survey : canonical.getSurveyList()) {
-                    SurveyDto surveyDto = new SurveyDto();
-                    DtoMarshaller.copyToDto(survey, surveyDto);
-                    surveyDto.setQuestionGroupList(null);
-                    if (survey.getQuestionGroupMap() != null
-                            && survey.getQuestionGroupMap().size() > 0) {
-                        for (QuestionGroup questionGroup : survey
-                                .getQuestionGroupMap().values()) {
-                            QuestionGroupDto questionGroupDto = new QuestionGroupDto();
-                            DtoMarshaller.copyToDto(questionGroup,
-                                    questionGroupDto);
-                            if (questionGroup.getQuestionMap() != null
-                                    && questionGroup.getQuestionMap().size() > 0) {
-                                for (Entry<Integer, Question> questionEntry : questionGroup
-                                        .getQuestionMap().entrySet()) {
-                                    Question question = questionEntry
-                                            .getValue();
-                                    Integer order = questionEntry.getKey();
-                                    QuestionDto questionDto = new QuestionDto();
-                                    DtoMarshaller.copyToDto(question,
-                                            questionDto);
-                                    questionGroupDto.addQuestion(questionDto,
-                                            order);
-                                }
-                            }
-                            surveyDto.addQuestionGroup(questionGroupDto);
-                        }
-                    }
-                    dto.addSurvey(surveyDto);
-                }
-            }
-            surveyGroupDtoList.add(dto);
-        }
-        response.setPayload(surveyGroupDtoList);
-        response.setCursorString(SurveyGroupDAO.getCursor(groupList));
-        return response;
-    }
-
     /**
      * This method will return a list of all the questions that have a specific type code
      */
@@ -290,36 +238,6 @@ public class SurveyServiceImpl extends RemoteServiceServlet implements
             }
         }
         return surveyDtos;
-    }
-
-    @Override
-    public SurveyGroupDto save(SurveyGroupDto value) {
-        SurveyGroupDAO sgDao = new SurveyGroupDAO();
-        SurveyGroup surveyGroup = new SurveyGroup();
-        DtoMarshaller.copyToCanonical(surveyGroup, value);
-        surveyGroup.setSurveyList(null);
-        for (SurveyDto item : value.getSurveyList()) {
-            // SurveyDto item = value.getSurveyList().get(0);
-            Survey survey = new Survey();
-            DtoMarshaller.copyToCanonical(survey, item);
-            survey.setQuestionGroupMap(null);
-            int order = 1;
-            for (QuestionGroupDto qgDto : item.getQuestionGroupList()) {
-                QuestionGroup qg = new QuestionGroup();
-                DtoMarshaller.copyToCanonical(qg, qgDto);
-                survey.addQuestionGroup(order++, qg);
-                int qOrder = 1;
-                for (Entry<Integer, QuestionDto> qDto : qgDto.getQuestionMap()
-                        .entrySet()) {
-                    Question q = marshalQuestion(qDto.getValue());
-                    qg.addQuestion(qOrder++, q);
-                }
-            }
-            surveyGroup.addSurvey(survey);
-        }
-
-        DtoMarshaller.copyToDto(sgDao.save(surveyGroup), value);
-        return value;
     }
 
     public static QuestionDto marshalQuestionDto(Question q) {
@@ -812,7 +730,7 @@ public class SurveyServiceImpl extends RemoteServiceServlet implements
         com.google.appengine.api.taskqueue.Queue queue = com.google.appengine.api.taskqueue.QueueFactory
                 .getQueue("surveyAssembly");
         queue.add(options);
-        
+
         Survey s = new SurveyDAO().getById(surveyId);
         SurveyGroup sg = s != null ? new SurveyGroupDAO().getByKey(s.getSurveyGroupId()) : null;
         if (sg != null && sg.getNewLocaleSurveyId() != null &&

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -39,6 +39,7 @@ import org.waterforpeople.mapping.app.util.DtoMarshaller;
 import org.waterforpeople.mapping.app.web.rest.dto.RestStatusDto;
 import org.waterforpeople.mapping.app.web.rest.dto.SurveyGroupPayload;
 
+import com.gallatinsystems.common.Constants;
 import com.gallatinsystems.survey.dao.SurveyDAO;
 import com.gallatinsystems.survey.dao.SurveyGroupDAO;
 import com.gallatinsystems.survey.dao.SurveyUtils;
@@ -86,7 +87,12 @@ public class SurveyGroupRestService {
 
         // if we are here, it is a regular request
         List<SurveyGroup> surveyGroups = surveyGroupDao.listAllFilteredByUserAuthorization();
-        List<Survey> surveys = surveyDao.listAllFilteredByUserAuthorization();
+
+        // we do not need to filter the list of Survey entities (forms) i.e. we list *all* results
+        // as the list will be filtered later when processing the list of SurveyGroup entities
+        // (surveys) to include
+        List<Survey> surveys = surveyDao.list(Constants.ALL_RESULTS);
+
         Map<Long, Survey> surveyGroupIdToSomeSurvey = new HashMap<>();
 
         if (surveys != null) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -105,8 +105,7 @@ public class SurveyGroupRestService {
 
         if (surveyGroups != null) {
             for (SurveyGroup sg : surveyGroups) {
-                SurveyGroupDto dto = new SurveyGroupDto();
-                DtoMarshaller.copyToDto(sg, dto);
+                SurveyGroupDto dto = new SurveyGroupDto(sg);
                 Survey survey = surveyGroupIdToSomeSurvey.get(sg.getKey().getId());
                 if (survey != null) {
                     // we don't want/need the full object

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2012-2016 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyGroupRestService.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.waterforpeople.mapping.app.gwt.client.survey.SurveyDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveyGroupDto;
 import org.waterforpeople.mapping.app.util.DtoMarshaller;
 import org.waterforpeople.mapping.app.web.rest.dto.RestStatusDto;
@@ -110,10 +109,8 @@ public class SurveyGroupRestService {
                 DtoMarshaller.copyToDto(sg, dto);
                 Survey survey = surveyGroupIdToSomeSurvey.get(sg.getKey().getId());
                 if (survey != null) {
-                    SurveyDto sDto = new SurveyDto();
                     // we don't want/need the full object
-                    sDto.setKeyId(survey.getKey().getId());
-                    dto.addSurvey(sDto);
+                    dto.addSurvey(survey.getKey().getId());
                 }
                 results.add(dto);
             }


### PR DESCRIPTION
* Get rid of BeanUtils for copying properties
* Rearranged order of requests to dashboard. Cascade resources and metrics end points loaded after surveys
* Reduced `surveyList` to array of IDs instead of array of Survey entities 