### PR TITLE
Remove _copy suffix from copied question IDs (connect #1203)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -107,6 +107,7 @@ public class SurveyUtils {
         final QuestionDao qDao = new QuestionDao();
         final Long sourceGroupId = sourceGroup.getKey().getId();
         final Long copyGroupId = copyGroup.getKey().getId();
+        final boolean sameSurvey = sourceGroup.getSurveyId() == newSurveyId;
 
         SurveyUtils.copyTranslation(sourceGroupId, copyGroupId, newSurveyId, copyGroupId,
                 ParentType.QUESTION_GROUP_NAME, ParentType.QUESTION_GROUP_DESC);
@@ -123,7 +124,7 @@ public class SurveyUtils {
         List<Question> qCopyList = new ArrayList<Question>();
         for (Question question : qList) {
             final Question questionCopy = SurveyUtils.copyQuestion(question, copyGroupId, qCount++,
-                    newSurveyId);
+                    newSurveyId, sameSurvey);
             qCopyList.add(questionCopy);
         }
 
@@ -152,7 +153,7 @@ public class SurveyUtils {
     }
 
     public static Question copyQuestion(Question source,
-            Long newQuestionGroupId, Integer order, Long newSurveyId) {
+            Long newQuestionGroupId, Integer order, Long newSurveyId, boolean sameSurvey) {
 
         final QuestionDao qDao = new QuestionDao();
         final QuestionOptionDao qoDao = new QuestionOptionDao();
@@ -173,7 +174,11 @@ public class SurveyUtils {
         tmp.setSourceQuestionId(sourceQuestionId);
 
         if (source.getQuestionId() != null) {
-            tmp.setQuestionId(source.getQuestionId());
+            if (sameSurvey) {
+                tmp.setQuestionId(source.getQuestionId() + "_copy");
+            } else {
+                tmp.setQuestionId(source.getQuestionId());
+            }
         }
 
         log.log(Level.INFO, "Copying `Question` " + sourceQuestionId);

--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -173,8 +173,9 @@ public class SurveyUtils {
         tmp.setSourceQuestionId(sourceQuestionId);
 
         if (source.getQuestionId() != null) {
-            tmp.setQuestionId(source.getQuestionId() + "_copy");
+            tmp.setQuestionId(source.getQuestionId());
         }
+
         log.log(Level.INFO, "Copying `Question` " + sourceQuestionId);
 
         final Question newQuestion = qDao.save(tmp, newQuestionGroupId);


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Copied question IDs have a superfluous _copy suffix.
#### The solution
Remove the suffix.

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [ ] Documentation

