### PR TITLE
Fixed skipped items by list retrieval logic (connect #2252)

### DIFF
--- a/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
+++ b/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
@@ -726,20 +726,23 @@ public class BaseDAO<T extends BaseDomain> {
         return concreteClass.getSimpleName() + "-" + objectId;
     }
 
-    public List<T> fetchItemsByIdBatches(List<Long> idsList, String fieldName) {
-        if (idsList == null || idsList.isEmpty()) {
+    public List<T> fetchItemsByIdBatches(List<Long> idsListOriginal, String fieldName) {
+        if (idsListOriginal == null || idsListOriginal.isEmpty()) {
             return Collections.emptyList();
         }
+        List<Long> idsList = new ArrayList<>(idsListOriginal);
         List<T> items = new ArrayList<>();
-        int start = 0;
         int listSize = idsList.size();
-        int end = Math.min(MAX_ALLOWED_FILTERED_ITEMS, listSize);
+        int end = Math.min(MAX_ALLOWED_FILTERED_ITEMS + 1, listSize);
         int maxRound = Math
                 .max(1, (int) Math.round((double) listSize / MAX_ALLOWED_FILTERED_ITEMS));
         for (int i = 0; i < maxRound; i++) {
-            items.addAll(listValuesByIdsList(idsList.subList(start, end), fieldName));
-            start = Math.min(start + MAX_ALLOWED_FILTERED_ITEMS, listSize - 1);
-            end = Math.min(end + MAX_ALLOWED_FILTERED_ITEMS, listSize);
+            List<Long> idsToRetrieve = idsList.subList(0, end);
+            items.addAll(listValuesByIdsList(idsToRetrieve, fieldName));
+            if(idsList != null && idsList.size() > 0) {
+                idsList.removeAll(idsToRetrieve);
+            }
+            end = Math.min(end + MAX_ALLOWED_FILTERED_ITEMS, idsList.size());
         }
         return items;
     }

--- a/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
+++ b/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
@@ -726,25 +726,25 @@ public class BaseDAO<T extends BaseDomain> {
         return concreteClass.getSimpleName() + "-" + objectId;
     }
 
-    public List<T> fetchItemsByIdBatches(List<Long> idsListOriginal, String fieldName) {
-        if (idsListOriginal == null || idsListOriginal.isEmpty()) {
+    public List<T> fetchItemsByIdBatches(List<Long> idsList, String fieldName) {
+        if (idsList == null || idsList.isEmpty()) {
             return Collections.emptyList();
         }
-        List<Long> idsList = new ArrayList<>(idsListOriginal);
-        List<T> items = new ArrayList<>();
-        int listSize = idsList.size();
-        int end = Math.min(MAX_ALLOWED_FILTERED_ITEMS + 1, listSize);
-        int maxRound = Math
-                .max(1, (int) Math.round((double) listSize / MAX_ALLOWED_FILTERED_ITEMS));
-        for (int i = 0; i < maxRound; i++) {
-            List<Long> idsToRetrieve = idsList.subList(0, end);
-            items.addAll(listValuesByIdsList(idsToRetrieve, fieldName));
-            if(idsList != null && idsList.size() > 0) {
-                idsList.removeAll(idsToRetrieve);
-            }
-            end = Math.min(end + MAX_ALLOWED_FILTERED_ITEMS, idsList.size());
+
+        List<T> fetchedItems = new ArrayList<>();
+        int idsListSize = idsList.size();
+        int start = 0;
+        int end = Math.min(MAX_ALLOWED_FILTERED_ITEMS, idsListSize);
+        int numberOfQueryRounds = (int) Math
+                .ceil((double) idsListSize / MAX_ALLOWED_FILTERED_ITEMS);
+
+        for (int i = 0; i < numberOfQueryRounds; i++) {
+            List<Long> idsToRetrieve = idsList.subList(start, end);
+            fetchedItems.addAll(listValuesByIdsList(idsToRetrieve, fieldName));
+            start = end;
+            end = Math.min(end + MAX_ALLOWED_FILTERED_ITEMS, idsListSize);
         }
-        return items;
+        return fetchedItems;
     }
 
     private List<T> listValuesByIdsList(List<Long> idsList, final String fieldName) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* Some items were ~randomly~ skipped when fetching surveyInstances and questionAnswers. Using `Math.round()` to determine the number of iterations to make meant the last IDs are skipped because we do one less iteration round that is required to complete them all.
 
#### The solution
* We use the ceiling function to ensure that ids in the `idsList` are processed when iterating over the list.

#### Screenshots (if appropriate)
NA
## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
