### PR TITLE
Exclude static files from security filter chain (connect #2183)

### DIFF
--- a/GAE/war/WEB-INF/webapp-security.xml
+++ b/GAE/war/WEB-INF/webapp-security.xml
@@ -7,6 +7,14 @@
     http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
 
 
+    <http pattern="/admin/js/**" security="none" />
+    <http pattern="/admin/images/**" security="none" />
+    <http pattern="/admin/css/**" security="none" />
+    <http pattern="/vendorjs/js/**" security="none" />
+    <http pattern="/publicmap/images/**" security="none" />
+    <http pattern="/publicmap/css/**" security="none" />
+    <http pattern="/publicmap/js/**" security="none" />
+
 	<http pattern="/api/v1/**" use-expressions="true" entry-point-ref="apiEntryPoint" authentication-manager-ref="apiAuthenticationManager" >
 
 		<intercept-url pattern="/api/v1/survey_groups/**" method="GET" access="hasRole('USER')"/>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* We were also filtering all static files through the security filter chain that checks a number of things that are not relevant to controlling access to these static files

#### The solution
* We bypass the security filter chain for static files


#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
