### PR TITLE
Issue/2232 displaynames for vanilla surveys (Connect #2232)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
@@ -132,12 +132,18 @@ public class SurveyInstanceServlet extends AbstractRestApiServlet {
             return "";
         }
         SurveyedLocale sl = slDao.getById(surveyedLocaleId);
-        if (sl == null || sl.getCreationSurveyId() == null) {
+        if (sl == null) {
             return "";
         }
         
+        Long regSurveyId;
+        if (sl.getCreationSurveyId() == null) { // non-monitoring survey
+            regSurveyId = surveyedLocaleId; // implicitly the registering survey
+        } else {
+            regSurveyId = sl.getCreationSurveyId();
+        }
+        
         //Get the questions of the registration survey
-        Long regSurveyId = sl.getCreationSurveyId();
         List<Question> nameQuestions = qDao.listDisplayNameQuestionsBySurveyId(regSurveyId);
         if (nameQuestions == null) {
             return "";

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
@@ -142,6 +142,9 @@ public class SurveyInstanceServlet extends AbstractRestApiServlet {
         } else {
             regSurveyId = sl.getCreationSurveyId();
         }
+        if (regSurveyId == null) {
+            return "";
+        }
         
         //Get the questions of the registration survey
         List<Question> nameQuestions = qDao.listDisplayNameQuestionsBySurveyId(regSurveyId);

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
@@ -138,7 +138,7 @@ public class SurveyInstanceServlet extends AbstractRestApiServlet {
         
         Long regSurveyId;
         if (sl.getCreationSurveyId() == null) { // non-monitoring survey
-            regSurveyId = si.getKey().getId(); // implicitly the registering survey
+            regSurveyId = si.getSurveyId(); // implicitly the registering survey
         } else {
             regSurveyId = sl.getCreationSurveyId();
         }

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyInstanceServlet.java
@@ -138,7 +138,7 @@ public class SurveyInstanceServlet extends AbstractRestApiServlet {
         
         Long regSurveyId;
         if (sl.getCreationSurveyId() == null) { // non-monitoring survey
-            regSurveyId = surveyedLocaleId; // implicitly the registering survey
+            regSurveyId = si.getKey().getId(); // implicitly the registering survey
         } else {
             regSurveyId = sl.getCreationSurveyId();
         }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
No displaynames shown for non-monitoring survey reports
#### The solution
Use survey of the surveyInstance if there is no creationSurveyId for surveyedLocale entity
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
