### PR TITLE
Set the caddisfly test file URL using environment variable (connect #2250)

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1821,7 +1821,7 @@ FLOW.translationControl = Ember.ArrayController.create({
 FLOW.CaddisflyResourceController = Ember.ArrayController.extend({
     sortProperties: ['name'],
     sortAscending: true,
-    caddisflyTestsFileUrl: 'https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json',
+    caddisflyTestsFileUrl: FLOW.Env.caddisflyTestsFileUrl,
     testsFileLoaded: false,
 
     load: function () {

--- a/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
@@ -51,6 +51,7 @@ public class EnvServlet extends HttpServlet {
             .getName());
 
     public static final String SHOW_MAPS_PROPERTY_KEY = "showMapsTab";
+    public static final String CADDISFLY_TESTS_FILE_URL_KEY = "caddisflyTestsFileUrl";
 
     private static final ArrayList<String> properties = new ArrayList<String>();
 
@@ -74,6 +75,7 @@ public class EnvServlet extends HttpServlet {
         properties.add("extraMapboxTileLayerMapId");
         properties.add("extraMapboxTileLayerAccessToken");
         properties.add("extraMapboxTileLayerLabel");
+        properties.add(CADDISFLY_TESTS_FILE_URL_KEY);
     }
 
     @Override
@@ -142,6 +144,12 @@ public class EnvServlet extends HttpServlet {
 
         if (!"false".equalsIgnoreCase(props.get(SHOW_MAPS_PROPERTY_KEY))) {
             props.put(SHOW_MAPS_PROPERTY_KEY, "true");
+        }
+
+        if (props.get(CADDISFLY_TESTS_FILE_URL_KEY) == null
+                || props.get(CADDISFLY_TESTS_FILE_URL_KEY).isEmpty()) {
+            props.put("caddisflyTestsFileUrl",
+                    "https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json");
         }
 
         // load language configuration and strings if present

--- a/GAE/war/Env.vm
+++ b/GAE/war/Env.vm
@@ -19,8 +19,8 @@ loader.register('akvo-flow/flowenv', function(require) {
     locale: #if ( $env.locale ) '$env.locale', #else 'en', #end
     extraMapboxTileLayerMapId: '$env.extraMapboxTileLayerMapId',
     extraMapboxTileLayerAccessToken: '$env.extraMapboxTileLayerAccessToken',
-    extraMapboxTileLayerLabel: '$env.extraMapboxTileLayerLabel'
-
+    extraMapboxTileLayerLabel: '$env.extraMapboxTileLayerLabel',
+    caddisflyTestsFileUrl: '$env.caddisflyTestsFileUrl'
   });
 
   #if( $localeStrings )


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* Caddisfly URL has been hardcoded but we would like this to be configurable to be able to overwrite the configuration for test files.

#### The solution

* Configure an environment variable for the caddisfly file URL
* Default URL is set if no property is present in the configuration file

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation