### PR TITLE
Improve assignments UI (#connect 2075)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -1709,6 +1709,9 @@ a.FadeIt {
 
 /* Survey Top Bar
 --------------------------------------------- */
+#float-right {
+    float:right
+}
 
 section.topBar {
     position: fixed;

--- a/Dashboard/app/js/templates/navDevices/assignment-edit-tab/assignment-edit.handlebars
+++ b/Dashboard/app/js/templates/navDevices/assignment-edit-tab/assignment-edit.handlebars
@@ -1,7 +1,6 @@
 {{#view FLOW.AssignmentEditView}}
 <section class="fullWidth assignmentsEdit" id="assignSurveys">
-  <h1>{{t _edit_assignment}}</h1>
-     <a {{action "cancelEditSurveyAssignment" target="this"}} class="stepBack">{{t _go_back_to_assignment_list}}</a>
+     <a {{action "cancelEditSurveyAssignment" target="this"}} class="stepBack" id="float-right">{{t _go_back_to_assignment_list}}</a>
     <form>
       <fieldset id="assignmentDetails">
         <h2>01. {{t _assignment_details}}</h2>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The page where Assignments were edited had a heading 'Edit Assignments' and the button 'Go back to assignment list was on the left side of the page.
#### The solution
Removed the heading by removing its html line of code from the assignment-edit.handlebars file
Changed the position of the button from left to right by adding a css id 'float-right' to the html tag and adding the float-right style in the main.scss file where the float style is set to right. 
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [x] Copyright header
* [x] Code formatting
* [x] Documentation
