### PR TITLE
Issue/1442 optimise question loading (Connect #1442)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
@@ -203,37 +203,7 @@ public class QuestionDao extends BaseDAO<Question> {
 
 
     /**
-     * list questions in order, by using question groups. Optionally filtered by type
-     *  author: Mark Tiele Westra
-     *
-     * @param surveyId
-     * @return
-     */
-    public List<Question> listQuestionsInOrderNested(Long surveyId, Question.Type type) {
-        List<Question> orderedQuestionList = new ArrayList<Question>();
-        QuestionGroupDao qgDao = new QuestionGroupDao();
-        List<QuestionGroup> qgList = qgDao.listQuestionGroupBySurvey(surveyId);
-        // for each question group, get the questions in the right order and put them in the list
-        List<Question> qList;
-        for (QuestionGroup qg : qgList) {
-            if (type == null) {
-                qList = listByProperty("questionGroupId", qg
-                        .getKey().getId(), "Long", "order", "asc");
-            } else {
-                qList = getByQuestiongroupAndType(qg.getKey().getId(), type);
-            }
-            if (qList != null && qList.size() > 0) {
-                for (Question q : qList) {
-                    orderedQuestionList.add(q);
-                }
-            }
-        }
-        return orderedQuestionList;
-    }
-
-    /**
      * list questions in order, doing our own sorting to avoid many datastore calls. Optionally filtered by type
-     *  author: Stellan
      *
      * @param surveyId
      * @return

--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -39,8 +39,6 @@ import javax.jdo.annotations.NotPersistent;
 import net.sf.jsr107cache.Cache;
 import net.sf.jsr107cache.CacheException;
 
-import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
-import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
 import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
 
 import com.gallatinsystems.framework.dao.BaseDAO;
@@ -79,33 +77,6 @@ public class QuestionDao extends BaseDAO<Question> {
         cache = initCache(4 * 60 * 60); // cache questions list for 4 hours
     }
 
-    /**
-     * lists all questions filtered by type optionally filtered by surveyId as well.
-     *
-     * @param surveyId
-     * @param type
-     * @return
-     */
-    public List<Question> listQuestionByType(Long surveyId, Question.Type type) {
-        if (surveyId == null) {
-            return listByProperty("type", type.toString(), "String", "order",
-                    "asc");
-        } else {
-            List<Question> allQuestionsInOrder = listQuestionInOrder(surveyId);
-            List<Question> typeQuestions = new ArrayList<Question>();
-            if (type != null) {
-                if (allQuestionsInOrder != null) {
-                    for (Question q : allQuestionsInOrder) {
-                        if (type.equals(q.getType())) {
-                            typeQuestions.add(q);
-                        }
-                    }
-                    return typeQuestions;
-                }
-            }
-            return allQuestionsInOrder;
-        }
-    }
 
     /**
      * loads the Question object but NOT any associated options
@@ -230,31 +201,6 @@ public class QuestionDao extends BaseDAO<Question> {
                 "asc");
     }
 
-    /**
-     * lists all questions for a survey and orders them by sort order. THIS METHOD SHOULD NOT BE
-     * USED AS SORT ORDERS MAY BE DUPLICATED ACROSS QUESTIONGROUPS SO THE ORDERING IS UNDEFINED
-     *
-     * @param surveyId
-     * @return
-     * @deprecated
-     */
-    @Deprecated
-    public List<Question> listQuestionInOrder(Long surveyId) {
-        List<Question> orderedQuestionList = new ArrayList<Question>();
-        List<Question> unknownOrder = listByProperty("surveyId", surveyId,
-                "Long", "order", "asc");
-        QuestionGroupDao qgDao = new QuestionGroupDao();
-
-        List<QuestionGroup> qgList = qgDao.listQuestionGroupBySurvey(surveyId);
-        for (QuestionGroup qg : qgList) {
-            for (Question q : unknownOrder) {
-                if (qg.getKey().getId() == q.getQuestionGroupId()) {
-                    orderedQuestionList.add(q);
-                }
-            }
-        }
-        return orderedQuestionList;
-    }
 
     /**
      * list questions in order, by using question groups. Optionally filtered by type

--- a/GAE/src/org/waterforpeople/mapping/analytics/SurveyQuestionSummarizer.java
+++ b/GAE/src/org/waterforpeople/mapping/analytics/SurveyQuestionSummarizer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -43,8 +43,9 @@ public class SurveyQuestionSummarizer implements DataSummarizer {
                     .listQuestionAnswerStoreByType(new Long(key), "VALUE");
             if (answers != null && answers.size() > 0) {
                 QuestionDao questionDao = new QuestionDao();
-                List<Question> qList = questionDao.listQuestionByType(answers
-                        .get(0).getSurveyId(), Question.Type.OPTION);
+                List<Question> qList = questionDao.listQuestionsInOrder(
+                        answers.get(0).getSurveyId(),
+                        Question.Type.OPTION);
                 int i = 0;
                 if (offset != null) {
                     i = offset;
@@ -54,8 +55,7 @@ public class SurveyQuestionSummarizer implements DataSummarizer {
                 // process BATCH_SIZE items
                 while (i < answers.size() && i < offset + BATCH_SIZE) {
                     if (isSummarizable(answers.get(i), qList)) {
-                        SurveyQuestionSummaryDao.incrementCount(answers.get(i),
-                                1);
+                        SurveyQuestionSummaryDao.incrementCount(answers.get(i), 1);
                     }
                     i++;
                 }

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/server/survey/SurveyServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -191,7 +191,7 @@ public class SurveyServiceImpl extends RemoteServiceServlet implements
             QuestionType type, boolean loadTranslations) {
 
         QuestionDao questionDao = new QuestionDao();
-        List<Question> qList = questionDao.listQuestionByType(surveyId,
+        List<Question> qList = questionDao.listQuestionsInOrder(surveyId,
                 Question.Type.valueOf(type.toString()));
         QuestionDto[] dtoArr = new QuestionDto[qList.size()];
         int i = 0;

--- a/GAE/src/org/waterforpeople/mapping/app/web/BootstrapGeneratorServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/BootstrapGeneratorServlet.java
@@ -182,7 +182,7 @@ public class BootstrapGeneratorServlet extends AbstractRestApiServlet {
 
     private Set<String> getSurveyResources(Long surveyId) {
         Set<String> resources = new HashSet<String>();
-        for (Question q : new QuestionDao().listQuestionByType(surveyId, Question.Type.CASCADE)) {
+        for (Question q : new QuestionDao().listQuestionsInOrder(surveyId, Question.Type.CASCADE)) {
             Long cascadeResourceId = q.getCascadeResourceId();
             if (cascadeResourceId != null) {
                 CascadeResource cr = cascadeDao.getByKey(cascadeResourceId);

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2017 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -768,7 +768,7 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
 
         final QuestionAnswerStoreDao qasDao = new QuestionAnswerStoreDao();
         final QuestionDao questionDao = new QuestionDao();
-        final List<Question> qList = questionDao.listQuestionByType(surveyId,
+        final List<Question> qList = questionDao.listQuestionsInOrder(surveyId,
                 Question.Type.OPTION);
 
         Cache cache = null;

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyRestServlet.java
@@ -456,7 +456,7 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
     private List<QuestionOptionDto> listSurveyQuestionOptions(Long surveyId) {
 
         List<QuestionOptionDto> dtoList = new ArrayList<>();
-        List<Question> questions = qDao.listQuestionByType(surveyId, Type.OPTION);
+        List<Question> questions = qDao.listQuestionsInOrder(surveyId, Type.OPTION);
         QuestionOptionDtoMapper mapper = new QuestionOptionDtoMapper();
         for (Question question : questions) {
             List<QuestionOption> options = qoDao.listByQuestionId(question.getKey().getId());


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Questions are loaded by looping over question groups, making many datastore calls.
#### The solution
Fetch them in a bunch do the sorting ourselves.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
