### PR TITLE
[#1976] remove user column (connect #1976)

### DIFF
--- a/Dashboard/app/js/templates/navMessages/nav-messages.handlebars
+++ b/Dashboard/app/js/templates/navMessages/nav-messages.handlebars
@@ -10,7 +10,7 @@
                   <a {{action "sort" target="this"}} class="date">{{t _date}}</a>
            {{/view}}
            {{#view FLOW.ColumnView item="objectId" type="message"}}
-                  <a {{action "sort" target="this"}} class="objectId">{{t _survey_id}}</a>
+                  <a {{action "sort" target="this"}} class="objectId">{{t _form_id}}</a>
            {{/view}}
             {{#view FLOW.ColumnView item="objectTitle" type="message"}}
                   <a {{action "sort" target="this"}} class="survey">{{t _survey}}</a>
@@ -20,9 +20,6 @@
            {{/view}}
            {{#view FLOW.ColumnView item="shortMessage" type="message"}}
                   <a {{action "sort" target="this"}} class="message">{{t _message}}</a>
-           {{/view}}
-            {{#view FLOW.ColumnView item="userName" type="message"}}
-                  <a {{action "sort" target="this"}} class="user">{{t _user}}</a>
            {{/view}}
         </tr>
       </thead>
@@ -35,7 +32,6 @@
             <td class="objectTitle">{{unbound mess.objectTitle}}</td>
             <td class="actionAbout">{{unbound mess.actionAbout}}</td>
             <td class="message" style="text-align:left; padding:0 0 0 20px;">{{unbound mess.shortMessage}}</td>
-              <td class="userName">{{unbound mess.userName}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -202,6 +202,7 @@ Exports\ all\ submitted\ raw\ data\ for\ a\ single\ form\ to\ a\ tab\ delimited\
 Exports\ all\ submitted\ raw\ data\ for\ a\ single\ form\ to\ an\ excel\ spreadsheet.\ This\ report\ will\ contain\ all\ responses\ submitted\ for\ the\ form.\ Please\ immediately\ make\ a\ local\ copy\ of\ this\ file\ before\ you\ make\ any\ changes.\ (same\ as\ raw\ data\ report) = Exports all submitted raw data for a single form to an excel spreadsheet. This report will contain all responses submitted for the form. Please immediately make a local copy of this file before you make any changes. (same as raw data report)
 Find = Find
 Form = Form
+Form\ ID = Form ID
 Form\ basics = Form basics
 Form\ description = Form description
 Form\ details = Form details

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -221,6 +221,7 @@ _form_basics = Form basics
 _form_description = Form description
 _form_details = Form details
 _form_details_in = Form details in
+_form_id = Form ID
 _form_title = Form title
 _form_translation = Form translation
 _forms = Forms


### PR DESCRIPTION
#### Before, the user column in the messages tab was blank and header of column with Form IDs read "Survey ID"
#### Removed user column and changed labeling of "Survey ID" column to "Form ID"

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
