### PR TITLE
Remove translations in reports (connect #2286)

### DIFF
--- a/Dashboard/app/js/lib/controllers/general-controllers-common.js
+++ b/Dashboard/app/js/lib/controllers/general-controllers-common.js
@@ -18,20 +18,8 @@ FLOW.dashboardLanguageControl = Ember.Object.create({
     });
   }.observes('dashboardLanguage'),
 });
-
-FLOW.reportLanguageControl = Ember.ArrayController.create({
-  content: [
-    Ember.Object.create({
-	  label: "English (Default)",
-	  value: "en"
-	}),
-	Ember.Object.create({
-	  label: "Español",
-	  value: "es"
-	})]
-});
-
-
+ 
+ 
 FLOW.selectedControl = Ember.Controller.create({
   selectedSurveyGroup: null,
   selectedSurvey: null,

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -64,9 +64,9 @@ FLOW.ReportLoader = Ember.Object.create({
       });
     }
 
-    if (criteria.opts.locale && FLOW.reportLanguageControl.get('selectedLanguage')) {
+    /*if (criteria.opts.locale && FLOW.reportLanguageControl.get('selectedLanguage')) {
       criteria.opts.locale = FLOW.reportLanguageControl.get('selectedLanguage').get('value');
-    }
+    }*/
 
     criteria.opts.lastCollection = '' + (exportType === 'RAW_DATA' && FLOW.selectedControl.get('selectedSurveyGroup').get('monitoringGroup') && !!FLOW.editControl.lastCollection);
     criteria.opts.useQuestionId = '' + !!FLOW.editControl.useQuestionId;

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -63,10 +63,7 @@ FLOW.ReportLoader = Ember.Object.create({
         criteria.opts[k] = opts[k];
       });
     }
-
-    /*if (criteria.opts.locale && FLOW.reportLanguageControl.get('selectedLanguage')) {
-      criteria.opts.locale = FLOW.reportLanguageControl.get('selectedLanguage').get('value');
-    }*/
+    
 
     criteria.opts.lastCollection = '' + (exportType === 'RAW_DATA' && FLOW.selectedControl.get('selectedSurveyGroup').get('monitoringGroup') && !!FLOW.editControl.lastCollection);
     criteria.opts.useQuestionId = '' + !!FLOW.editControl.useQuestionId;

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -14,15 +14,15 @@
           optionValuePath="content.keyId"
           prompt=""
           promptBinding="Ember.STRINGS._select_form"}}
-      {{#if FLOW.selectedControl.selectedSurvey}}
-        {{view Ember.Select
+      {{!#if FLOW.selectedControl.selectedSurvey}}
+        {{!view Ember.Select
             contentBinding="FLOW.reportLanguageControl.arrangedContent"
             selectionBinding="FLOW.reportLanguageControl.selectedLanguage"
             optionLabelPath="content.label"
             optionValuePath="content.value"
             prompt=""
             promptBinding="Ember.STRINGS._select_language"}}
-      {{/if}}
+      {{!/if}}
     {{/if}}
   </div>
 <div class="rawDataReport block dataExport">

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -14,15 +14,6 @@
           optionValuePath="content.keyId"
           prompt=""
           promptBinding="Ember.STRINGS._select_form"}}
-      {{!#if FLOW.selectedControl.selectedSurvey}}
-        {{!view Ember.Select
-            contentBinding="FLOW.reportLanguageControl.arrangedContent"
-            selectionBinding="FLOW.reportLanguageControl.selectedLanguage"
-            optionLabelPath="content.label"
-            optionValuePath="content.value"
-            prompt=""
-            promptBinding="Ember.STRINGS._select_language"}}
-      {{!/if}}
     {{/if}}
   </div>
 <div class="rawDataReport block dataExport">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
 dropdown  for selecting language was confusing  to some users 
#### The solution
Remove the select language dropdown thus do away with translations in reports
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
