### PR TITLE
Set minimum zoom for mapbox maps (connect #2001)

### DIFF
--- a/Dashboard/app/js/lib/views/maps/map-views-common-public.js
+++ b/Dashboard/app/js/lib/views/maps/map-views-common-public.js
@@ -63,8 +63,11 @@ FLOW.NavMapsView = FLOW.View.extend({
       }, {}));
     } else {
       // insert the map
-      this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm')
-        .setView([-0.703107, 36.765], 2);
+      var options = {
+          minZoom: 2,
+          maxZoom: 18
+      };
+      this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm', options).setView([-0.703107, 36.765], 2);
 
       L.control.layers({
         'Terrain': L.mapbox.tileLayer('akvo.he30g8mm').addTo(this.map),

--- a/Dashboard/app/js/lib/views/maps/map-views-common.js
+++ b/Dashboard/app/js/lib/views/maps/map-views-common.js
@@ -106,7 +106,11 @@ FLOW.NavMapsView = FLOW.View.extend({
   },
 
   insertMapboxMap: function() {
-    this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm').setView([-0.703107, 36.765], 2);
+      var options = {
+          minZoom: 2,
+          maxZoom: 18
+      };
+    this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm', options).setView([-0.703107, 36.765], 2);
     L.control.layers({
       'Terrain': L.mapbox.tileLayer('akvo.he30g8mm').addTo(this.map),
       'Streets': L.mapbox.tileLayer('akvo.he2pdjhk'),


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Mapbox maps were zooming so far out that there would be an overlap
#### The solution
Set minimum zoom level to 2 which fits the world map so user cannot zoom out any further

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
