### PR TITLE
Load metrics end point only when showStatisticsFeature flag is enabled (connect #1855)

### DIFF
--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -29,7 +29,7 @@ FLOW.attributeControl = Ember.ArrayController.create({
 
   // load all Survey Groups
   populate: function () {
-    if(FLOW.Env.showStatisticsFeature){
+    if (FLOW.Env.showStatisticsFeature) {
         FLOW.store.find(FLOW.Metric);
     }
     this.setFilteredContent();

--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -29,7 +29,9 @@ FLOW.attributeControl = Ember.ArrayController.create({
 
   // load all Survey Groups
   populate: function () {
-    FLOW.store.find(FLOW.Metric);
+    if(FLOW.Env.showStatisticsFeature){
+        FLOW.store.find(FLOW.Metric);
+    }
     this.setFilteredContent();
     this.set('sortProperties', ['name']);
     this.set('sortAscending', true);


### PR DESCRIPTION
#### Metrics end point loading regardless of whether statistics feature flag is enabled or not
#### Confirm that "showStatisticsFeature" is enabled before loading end point

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
