### PR TITLE
Update the datapoint geolocation based on updated responses (connect #1839)

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
+++ b/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
@@ -350,5 +350,14 @@ public class SurveyedLocale extends BaseDomain {
                 oldStyleIdentifier.substring(4, 8),
                 base32Uuid.substring(10));
     }
-    
+
+    public void setGeoLocation(String geoLocationString) {
+        String[] geoParts = geoLocationString.split("\\|");
+        if (geoParts == null || geoParts.length < 2 || geoParts[0] == null || geoParts[1] == null)
+            return;
+
+        this.latitude = Double.parseDouble(geoParts[0]);
+        this.longitude = Double.parseDouble(geoParts[1]);
+    }
+
 }

--- a/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
+++ b/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
@@ -352,9 +352,14 @@ public class SurveyedLocale extends BaseDomain {
     }
 
     public void setGeoLocation(String geoLocationString) {
-        String[] geoParts = geoLocationString.split("\\|");
-        if (geoParts == null || geoParts.length < 2 || geoParts[0] == null || geoParts[1] == null)
+        if (geoLocationString == null) {
             return;
+        }
+
+        String[] geoParts = geoLocationString.split("\\|");
+        if (geoParts == null || geoParts.length < 2 || geoParts[0] == null || geoParts[1] == null) {
+            return;
+        }
 
         this.latitude = Double.parseDouble(geoParts[0]);
         this.longitude = Double.parseDouble(geoParts[1]);

--- a/GAE/src/org/waterforpeople/mapping/app/web/RawDataRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/RawDataRestServlet.java
@@ -214,10 +214,13 @@ public class RawDataRestServlet extends AbstractRestApiServlet {
             qasDao.delete(deletedAnswers);
 
             if (!isMonitoringForm && !isNewInstance) {
-                // Update datapoint name for this locale
+                // Update datapoint name and location for this locale
                 SurveyedLocale sl = slDao.getById(instance.getSurveyedLocaleId());
                 sl.assembleDisplayName(
                         qDao.listDisplayNameQuestionsBySurveyId(s.getKey().getId()), updatedAnswers);
+
+                updateDataPointLocation(sl, updatedAnswers);
+
                 slDao.save(sl);
             }
 
@@ -416,6 +419,15 @@ public class RawDataRestServlet extends AbstractRestApiServlet {
 
         }
         return null;
+    }
+
+    private void updateDataPointLocation(SurveyedLocale dataPoint,
+            List<QuestionAnswerStore> updatedAnswers) {
+        for (QuestionAnswerStore answer : updatedAnswers) {
+            if (Type.GEO.toString().equals(answer.getType())) {
+                dataPoint.setGeoLocation(answer.getValue());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The data point location was not being updated on the map when data was changed via data cleaning

#### The solution

* When saving data from data cleaning, we check for any `GEO` question answers and use those to update the datapoint location.  Note: We do this only when updating registration forms responses for existing datapoints.


#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation