### PR TITLE
[#1785] Data point approval status on completion (connects #1785)

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -118,9 +118,16 @@ FLOW.DataPointView = FLOW.View.extend({
     }.property('FLOW.router.dataPointApprovalController.content.@each'),
 
     /*
-     * Derive the approvalStepId for the next approval (in ordered approvals)
+     * get the next approval step id
      */
     nextApprovalStepId: function () {
+        return this.get('nextApprovalStep') && this.get('nextApprovalStep').get('keyId');
+    }.property('this.nextApprovalStep'),
+
+    /*
+     * Derive the next approval step (in ordered approvals)
+     */
+    nextApprovalStep: function () {
         var approvals = this.get('dataPointApprovals');
         var steps = FLOW.router.approvalStepsController.get('arrangedContent');
         var lastApprovedStepOrder = -1;
@@ -134,8 +141,8 @@ FLOW.DataPointView = FLOW.View.extend({
             }
         });
 
-        var nextStep = steps && steps.filterProperty('order', ++lastApprovedStepOrder).get('firstObject');
-        return nextStep && nextStep.get('keyId');
+        var nextStep = steps.filterProperty('order', ++lastApprovedStepOrder).get('firstObject');
+        return nextStep;
 
     // NOTE: below we observe the '@each.approvalDate' in order to be
     // sure that we only recalculate the next step whenever the approval
@@ -230,7 +237,7 @@ FLOW.DataPointApprovalView = FLOW.View.extend({
             // all steps so that its possible to approve any step
             return true;
         }
-    }.property('this.parentView.nextApprovalStepId'),
+    }.property('this.parentView.nextApprovalStep'),
 
     /*
      *  Submit data approval properties to controller

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -180,12 +180,22 @@ FLOW.DataPointView = FLOW.View.extend({
 FLOW.DataPointApprovalStatusView = FLOW.View.extend({
     content: null,
 
-    latestApprovalStepTitle: function () {
-        var nextStepId = this.get('parentView').get('nextApprovalStepId');
-        var stepsController = FLOW.router.get('approvalStepsController');
-        var step = stepsController.filterProperty('keyId', nextStepId).get('firstObject');
-        return step && step.get('title');
-    }.property('this.parentView.nextApprovalStepId'),
+    dataPointApprovalStatus: function () {
+        var approvalStepStatus;
+        var latestApprovalStep = this.get('latestApprovalStep');
+        if (!latestApprovalStep) {
+            return;
+        }
+
+        var dataPointApprovals = this.get('parentView').get('dataPointApprovals');
+        var dataPointApproval = dataPointApprovals &&
+                                    dataPointApprovals.filterProperty('approvalStepId',
+                                            latestApprovalStep.get('keyId')).get('firstObject');
+        approvalStepStatus = dataPointApproval && dataPointApproval.get('status') ||
+                                Ember.String.loc('_pending');
+
+        return latestApprovalStep.get('title') + ' - ' + approvalStepStatus.toUpperCase();
+    }.property('this.parentView.nextApprovalStep'),
 
     /*
      * Derive the latest approval step for a particular data point

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -186,6 +186,22 @@ FLOW.DataPointApprovalStatusView = FLOW.View.extend({
         var step = stepsController.filterProperty('keyId', nextStepId).get('firstObject');
         return step && step.get('title');
     }.property('this.parentView.nextApprovalStepId'),
+
+    /*
+     * Derive the latest approval step for a particular data point
+     */
+    latestApprovalStep: function () {
+        var lastStep, steps;
+        var nextStep = this.get('parentView').get('nextApprovalStep');
+
+        if (nextStep) {
+            return nextStep;
+        } else {
+            steps = FLOW.router.approvalStepsController.get('arrangedContent');
+            lastStep = steps && steps.get('lastObject');
+            return lastStep;
+        }
+    }.property('this.parentView.nextApprovalStep'),
 });
 
 /**

--- a/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
@@ -7,7 +7,7 @@
     {{#if view.parentView.showApprovalStatusColumn}}
     <td class="approvalStatus">
         <a {{action toggleShowDataApprovalBlock target="view"}}>
-            {{#view FLOW.DataPointApprovalStatusView}}{{view.latestApprovalStepTitle}}{{/view}}
+            {{#view FLOW.DataPointApprovalStatusView}}{{view.dataPointApprovalStatus}}{{/view}}
         </a>
     </td>
     {{/if}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The data point status was not shown when a set of approvals was completed, making it impossible to review the comments on the different approval steps.

#### The solution
Fix includes displaying the last step when approvals have been completed as well as including the status of that last step.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation