### PR TITLE
Disable clickable question text for users with view rights only (connect #2146)

### DIFF
--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -212,7 +212,13 @@
 		{{/if}}
       </ul>
     </nav>
-    <h1 class="questionNbr"><a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}}} </span>{{view.content.text}}</a></h1>
+    <h1 class="questionNbr">
+        {{#if view.showQuestionModifyButtons}}
+        <a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}}} </span>{{view.content.text}}</a>
+        {{else}}
+        <span>{{view.content.order}}} </span>{{view.content.text}}
+        {{/if}}
+    </h1>
 
   {{/if}}
   </div>

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -214,9 +214,9 @@
     </nav>
     <h1 class="questionNbr">
         {{#if view.showQuestionModifyButtons}}
-        <a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}}} </span>{{view.content.text}}</a>
+        <a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}} </span>{{view.content.text}}</a>
         {{else}}
-        <span>{{view.content.order}}} </span>{{view.content.text}}
+        <span>{{view.content.order}} </span>{{view.content.text}}
         {{/if}}
     </h1>
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
A user with view rights only could open a survey and click on the question text to enable question editing
#### The solution
A permissions check is now done before enabling clickable question text

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
