### PR TITLE
Remove `NAME` question type and associated properties (connect #2053)

### DIFF
--- a/Dashboard/app/js/lib/models/models.js
+++ b/Dashboard/app/js/lib/models/models.js
@@ -225,9 +225,6 @@ FLOW.Question = FLOW.BaseModel.extend({
   immutable: DS.attr('boolean', {
     defaultValue: false
   }),
-  isName: DS.attr('boolean', {
-    defaultValue: false
-  }),
   mandatoryFlag: DS.attr('boolean', {
     defaultValue: true
   }),

--- a/GAE/src/com/gallatinsystems/survey/domain/Question.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Question.java
@@ -35,7 +35,7 @@ public class Question extends BaseDomain {
     private static final long serialVersionUID = -9123426646238761996L;
 
     public enum Type {
-        FREE_TEXT, OPTION, NUMBER, GEO, PHOTO, VIDEO, SCAN, TRACK, NAME, STRENGTH, DATE, CASCADE,
+        FREE_TEXT, OPTION, NUMBER, GEO, PHOTO, VIDEO, SCAN, TRACK, STRENGTH, DATE, CASCADE,
         GEOSHAPE, SIGNATURE, CADDISFLY
     };
 

--- a/GAE/src/com/gallatinsystems/survey/domain/Question.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Question.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/com/gallatinsystems/survey/domain/Question.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Question.java
@@ -71,7 +71,6 @@ public class Question extends BaseDomain {
     private Double minVal;
     private Double maxVal;
     private Boolean allowExternalSources;
-    private Boolean isName;
     private Boolean localeNameFlag;
     private Boolean localeLocationFlag;
     /**
@@ -132,14 +131,6 @@ public class Question extends BaseDomain {
 
     public void setMaxVal(Double maxVal) {
         this.maxVal = maxVal;
-    }
-
-    public Boolean getName() {
-        return isName;
-    }
-
-    public void setName(Boolean name) {
-        this.isName = name;
     }
 
     public Long getSurveyId() {

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/QuestionDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/QuestionDto.java
@@ -23,13 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-
 public class QuestionDto extends BaseDto {
 
     private static final long serialVersionUID = -4708385830894435407L;
 
     public enum QuestionType {
-        FREE_TEXT, OPTION, NUMBER, GEO, PHOTO, VIDEO, SCAN, TRACK, NAME, STRENGTH, DATE, CASCADE, GEOSHAPE, SIGNATURE, CADDISFLY
+        FREE_TEXT, OPTION, NUMBER, GEO, PHOTO, VIDEO, SCAN, TRACK, STRENGTH, DATE, CASCADE, GEOSHAPE, SIGNATURE, CADDISFLY
     }
 
     private QuestionType type;

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
@@ -532,12 +532,7 @@ public class SurveyAssemblyServlet extends AbstractRestApiServlet {
         }
 
         boolean hasValidation = false;
-        if (q.getName() != null && q.getName()) {
-            ValidationRule validationRule = objFactory.createValidationRule();
-            validationRule.setValidationType("name");
-            qXML.setValidationRule(validationRule);
-            hasValidation = true;
-        } else if (q.getType() == Question.Type.NUMBER
+       if (q.getType() == Question.Type.NUMBER
                 && (q.getAllowDecimal() != null || q.getAllowSign() != null
                         || q.getMinVal() != null || q.getMaxVal() != null)) {
             ValidationRule validationRule = objFactory.createValidationRule();

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
@@ -581,11 +581,6 @@ public class SurveyAssemblyServlet extends AbstractRestApiServlet {
             qXML.setType(VIDEO_QUESTION_TYPE);
         } else if (q.getType().equals(Question.Type.SCAN)) {
             qXML.setType(SCAN_QUESTION_TYPE);
-        } else if (q.getType().equals(Question.Type.NAME)) {
-            qXML.setType(FREE_QUESTION_TYPE);
-            ValidationRule vrule = new ValidationRule();
-            vrule.setValidationType("name");
-            qXML.setValidationRule(vrule);
         } else if (q.getType().equals(Question.Type.STRENGTH)) {
             qXML.setType(STRENGTH_QUESTION_TYPE);
         } else if (q.getType().equals(Question.Type.DATE)) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -604,7 +604,6 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
             q.setType(Question.Type.GEO);
         } else if (questionType.equals("FREE_TEXT")) {
             q.setType(Question.Type.FREE_TEXT);
-            q.setName(req.getIsName());
         } else if (questionType.equals("OPTION")
                 || questionType.equals("STRENGTH")) {
             q.setAllowMultipleFlag(req.getAllowMultipleFlag());

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -639,8 +639,6 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
             q.setAllowSign(req.getAllowSign());
             q.setMinVal(req.getMinVal());
             q.setMaxVal(req.getMaxVal());
-        } else if (questionType.equals("NAME")) {
-            q.setType(Question.Type.NAME);
         } else if (questionType.equals("VIDEO")) {
             q.setType(Question.Type.VIDEO);
         }

--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveySpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveySpreadsheetImporter.java
@@ -430,8 +430,6 @@ public class SurveySpreadsheetImporter implements DataImporter {
                                                         .toString())
                                                 || type.equals(QuestionDto.QuestionType.TRACK
                                                         .toString())
-                                                || type.equals(QuestionDto.QuestionType.NAME
-                                                        .toString())
                                                 || type.equals(QuestionDto.QuestionType.NUMBER
                                                         .toString()) || type
                                                     .equals(QuestionDto.QuestionType.OPTION

--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveySpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveySpreadsheetImporter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The `isName` property was intended to be marked and used to generate validation rules for questions of type `QuestionType.NAME`. However, this question type is never used and therefore the validation rule is never generated in the survey definition.

#### The solution

* We remove the question type, its associated property and the code for generating the corresponding validation rule.

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation