### PR TITLE
Load survey assignments list only when tab is selected (connect #2035)

### DIFF
--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -215,7 +215,6 @@ FLOW.Router = Ember.Router.extend({
           router.resetState();
           FLOW.deviceGroupControl.populate();
           FLOW.deviceControl.populate();
-          FLOW.surveyAssignmentControl.populate();
           router.set('devicesSubnavController.selected', 'currentDevices');
         }
       }),
@@ -224,6 +223,7 @@ FLOW.Router = Ember.Router.extend({
         route: '/assign-surveys',
         connectOutlets: function (router, context) {
           router.get('navDevicesController').connectOutlet('assignSurveysOverview');
+          FLOW.surveyAssignmentControl.populate();
           router.set('devicesSubnavController.selected', 'assignSurveys');
         }
       }),


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* When loading the devices tab, the devices list, the device group list and additionally the survey assignments list are loaded.  Its not necessary to load this last list until a user actually selects the survey assignments tab.

#### The solution
* We only load the assignments list when a user clicks on the survey assignments tab

#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation