### PR TITLE
[#1786] Data point approval status (connect #1786)

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -49,7 +49,17 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
 	  if (this.get('cursorStart')) {
 		criteria.since = this.get('cursorStart');
 	  }
-      FLOW.router.surveyedLocaleController.populate(criteria);
+      var surveyedLocaleController = FLOW.router.get('surveyedLocaleController');
+      surveyedLocaleController.populate(criteria);
+
+      surveyedLocaleController.get('content').on('didLoad', function () {
+          var surveyedLocales = this;
+          var surveyedLocaleIds = Ember.A();
+          surveyedLocales.forEach(function (item) {
+              surveyedLocaleIds.addObject(item.get('keyId'));
+          })
+          FLOW.router.dataPointApprovalController.loadBySurveyedLocaleId(surveyedLocaleIds);
+      })
   },
 
   doNextPage: function () {

--- a/GAE/src/com/gallatinsystems/survey/dao/DataPointApprovalDAO.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/DataPointApprovalDAO.java
@@ -16,9 +16,13 @@
 
 package com.gallatinsystems.survey.dao;
 
+import java.util.Collections;
 import java.util.List;
 
+import javax.jdo.PersistenceManager;
+
 import com.gallatinsystems.framework.dao.BaseDAO;
+import com.gallatinsystems.framework.servlet.PersistenceFilter;
 import com.gallatinsystems.survey.domain.DataPointApproval;
 
 public class DataPointApprovalDAO extends BaseDAO<DataPointApproval> {
@@ -31,4 +35,13 @@ public class DataPointApprovalDAO extends BaseDAO<DataPointApproval> {
         return this.listByProperty("surveyedLocaleId", surveyedLocaleId, "Long");
     }
 
+    public List<DataPointApproval> listBySurveyedLocaleIds(List<Long> surveyedLocaleIds) {
+        if (surveyedLocaleIds == null || surveyedLocaleIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        PersistenceManager pm = PersistenceFilter.getManager();
+        String queryString = ":p2.contains(surveyedLocaleId)";
+        javax.jdo.Query query = pm.newQuery(DataPointApproval.class, queryString);
+        return (List<DataPointApproval>) query.execute(surveyedLocaleIds);
+    }
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/DataPointApprovalRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/DataPointApprovalRestService.java
@@ -83,12 +83,19 @@ public class DataPointApprovalRestService {
     @RequestMapping(method = RequestMethod.GET)
     @ResponseBody
     public Map<String, List<DataPointApprovalDTO>> listDataPointApprovals(
+            @RequestParam(value = "surveyedLocaleId[]", required = false) List<Long> surveyedLocaleIds,
             @RequestParam(value = "surveyedLocaleId", required = false) Long surveyedLocaleId) {
         Map<String, List<DataPointApprovalDTO>> response = new HashMap<String, List<DataPointApprovalDTO>>();
 
+        List<DataPointApproval> approvals = new ArrayList<DataPointApproval>();
+        if (surveyedLocaleIds != null) {
+            approvals.addAll(dataPointApprovalDao.listBySurveyedLocaleIds(surveyedLocaleIds));
+        } else if (surveyedLocaleId != null) {
+            approvals.addAll(dataPointApprovalDao.listBySurveyedLocaleId(surveyedLocaleId));
+        }
+
         List<DataPointApprovalDTO> approvalsResponseList = new ArrayList<DataPointApprovalDTO>();
-        for (DataPointApproval approval : dataPointApprovalDao
-                .listBySurveyedLocaleId(surveyedLocaleId)) {
+        for (DataPointApproval approval : approvals) {
             approvalsResponseList.add(new DataPointApprovalDTO(approval));
         }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The approval status for a data point was always reset to the first step in an approval group.  This fixes the issue.

#### The solution
We are now loading the approval status just after loading the data points.  This shows the correct status in which a data point is.

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation