### PR TITLE
Retrieve survey instance data and data approval status in combined request (connect #1666)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/DataPointApprovalDAO.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/DataPointApprovalDAO.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo Flow.
  *
@@ -32,7 +32,12 @@ public class DataPointApprovalDAO extends BaseDAO<DataPointApproval> {
     }
 
     public List<DataPointApproval> listBySurveyedLocaleId(Long surveyedLocaleId) {
-        return this.listByProperty("surveyedLocaleId", surveyedLocaleId, "Long");
+        List<DataPointApproval> approvals = this.listByProperty("surveyedLocaleId",
+                surveyedLocaleId, "Long");
+        if (approvals == null) {
+            return Collections.emptyList();
+        }
+        return approvals;
     }
 
     public List<DataPointApproval> listBySurveyedLocaleIds(List<Long> surveyedLocaleIds) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
@@ -99,13 +99,13 @@ public class SurveyInstanceServlet extends AbstractRestApiServlet {
         instanceData.surveyInstanceData = si;
 
         if (si.getSurveyedLocaleId() != null) {
-            instanceData.latestApprovalStatus = retrieveSurveyInstanceApprovalStatus(si
+            instanceData.latestApprovalStatus = retrieveDataPointApprovalStatus(si
                     .getSurveyedLocaleId());
         }
         return instanceData;
     }
 
-    private String retrieveSurveyInstanceApprovalStatus(Long surveyedLocaleId) {
+    private String retrieveDataPointApprovalStatus(Long surveyedLocaleId) {
         List<DataPointApproval> approvals = approvalDao.listBySurveyedLocaleId(surveyedLocaleId);
         List<Long> approvalStepIds = extractApprovalStepIds(approvals);
         ApprovalStep latestApprovalStep = retrieveLatestApprovalStep(approvalStepIds);

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/InstanceDataDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/InstanceDataDto.java
@@ -16,13 +16,15 @@
 
 package org.waterforpeople.mapping.app.web.dto;
 
+import org.waterforpeople.mapping.domain.SurveyInstance;
+
 import com.gallatinsystems.framework.rest.RestResponse;
 
 public class InstanceDataDto extends RestResponse {
 
     private static final long serialVersionUID = -1944714927631560507L;
 
-    public SurveyInstanceDto surveyInstanceData;
+    public SurveyInstance surveyInstanceData;
 
     public String latestApprovalStatus;
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/InstanceDataDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/InstanceDataDto.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.app.web.dto;
+
+import com.gallatinsystems.framework.rest.RestResponse;
+
+public class InstanceDataDto extends RestResponse {
+
+    private static final long serialVersionUID = -1944714927631560507L;
+
+    public SurveyInstanceDto surveyInstanceData;
+
+    public String latestApprovalStatus;
+}

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/SurveyInstanceRequest.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/SurveyInstanceRequest.java
@@ -16,20 +16,23 @@
 
 package org.waterforpeople.mapping.app.web.dto;
 
+import java.util.logging.Logger;
+
 import javax.servlet.http.HttpServletRequest;
 
 import com.gallatinsystems.framework.rest.RestRequest;
 
 public class SurveyInstanceRequest extends RestRequest {
 
-    /**
-	 * 
-	 */
+    private static final Logger log = Logger.getLogger(SurveyInstanceRequest.class.getName());
     private static final long serialVersionUID = 6642806619258697157L;
     private static final String FIELD_NAME_PARAM = "fieldName";
     private static final String VALUE_NAME_PARAM = "value";
+    public static final String GET_INSTANCE_DATA_ACTION = "getInstanceData";
+    public static final String SURVEY_INSTANCE_ID_PARAM = "surveyInstanceId";
 
     private String fieldName = null;
+    public Long surveyInstanceId;
 
     public String getFieldName() {
         return fieldName;
@@ -56,6 +59,13 @@ public class SurveyInstanceRequest extends RestRequest {
         }
         if (req.getParameter(VALUE_NAME_PARAM) != null) {
             setValue(req.getParameter(VALUE_NAME_PARAM));
+        }
+        if (req.getParameter(SURVEY_INSTANCE_ID_PARAM) != null) {
+            try {
+                this.surveyInstanceId = Long.parseLong(req.getParameter(SURVEY_INSTANCE_ID_PARAM));
+            } catch (NumberFormatException e) {
+                log.warning("Could not convert survey instance id: " + surveyInstanceId);
+            }
         }
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* We are retrieving the different elements required to build up reports in separate requests to the backends.  however, this creates too much unnecessary traffic and possible points of failure

#### The solution
* We combine the request for instance data into a single call.  This is the first half of the changeset.  In this part we refactor the `SurveyInstanceServlet` to support a single action `getInstanceData` that returns all the data corresponding to a single response.  For now we return the instance data and the approval status of the corresponding data point.  In a later PR we will use this request to populate the raw data report column

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation