### PR TITLE
Enable retrieval of a single `SurveyGroup` entity as part of data approval report generation (connect #1666)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/SurveyGroupDto.java
@@ -21,12 +21,11 @@ import java.util.Date;
 import java.util.List;
 
 import com.gallatinsystems.framework.gwt.dto.client.BaseDto;
-import com.gallatinsystems.framework.gwt.dto.client.NamedObject;
 import com.gallatinsystems.survey.domain.SurveyGroup;
 import com.gallatinsystems.survey.domain.SurveyGroup.PrivacyLevel;
 import com.gallatinsystems.survey.domain.SurveyGroup.ProjectType;
 
-public class SurveyGroupDto extends BaseDto implements NamedObject {
+public class SurveyGroupDto extends BaseDto {
 
     private static final long serialVersionUID = -2235565143615667202L;
 
@@ -127,11 +126,6 @@ public class SurveyGroupDto extends BaseDto implements NamedObject {
             surveyList = new ArrayList<Long>();
         }
         surveyList.add(surveyId);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return getCode();
     }
 
     public void setName(String name) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -135,23 +135,21 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
         } else if (SurveyRestRequest.GET_SURVEY_GROUP_ACTION.equals(surveyReq
                 .getAction())) {
             List<SurveyGroupDto> sgList = new ArrayList<SurveyGroupDto>();
-            Long sgId = surveyReq.getSurveyGroupId();
-            if (sgId != null) {
-                SurveyGroupDto dto = getSurveyGroup(sgId);
-                if (dto != null) {
-                    sgList.add(dto);
+            Long surveyGroupId = null;
+
+            if (surveyReq.getSurveyGroupId() != null) {
+                surveyGroupId = surveyReq.getSurveyGroupId();
+            } else if (surveyReq.getSurveyId() != null) {
+                Survey s = surveyDao.getById(surveyReq.getSurveyId());
+                if (s != null) {
+                    surveyGroupId = s.getSurveyGroupId();
                 }
-            } else {
-                // Trying to get it using Survey ID
-                Long sId = surveyReq.getSurveyId();
-                if (sId != null) {
-                    Survey s = surveyDao.getById(sId);
-                    if (s != null) {
-                        SurveyGroupDto dto = getSurveyGroup(s.getSurveyGroupId());
-                        if (dto != null) {
-                            sgList.add(dto);
-                        }
-                    }
+            }
+
+            if (surveyGroupId != null) {
+                SurveyGroup sg = sgDao.getByKey(surveyGroupId);
+                if (sg != null) {
+                    sgList.add(new SurveyGroupDto(sg));
                 }
             }
             response.setDtoList(sgList);
@@ -267,15 +265,6 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
         response.setDtoList(dtoList);
         response.setCursor(cursorString);
         return response;
-    }
-
-    private SurveyGroupDto getSurveyGroup(Long surveyGroupId) {
-        SurveyGroupDAO surveyGroupDao = new SurveyGroupDAO();
-        SurveyGroup sg = surveyGroupDao.getByKey(surveyGroupId);
-        if (sg == null) {
-            return null;
-        }
-        return new SurveyGroupDto(sg);
     }
 
     private SurveyDto getSurvey(Long surveyId) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -271,13 +271,11 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
 
     private SurveyGroupDto getSurveyGroup(Long surveyGroupId) {
         SurveyGroupDAO surveyGroupDao = new SurveyGroupDAO();
-        SurveyGroupDto dto = new SurveyGroupDto();
         SurveyGroup sg = surveyGroupDao.getByKey(surveyGroupId);
         if (sg == null) {
             return null;
         }
-        DtoMarshaller.copyToDto(sg, dto);
-        return dto;
+        return new SurveyGroupDto(sg);
     }
 
     private SurveyDto getSurvey(Long surveyId) {

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -64,6 +64,7 @@ import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto.QuestionType;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionOptionDto;
+import org.waterforpeople.mapping.app.gwt.client.survey.SurveyGroupDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.TranslationDto;
 import org.waterforpeople.mapping.app.gwt.client.surveyinstance.SurveyInstanceDto;
 import org.waterforpeople.mapping.app.web.dto.SurveyRestRequest;
@@ -308,6 +309,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     private boolean performGeoRollup;
     private boolean generateCharts;
     private Map<Long, QuestionDto> questionsById;
+    private SurveyGroupDto surveyGroupDto;
     private boolean lastCollection = false;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private CaddisflyResourceDao caddisflyResourceDao = new CaddisflyResourceDao();
@@ -327,17 +329,20 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     @Override
     public void export(Map<String, String> criteria, File fileName,
             String serverBase, Map<String, String> options) {
+        final String surveyId = criteria.get(SurveyRestRequest.SURVEY_ID_PARAM).trim();
+
         processOptions(options);
 
         questionsById = new HashMap<Long, QuestionDto>();
+        surveyGroupDto = BulkDataServiceClient.fetchSurveyGroup(surveyId, serverBase,
+                criteria.get("apiKey").trim());
         this.serverBase = serverBase;
         boolean useQuestionId = "true".equals(options.get("useQuestionId"));
         String from = options.get("from");
         String to = options.get("to");
         String limit = options.get("maxDataReportRows");
         try {
-            Map<QuestionGroupDto, List<QuestionDto>> questionMap = loadAllQuestions(
-                    criteria.get(SurveyRestRequest.SURVEY_ID_PARAM),
+            Map<QuestionGroupDto, List<QuestionDto>> questionMap = loadAllQuestions(surveyId,
                     performGeoRollup, serverBase, criteria.get("apiKey"));
             if (questionMap != null) {
                 for (List<QuestionDto> qList : questionMap.values()) {

--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveySummaryExporter.java
@@ -44,7 +44,6 @@ import org.json.JSONObject;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto.QuestionType;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
-import org.waterforpeople.mapping.app.gwt.client.survey.SurveyGroupDto;
 import org.waterforpeople.mapping.app.web.dto.SurveyRestRequest;
 import org.waterforpeople.mapping.dataexport.service.BulkDataServiceClient;
 
@@ -214,16 +213,6 @@ public class SurveySummaryExporter extends AbstractDataExporter {
 
     }
 
-    protected List<SurveyGroupDto> fetchSurveyGroup(String surveyId, String serverBase,
-            String apiKey) throws Exception {
-
-        return parseSurveyGroups(BulkDataServiceClient.fetchDataFromServer(
-                serverBase + SERVLET_URL, "action="
-                        + SurveyRestRequest.GET_SURVEY_GROUP_ACTION + "&"
-                        + SurveyRestRequest.SURVEY_ID_PARAM + "="
-                        + surveyId, true, apiKey));
-    }
-
     protected Map<QuestionGroupDto, List<QuestionDto>> loadAllQuestions(
             String surveyId, boolean performRollups, String serverBase, String apiKey)
             throws Exception {
@@ -346,41 +335,6 @@ public class SurveySummaryExporter extends AbstractDataExporter {
                 }
             }
         }
-        return dtoList;
-    }
-
-    protected List<SurveyGroupDto> parseSurveyGroups(String response) throws Exception {
-        List<SurveyGroupDto> dtoList = new ArrayList<SurveyGroupDto>();
-        JSONArray jsonArray = getJsonArray(response);
-
-        if (jsonArray == null) {
-            return dtoList;
-        }
-
-        for (int i = 0; i < jsonArray.length(); i++) {
-            JSONObject o = jsonArray.getJSONObject(i);
-            if (o != null) {
-                try {
-
-                    SurveyGroupDto dto = new SurveyGroupDto();
-
-                    if (!o.isNull("name")) {
-                        dto.setName(o.getString("name"));
-                    }
-
-                    if (o.isNull("monitoringGroup")) {
-                        dto.setMonitoringGroup(false);
-                    } else {
-                        dto.setMonitoringGroup(o.getBoolean("monitoringGroup"));
-                    }
-
-                    dtoList.add(dto);
-                } catch (Exception e) {
-                    log.error("Error in json parsing: " + e.getMessage(), e);
-                }
-            }
-        }
-
         return dtoList;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
@@ -510,6 +510,8 @@ public class BulkDataServiceClient {
                             + SurveyRestRequest.SURVEY_ID_PARAM + "="
                             + surveyId, true, apiKey);
 
+            log.debug("response: " + surveyGroupResponse);
+
             final JsonNode surveyGroupListNode = JSON_RESPONSE_PARSER.readTree(surveyGroupResponse)
                     .get("dtoList");
             final List<SurveyGroupDto> surveyGroupList = JSON_RESPONSE_PARSER.readValue(

--- a/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
@@ -41,6 +41,9 @@ import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.log4j.Logger;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -78,6 +81,7 @@ public class BulkDataServiceClient {
     public static final String RESPONSE_KEY = "dtoList";
     private static final String SURVEY_SERVLET_PATH = "/surveyrestapi";
     private static final String DEVICE_FILES_SERVLET_PATH = "/devicefilesrestapi?action=";
+    private static final ObjectMapper JSON_RESPONSE_PARSER = new ObjectMapper();
 
     /**
      * lists all responses from the server for a surveyInstance submission as a map of values keyed
@@ -485,6 +489,40 @@ public class BulkDataServiceClient {
                 + SurveyRestRequest.LIST_GROUP_ACTION + "&"
                 + SurveyRestRequest.SURVEY_ID_PARAM + "=" + surveyId, true,
                 apiKey));
+    }
+
+    /**
+     * Fetch a single SurveyGroup based for the surveyId provided
+     *
+     * @param surveyId
+     * @param serverBase
+     * @param apiKey
+     * @return
+     * @throws Exception
+     */
+    public static SurveyGroupDto fetchSurveyGroup(String surveyId, String serverBase,
+            String apiKey) {
+        SurveyGroupDto surveyGroupDto = null;
+        try {
+            final String surveyGroupResponse = fetchDataFromServer(
+                    serverBase + SURVEY_SERVLET_PATH, "action="
+                            + SurveyRestRequest.GET_SURVEY_GROUP_ACTION + "&"
+                            + SurveyRestRequest.SURVEY_ID_PARAM + "="
+                            + surveyId, true, apiKey);
+
+            final JsonNode surveyGroupListNode = JSON_RESPONSE_PARSER.readTree(surveyGroupResponse)
+                    .get("dtoList");
+            final List<SurveyGroupDto> surveyGroupList = JSON_RESPONSE_PARSER.readValue(
+                    surveyGroupListNode, new TypeReference<List<SurveyGroupDto>>() {
+                    });
+            if (surveyGroupList != null && !surveyGroupList.isEmpty()) {
+                surveyGroupDto = surveyGroupList.get(0);
+            }
+        } catch (Exception e) {
+            log.error(e);
+        }
+
+        return surveyGroupDto;
     }
 
     /**


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

This PR is part of the work that will go into data approval report generation.  In order to generate the reports, we need to know whether a particular `SurveyGroup` entity has been assigned the property `requireDataApproval == true`.  

Currently we have a utility method to retrieve an entire list of `SurveyGroup` entities, however, when generating a report we only need a single once, for the current report.  We therefore refactor our code to enable retrieving a single entity and remove some unneeded code as well.

We also use Jackson library for parsing the returned JSON responses.

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
