### PR TITLE
Add caddisfly test definitions file URL for report generation (connect #2250)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/CaddisflyResourceDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/CaddisflyResourceDao.java
@@ -38,16 +38,11 @@ public class CaddisflyResourceDao {
     private static final Logger log = Logger.getLogger(CascadeResourceDao.class
             .getName());
 
-    /**
-     * lists caddisfly resources. Source is the json file caddisfly-tests.json stored in
-     * WEB-INF/resources
-     */
-    public List<CaddisflyResource> listResources() {
+    public List<CaddisflyResource> listResources(String caddisflyTestsUrl) {
         List<CaddisflyResource> result = null;
 
         try {
-            URL caddisflyFileUrl = new URL(
-                    "https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json");
+            URL caddisflyFileUrl = new URL(caddisflyTestsUrl);
             InputStream stream = caddisflyFileUrl.openStream();
 
             // create a list of caddisflyResource objects
@@ -66,5 +61,12 @@ public class CaddisflyResourceDao {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * lists caddisfly resources using default caddisfly tests definition file URL
+     */
+    public List<CaddisflyResource> listResources() {
+        return listResources("https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json");
     }
 }

--- a/GAE/src/com/gallatinsystems/survey/dao/CaddisflyResourceDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/CaddisflyResourceDao.java
@@ -35,6 +35,8 @@ import org.waterforpeople.mapping.domain.CaddisflyResource;
 public class CaddisflyResourceDao {
     private static ObjectMapper mapper = new ObjectMapper();
 
+    public static String DEFAULT_CADDISFLY_TESTS_FILE_URL = "https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json";
+
     private static final Logger log = Logger.getLogger(CascadeResourceDao.class
             .getName());
 
@@ -67,6 +69,6 @@ public class CaddisflyResourceDao {
      * lists caddisfly resources using default caddisfly tests definition file URL
      */
     public List<CaddisflyResource> listResources() {
-        return listResources("https://akvoflow-public.s3.amazonaws.com/caddisfly-tests.json");
+        return listResources(DEFAULT_CADDISFLY_TESTS_FILE_URL);
     }
 }

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -97,6 +97,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     private static final String RAW_ONLY_TYPE = "RAW_DATA";
     private static final String NO_CHART_OPT = "nocharts";
     private static final String LAST_COLLECTION_OPT = "lastCollection";
+    private static final String CADDISFLY_TESTS_FILE_URL_OPT = "caddisflyTestsFileUrl";
 
     private static final String DEFAULT_IMAGE_PREFIX = "http://waterforpeople.s3.amazonaws.com/images/";
 
@@ -319,6 +320,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     private boolean lastCollection = false;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private CaddisflyResourceDao caddisflyResourceDao = new CaddisflyResourceDao();
+    private String caddisflyTestsFileUrl;
 
     // for caddisfly-specific metadata
     //TODO private Map<Long, Integer> numResultsMap = new HashMap<>();
@@ -331,6 +333,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
 
     // store indices of file columns for lookup when generating responses
     private Map<String, Integer> columnIndexMap = new HashMap<>();
+
     // stores the questions whose answers will make up the display name, in order
 
     @Override
@@ -1328,7 +1331,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
 
         if (caddisflyResourceMap == null) {
             caddisflyResourceMap = new HashMap<String, CaddisflyResource>();
-            for (CaddisflyResource r : caddisflyResourceDao.listResources()) {
+            for (CaddisflyResource r : retrieveCaddisflyTestsDefinitions()) {
                 caddisflyResourceMap.put(r.getUuid().trim(), r);
             }
         }
@@ -1387,6 +1390,14 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             hasImageMap.put(q.getKeyId(), cr.getHasImage());
         }
         return offset;
+    }
+
+    private List<CaddisflyResource> retrieveCaddisflyTestsDefinitions() {
+        if (caddisflyTestsFileUrl == null || caddisflyTestsFileUrl.isEmpty()) {
+            return caddisflyResourceDao.listResources();
+        } else {
+            return caddisflyResourceDao.listResources(caddisflyTestsFileUrl);
+        }
     }
 
     private int addPhotoDataColumnHeader(QuestionDto q, Row row, int originalOffset, String questionId,
@@ -1810,6 +1821,11 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             if (options.get(LAST_COLLECTION_OPT) != null
                     && "true".equals(options.get(LAST_COLLECTION_OPT))) {
                 lastCollection = true;
+            }
+
+            if (options.get(CADDISFLY_TESTS_FILE_URL_OPT) != null
+                    && !options.get(CADDISFLY_TESTS_FILE_URL_OPT).isEmpty()) {
+                caddisflyTestsFileUrl = options.get(CADDISFLY_TESTS_FILE_URL_OPT);
             }
         }
         if (locale != null) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* Reports generation used the default hard-coded caddisfly tests file URL

#### The solution

* We use the properties from the appengine-web.xml file to configure the caddisfly tests file URL if its available.  If no property is present, we fall back on the default file.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation