### PR TITLE
Remove non-existent class bean definition (connect #2022)

### DIFF
--- a/GAE/war/WEB-INF/rest-servlet.xml
+++ b/GAE/war/WEB-INF/rest-servlet.xml
@@ -23,7 +23,6 @@
     <bean name="/actions" class="org.waterforpeople.mapping.app.web.rest.ActionRestService" />
     <bean name="/approval_groups" class="org.waterforpeople.mapping.app.web.rest.ApprovalGroupRestService" />
     <bean name="/approval_steps" class="org.waterforpeople.mapping.app.web.rest.ApprovalStepRestService" />
-    <bean name="/approver_users" class="org.waterforpeople.mapping.app.web.rest.ApproverUserRestService" />
     <bean name="/caddisfly_resources" class="org.waterforpeople.mapping.app.web.rest.CaddisflyResourceRestService" />
     <bean name="/cartodb" class="org.waterforpeople.mapping.app.web.rest.CartodbRestService" />
     <bean name="/cascade_nodes" class="org.waterforpeople.mapping.app.web.rest.CascadeNodeRestService" />


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* Calls to endpoints on the backend failing because of a missing or failed bean definitions.  This was caused by a bean definition for a non-existing class that caused the rest of the bean definitions to fail as well.

#### The solution
* Remove the bean definition for a non-existent class

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
