### PR TITLE
[1845]Update copyright headers to 2012-2017 for January release. (Connect #1845)

### DIFF
--- a/Dashboard/app/js/templates/application/footer-public.handlebars
+++ b/Dashboard/app/js/templates/application/footer-public.handlebars
@@ -11,5 +11,5 @@
 		</ul>
 	</nav>
   </div>
-  <div><small>{{t _copyright}} &copy; 2012-2016 akvo.org</small></div>
+  <div><small>{{t _copyright}} &copy; 2012-2017 akvo.org</small></div>
 </footer>

--- a/Dashboard/app/js/templates/application/footer.handlebars
+++ b/Dashboard/app/js/templates/application/footer.handlebars
@@ -12,5 +12,5 @@
 		</ul>
 	</nav>
   </div>
-  <div><small>__VERSION__ - {{t _copyright}} &copy; 2012-2016 akvo.org</small></div>
+  <div><small>__VERSION__ - {{t _copyright}} &copy; 2012-2017 akvo.org</small></div>
 </footer>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 LICENSE.md, v1.0, 24 May 2012 [co, ogl]
 
-Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
 
 This file is part of Akvo Flow.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,23 +1,3 @@
-LICENSE.md, v1.0, 24 May 2012 [co, ogl]
-
-Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
-
-This file is part of Akvo Flow.
-
-Akvo Flow is free software: you can redistribute it and modify
-it under the terms of the GNU Affero General Public License (AGPL)
-as published by the Free Software Foundation, either version 3 of the
-License or any later version.
-
-Akvo Flow is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License included below for more details.  
-
-The license can also be seen at <http://www.gnu.org/licenses/agpl.html>.
-
-=====
-
 ## GNU AFFERO GENERAL PUBLIC LICENSE
 ### Version 3 (19 November 2007)
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Copyright year span 2012-2016 would be outdated by the time of the release.
#### The solution
Changed to 2012-2017
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation

