### PR TITLE
Fix regression for datapoint name rebuild (connect #1934)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
@@ -49,6 +49,7 @@ import org.waterforpeople.mapping.app.gwt.client.survey.SurveyGroupDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveyService;
 import org.waterforpeople.mapping.app.gwt.client.survey.TranslationDto;
 import org.waterforpeople.mapping.app.util.DtoMarshaller;
+import org.waterforpeople.mapping.app.web.DataProcessorRestServlet;
 import org.waterforpeople.mapping.app.web.dto.BootstrapGeneratorRequest;
 import org.waterforpeople.mapping.app.web.dto.SurveyAssemblyRequest;
 import org.waterforpeople.mapping.app.web.dto.SurveyTaskRequest;
@@ -734,7 +735,7 @@ public class SurveyServiceImpl extends RemoteServiceServlet implements
         if (sg != null && sg.getNewLocaleSurveyId() != null &&
                 sg.getNewLocaleSurveyId().longValue() == surveyId.longValue()) {
             // This is the registration form. Schedule datapoint name re-assembly
-            // DataProcessorRestServlet.scheduleDatapointNameAssembly(sg.getKey().getId(), null);
+            DataProcessorRestServlet.scheduleDatapointNameAssembly(sg.getKey().getId(), null);
         }
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
A regression was introduced in this commit (3a70e36b0a50cc2aee620adfa22a51407dc60fcb) that removed the code to rebuild data point names when a survey is republished.

#### The solution
We reintroduce the datapoint name rebuilding code.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
