### PR TITLE
Issue/2116 questions are never deleted (Connect #2116)

### DIFF
--- a/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
+++ b/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import javax.jdo.JDOHelper;
 import javax.jdo.JDOObjectNotFoundException;
 import javax.jdo.PersistenceManager;
+import javax.jdo.ObjectState;
 
 import net.sf.jsr107cache.CacheException;
 
@@ -564,7 +566,15 @@ public class BaseDAO<T extends BaseDomain> {
      */
     public <E extends BaseDomain> void delete(E obj) {
         PersistenceManager pm = PersistenceFilter.getManager();
-        pm.deletePersistent(obj);
+        ObjectState state = JDOHelper.getObjectState(obj);
+        if (state == ObjectState.TRANSIENT ||
+            state == ObjectState.TRANSIENT_CLEAN ||
+            state == ObjectState.TRANSIENT_DIRTY
+           ) {
+            log.warning("Trying to deletePersistent() object '" + obj.toString() + "' in state " + state);
+        } else {
+            pm.deletePersistent(obj);
+        }
     }
 
     /**

--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
@@ -162,7 +162,11 @@ public class QuestionDao extends BaseDAO<Question> {
         uncache(Arrays.asList(question)); // clear from cached first
 
         // only delete after extracting group ID and order
-        super.delete(question);
+        //cached Entity has no connection to datastore, so bypass cache
+        Question persistedQuestion = super.getByKey(question.getKey());
+        if (persistedQuestion != null) { //assume nothing
+            super.delete(persistedQuestion);
+        }
 
         if (adjustQuestionOrder != null && adjustQuestionOrder) {
             // update question order

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -211,8 +211,8 @@ public class QuestionRestService {
         statusDto.setStatus("failed");
         statusDto.setMessage("_cannot_delete");
 
-        // check if question exists in the datastore
-        if (q != null) {
+        if (q != null) { // if question exists in the cache/datastore
+
             try {
                 TaskOptions deleteQuestionTask = TaskOptions.Builder
                         .withUrl("/app_worker/surveytask")


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Deletion of questions fails silently, they remain in the datastore.
#### The solution
Bypass cache when fetching the question to delete. To avoid a problem when the just-deleted q would be fetched during the resorting, move the deletion last.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
