### PR TITLE
Remove API endpoints servlet configuration (connect #2112)

### DIFF
--- a/GAE/war/WEB-INF/web.xml
+++ b/GAE/war/WEB-INF/web.xml
@@ -562,18 +562,4 @@
 	<welcome-file-list>
 		<welcome-file>index.html</welcome-file>
 	</welcome-file-list>
-  <servlet>
-    <servlet-name>SystemServiceServlet</servlet-name>
-    <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
-    <init-param>
-      <param-name>services</param-name>
-      <param-value/>
-    </init-param>
-  </servlet>
-
-  <servlet-mapping>
-    <servlet-name>SystemServiceServlet</servlet-name>
-    <url-pattern>/_ah/spi/*</url-pattern>
-  </servlet-mapping>
-
 </web-app>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The configuration for api endpoints servlet is included in the web.xml.  However, since we restrict the access of this endpoint through the `<security-constraint>` configuration, the deployment fails.  GAE documentation advises that this endpoint is not to be restricted through the web.xml.  It should be done as described here https://cloud.google.com/endpoints/docs/frameworks/legacy/v1/java/add-authorization-backend

_Note: we are not using API endpoints so we do not need to follow these steps_

#### The solution
* We remove the configuration for restricted, authorized access of this endpoint in the web.xml

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
