### PR TITLE
Trigger save when user hits enter after changing survey/form title (connect #1929)

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -572,7 +572,7 @@ FLOW.projectControl = Ember.ArrayController.create({
 
   saveProject: function() {
     var currentProject = this.get('currentProject');
-    var currentForm = this.get('selectedSurvey');
+    var currentForm = FLOW.selectedControl.get('selectedSurvey');
 
     if (currentProject && currentProject.get('isDirty')) {
       var name = currentProject.get('name').trim();

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -569,6 +569,28 @@ FLOW.projectControl = Ember.ArrayController.create({
       var groups = FLOW.router.approvalGroupListController.get('content');
       return groups && groups.filterProperty('keyId', approvalGroupId).get('firstObject');
   }.property('this.currentProject.dataApprovalGroupId'),
+
+  saveProject: function() {
+    var currentProject = this.get('currentProject');
+    var currentForm = this.get('selectedSurvey');
+
+    if (currentProject && currentProject.get('isDirty')) {
+      var name = currentProject.get('name').trim();
+      currentProject.set('name', name);
+      currentProject.set('code', name);
+      currentProject.set('path', this.get('currentProjectPath'));
+    }
+
+    if (currentForm && currentForm.get('isDirty')) {
+      var name = currentForm.get('name').trim();
+      currentForm.set('name', name);
+      currentForm.set('code', name);
+      var path = this.get('currentProjectPath') + "/" + name;
+      currentForm.set('path', path);
+    }
+
+    FLOW.store.commit();
+  }
 });
 
 

--- a/Dashboard/app/js/lib/views/surveys/survey-group-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-group-views.js
@@ -197,29 +197,6 @@ FLOW.ApprovalResponsibleUserView = FLOW.View.extend({
 });
 
 FLOW.ProjectMainView = FLOW.View.extend({
-
-  doSave: function() {
-    var currentProject = FLOW.projectControl.get('currentProject');
-    var currentForm = FLOW.selectedControl.get('selectedSurvey');
-
-    if (currentProject && currentProject.get('isDirty')) {
-      var name = currentProject.get('name').trim();
-      currentProject.set('name', name);
-      currentProject.set('code', name);
-      currentProject.set('path', FLOW.projectControl.get('currentProjectPath'));
-    }
-
-    if (currentForm && currentForm.get('isDirty')) {
-      var name = currentForm.get('name').trim();
-      currentForm.set('name', name);
-      currentForm.set('code', name);
-      var path = FLOW.projectControl.get('currentProjectPath') + "/" + name;
-      currentForm.set('path', path);
-    }
-
-    FLOW.store.commit();
-  },
-
   hasUnsavedChanges: function() {
     var selectedProject = FLOW.projectControl.get('currentProject');
     var isProjectDirty = selectedProject ? selectedProject.get('isDirty') : false;

--- a/Dashboard/app/js/templates/navSurveys/form.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/form.handlebars
@@ -22,7 +22,7 @@
 			{{#unless view.isNewForm}}
 				<a {{action "toggleShowFormBasics" target="this"}} class="button">{{t _collapse}}</a>
 			{{/unless}}
-			<form class="surveyDetailForm">
+			<form class="surveyDetailForm" {{action 'saveProject' on='submit' target="FLOW.projectControl"}}>
 				<label>{{t _form_title}}</label>
 				{{view Ember.TextField valueBinding="form.name" disabledBinding="view.disableFormFields"}}
 				<nav class="newSurveyNav">

--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -55,7 +55,7 @@
         <nav class="menuTopbar">
           <ul>
             {{#if view.hasUnsavedChanges}}
-              <li><a class="saveProject" {{action "doSave" target="this"}}>{{t _save}}</a></li>
+              <li><a class="saveProject" {{action 'saveProject' target="FLOW.projectControl"}}>{{t _save}}</a></li>
             {{else}}
               <li><a class="saveProject noChanges">{{t _save}}</a></li>
             {{/if}}

--- a/Dashboard/app/js/templates/navSurveys/project.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/project.handlebars
@@ -32,7 +32,7 @@
               </a>
             {{/unless}}
             {{#if view.visibleProjectBasics}}
-              <form class="projectDetailForm">
+              <form class="projectDetailForm" {{action 'saveProject' on='submit' target="FLOW.projectControl"}}>
                 <label>{{t _survey_title}}</label>{{view Ember.TextField id="projectTitle" valueBinding="FLOW.projectControl.currentProject.name" disabledBinding="view.disableFolderSurveyInputField"}}
 
                 <ul class="projectSelect floats-in">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Hitting the 'enter' key after changing survey/form title would trigger a page reload instead of saving the new title 
#### The solution
Hitting the 'enter' key now triggers a save of the new survey/form title
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
