### PR TITLE
Issue/2151 change order reports subnav (Connect #2151)

### DIFF
--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -421,7 +421,7 @@ FLOW.Router = Ember.Router.extend({
 
       index: Ember.Route.extend({
         route: '/',
-        redirectsTo: 'chartReports'
+        redirectsTo: 'exportReports'
       }),
 
       exportReports: Ember.Route.extend({

--- a/Dashboard/app/js/templates/navReports/reports-subnav.handlebars
+++ b/Dashboard/app/js/templates/navReports/reports-subnav.handlebars
@@ -1,9 +1,9 @@
 <ul>
-    {{#view view.NavItemView item="chartReports" }}
-      <a {{action doChartReports}}>{{t _charts}}</a>
-    {{/view}} 
     {{#view view.NavItemView item="exportReports" }}
     	<a {{action doExportReports}}>{{t _export_reports}}</a>
+    {{/view}} 
+    {{#view view.NavItemView item="chartReports" }}
+      <a {{action doChartReports}}>{{t _charts}}</a>
     {{/view}} 
     {{#if FLOW.Env.showStatisticsFeature}}
      {{#view view.NavItemView item="statistics" }}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Reports export is most used sub-feature of reports, but is on second, non-default tab.
#### The solution
Move it first and make it default.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
