### PR TITLE
Fix broken bootstrap file generation for forms without cascading questions (connect #2078)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
@@ -288,9 +288,10 @@ public class QuestionDao extends BaseDAO<Question> {
         if (results != null && results.size() > 0) {
             return results;
         } else {
-            return null;
+            return Collections.emptyList();
         }
     }
+
     /**
      * saves a question object in a transaction
      *

--- a/GAE/src/org/waterforpeople/mapping/app/web/BootstrapGeneratorServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/BootstrapGeneratorServlet.java
@@ -126,9 +126,10 @@ public class BootstrapGeneratorServlet extends AbstractRestApiServlet {
                     reader.close();
                     contentMap.put(s.getKey().getId() + "/" + surveyFilename + ".xml",
                             buf.toString());
-                    
+
                     resourcesSet.addAll(getSurveyResources(id));// Add survey resources
                 } catch (Exception e) {
+                    log.log(Level.SEVERE, "Could not include survey id " + id + "\n", e);
                     errors.append("Could not include survey id " + id + "\n");
                 }
             }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* When attempting to generate manual bootstrap loading file for forms not containing cascading questions, an error occurred as a result of a `null` result returned when querying for a list of cascading questions.  This error subsequently prevented the generation of a bootstrap file for that form

#### The solution

* When no cascading questions are found for a particular form, we return an empty collection of questions. 
* We also improve the logging of bootstrap errors in order to be able to identify the exception in logs

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
