### PR TITLE
[#1770] Data approval assignment dropdown (connect #1770)

### DIFF
--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -514,7 +514,7 @@ FLOW.ApprovalGroupController = Ember.ObjectController.extend({
     add: function () {
         var group = FLOW.ApprovalGroup.createRecord({
             name: Ember.String.loc('_new_approval_group'),
-            ordered: false,
+            ordered: true,
         });
 
         this.set('content', group);

--- a/Dashboard/app/js/templates/navSurveys/project.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/project.handlebars
@@ -92,7 +92,8 @@
                             optionLabelPath="content.name"
                             optionValuePath="content.keyId"
                             selectionBinding="FLOW.projectControl.dataApprovalGroup"
-                            disabledBinding="view.disableFolderSurveyInputField"}}
+                            disabledBinding="view.disableFolderSurveyInputField"
+                            promptBinding="Ember.STRINGS._choose_data_approval_group"}}
 
                             {{#if view.showDataApprovalDetails}}
                               <div class="hideShow">

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -96,6 +96,7 @@ Choose\ a\ pre-created\ cascade\ from\ the\ Cascade\ resources\ library.\ If\ yo
 Choose\ a\ question\ using\ the\ dropdown\ selectors\ above = Choose a question using the dropdown selectors above
 Choose\ an\ existing\ device\ group\ from\ the\ list = Choose an existing device group from the list
 Choose\ cascade\ resource = Choose cascade resource
+Choose\ data\ approval\ group = Choose data approval group
 Choose\ survey\ data\ to\ display = Choose survey data to display
 Choose\ test\ type = Choose test type
 Choose\ the\ registration\ form = Choose the registration form

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -102,6 +102,7 @@ _choose_caddisfly_question_resource = Choose test type
 _choose_caddisfly_question_resource_tooltip = Select the test type you want to work with.
 _choose_cascade_question_resource = Choose cascade resource
 _choose_cascade_question_resource_tooltip = Choose a pre-created cascade from the Cascade resources library. If you want to create a new cascade, you can create and publish it in the Cascade resources under the Data tab.
+_choose_data_approval_group = Choose data approval group
 _choose_existing_cascade = Select an existing cascade
 _choose_folder_or_survey = Choose a folder or survey
 _choose_survey_data_to_display = Choose survey data to display


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* When assigning a data approval to a survey, the dropdown already contained a selected approval.  This is now replaced with a prompt to select an approval.
* In addition, when creating an approval group, the default setting is to an `Ordered` approval group since this is the only type we are dealing with at the moment.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation