### PR TITLE
[#1880] Fix to return the next ApprovalStep entity not its `keyId` (connects #1880)

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -137,7 +137,7 @@ FLOW.DataPointView = FLOW.View.extend({
         var steps = FLOW.router.approvalStepsController.get('arrangedContent');
 
         if (Ember.empty(approvals)) {
-            return steps && steps.get('firstObject').get('keyId');
+            return steps && steps.get('firstObject');
         }
 
         steps.forEach(function (step) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The monitoring data tab is not loading data points because it encounters a null object error due to a wrongly returned property.  This fix ensures the correct property is returned.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation