### PR TITLE
Disable xml validation in production environments (connect #2022)

### DIFF
--- a/GAE/src/org/akvo/flow/servlet/config/AkvoFlowXmlWebApplicationContext.java
+++ b/GAE/src/org/akvo/flow/servlet/config/AkvoFlowXmlWebApplicationContext.java
@@ -1,0 +1,19 @@
+
+package org.akvo.flow.servlet.config;
+
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.web.context.support.XmlWebApplicationContext;
+
+import com.google.appengine.api.utils.SystemProperty;
+
+public class AkvoFlowXmlWebApplicationContext extends XmlWebApplicationContext {
+
+    @Override
+    protected void initBeanDefinitionReader(XmlBeanDefinitionReader beanDefinitionReader) {
+        super.initBeanDefinitionReader(beanDefinitionReader);
+        if (SystemProperty.environment.value() == SystemProperty.Environment.Value.Production) {
+            beanDefinitionReader.setValidating(false);
+            beanDefinitionReader.setNamespaceAware(true);
+        }
+    }
+}

--- a/GAE/src/org/akvo/flow/servlet/config/ProductionEnvironmentXmlWebApplicationContext.java
+++ b/GAE/src/org/akvo/flow/servlet/config/ProductionEnvironmentXmlWebApplicationContext.java
@@ -6,7 +6,7 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
 
 import com.google.appengine.api.utils.SystemProperty;
 
-public class AkvoFlowXmlWebApplicationContext extends XmlWebApplicationContext {
+public class ProductionEnvironmentXmlWebApplicationContext extends XmlWebApplicationContext {
 
     @Override
     protected void initBeanDefinitionReader(XmlBeanDefinitionReader beanDefinitionReader) {

--- a/GAE/src/org/akvo/flow/servlet/config/ProductionEnvironmentXmlWebApplicationContext.java
+++ b/GAE/src/org/akvo/flow/servlet/config/ProductionEnvironmentXmlWebApplicationContext.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (C) 2017 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
 
 package org.akvo.flow.servlet.config;
 

--- a/GAE/war/WEB-INF/web.xml
+++ b/GAE/war/WEB-INF/web.xml
@@ -5,7 +5,7 @@
     </context-param>
     <context-param>
         <param-name>contextClass</param-name>
-        <param-value>org.akvo.flow.servlet.config.AkvoFlowXmlWebApplicationContext</param-value>
+        <param-value>org.akvo.flow.servlet.config.ProductionEnvironmentXmlWebApplicationContext</param-value>
     </context-param>
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>

--- a/GAE/war/WEB-INF/web.xml
+++ b/GAE/war/WEB-INF/web.xml
@@ -3,6 +3,10 @@
         <param-name>contextConfigLocation</param-name>
 		<param-value>/WEB-INF/webapp-security.xml</param-value>
     </context-param>
+    <context-param>
+        <param-name>contextClass</param-name>
+        <param-value>org.akvo.flow.servlet.config.AkvoFlowXmlWebApplicationContext</param-value>
+    </context-param>
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The spring framework performs XML validation on the beans definitions that affects performance of an application. 

#### The solution

* We disable the XML validation for production environments.  Given that this is risky for misconfigured beans, we correctly set the system property for development environments to be able to catch any validation issues.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation