### PR TITLE
[#1882] Show correct approval status for rejected data points (connects #1882)

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -144,7 +144,8 @@ FLOW.DataPointView = FLOW.View.extend({
             var approval = approvals.filterProperty('approvalStepId',
                                         step.get('keyId')).get('firstObject');
             var isPendingStep = !approval || approval.get('status') === 'PENDING';
-            if (!nextStep && isPendingStep) {
+            var isRejectedStep = approval && approval.get('status') === 'REJECTED';
+            if (!nextStep && (isPendingStep || isRejectedStep)) {
                 nextStep = step;
             }
         });


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

For cases where an approval step is rejected, the data point status was still showing the following approval step as pending whereas it should show the last step along with the status as being rejected.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
