### PR TITLE
[#1732] do not include Google maps library unless when needed (connect #1732)

### DIFF
--- a/Dashboard/app/dashboard.html
+++ b/Dashboard/app/dashboard.html
@@ -45,15 +45,23 @@
     </script>
 
     <script>
-      link_href = (FLOW.Env.mapsProvider === 'cartodb') ? "//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" : "//api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.css";
-      script_src = (FLOW.Env.mapsProvider === 'cartodb') ? "//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js": "//api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.js";
-
-      document.write("<link rel=\"stylesheet\" href=\""+link_href+"\" />");
-      document.write("<script type=\"text/javascript\" src=\""+script_src+"\"><\/script>");
-
-      var regionBias = FLOW.Env.googleMapsRegionBias;
-      var region = regionBias ? '&region=' + regionBias : '';
-      document.write('<script src="//maps.google.com/maps/api/js?v=3.2&sensor=false' + region + '"><\/script>');
+      //default leaflet library
+      var css_src = "//api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.css";
+      var js_src = "//api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.js";
+      switch (FLOW.Env.mapsProvider) {
+          case 'cartodb':
+              //replace leaflet library
+              css_src = "//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css";
+              js_src = "//cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js";
+              break;
+          case 'google':
+              var regionBias = FLOW.Env.googleMapsRegionBias;
+              var region = regionBias ? '&region=' + regionBias : '';
+              document.write('<script src="//maps.google.com/maps/api/js?key=AIzaSyBZU7kLJ75VlTlC5Qrfi1n1N-5hJYProuQ' + region + '"><\/script>');
+              break;
+      }
+      document.write("<link rel=\"stylesheet\" href=\""+css_src+"\" />");
+      document.write("<script type=\"text/javascript\" src=\""+js_src+"\"><\/script>");
     </script>
     <script src="/vendorjs/js/vendor/Google.js"></script>
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
@@ -124,6 +124,10 @@ public class EnvServlet extends HttpServlet {
             props.put("enableDataApproval", "false");
         }
 
+        if (props.get("googleMapsRegionBias") == null) {
+            props.put("googleMapsRegionBias", "");
+        }
+
         if (props.get("extraMapboxTileLayerMapId") == null) {
             props.put("extraMapboxTileLayerMapId", "");
         }


### PR DESCRIPTION
#### Google maps library included even when maps provider is specified as cartodb or mapbox
#### Logic changed to load libraries based on specified maps provider

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
