### PR TITLE
Fix deleted `appId` property (connect #2153)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
@@ -42,6 +42,7 @@ import com.gallatinsystems.common.util.PropertyUtil;
 import com.gallatinsystems.user.dao.UserDao;
 import com.gallatinsystems.user.domain.User;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.utils.SystemProperty;
 
 public class EnvServlet extends HttpServlet {
 
@@ -136,6 +137,8 @@ public class EnvServlet extends HttpServlet {
         if (props.get("extraMapboxTileLayerLabel") == null) {
             props.put("extraMapboxTileLayerLabel", "");
         }
+
+        props.put("appId", SystemProperty.applicationId.get());
 
         if (!"false".equalsIgnoreCase(props.get(SHOW_MAPS_PROPERTY_KEY))) {
             props.put(SHOW_MAPS_PROPERTY_KEY, "true");


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* In the PR https://github.com/akvo/akvo-flow/pull/2172/files the `appId` property was accidentally deleted.

#### The solution

* We reintroduce the property.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
