### PR TITLE
[#2278]Remove unused parameters. (Connect #2278)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -1365,7 +1365,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     /*
      * Add a meta data column header to the report.
      */
-    private void addMetaDataColumnHeader(String columnHeaderName, int columnIdx, Row row, Sheet sheet) {
+    private void addMetaDataColumnHeader(String columnHeaderName, int columnIdx, Row row) {
         //columnIndexMap.put(columnHeaderName, columnIdx);
         //metadata no longer in map since it is different on different sheets
         createCell(row, columnIdx, columnHeaderName, headerStyle);

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -1340,23 +1340,23 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     private int addMetaDataHeaders(Sheet sheet, boolean showRepeatColumn) {
         Row row = getRow(doGroupHeaders ? 1 : 0, sheet);
         int columnIdx = -1;
-        addMetaDataColumnHeader(IDENTIFIER_LABEL.get(locale), ++columnIdx, row, sheet);
+        addMetaDataColumnHeader(IDENTIFIER_LABEL.get(locale), ++columnIdx, row);
         if (hasDataApproval()) {
-            addMetaDataColumnHeader(DATA_APPROVAL_STATUS_LABEL.get(locale), ++columnIdx, row, sheet);
+            addMetaDataColumnHeader(DATA_APPROVAL_STATUS_LABEL.get(locale), ++columnIdx, row);
         }
         if (showRepeatColumn) {
-            addMetaDataColumnHeader(REPEAT_LABEL.get(locale), ++columnIdx, row, sheet);
+            addMetaDataColumnHeader(REPEAT_LABEL.get(locale), ++columnIdx, row);
         }
-        addMetaDataColumnHeader(DISPLAY_NAME_LABEL.get(locale), ++columnIdx, row, sheet);
-        addMetaDataColumnHeader(DEVICE_IDENTIFIER_LABEL.get(locale), ++columnIdx, row, sheet);
-        addMetaDataColumnHeader(INSTANCE_LABEL.get(locale), ++columnIdx, row, sheet);
-        addMetaDataColumnHeader(SUB_DATE_LABEL.get(locale), ++columnIdx, row, sheet);
-        addMetaDataColumnHeader(SUBMITTER_LABEL.get(locale), ++columnIdx, row, sheet);
-        addMetaDataColumnHeader(DURATION_LABEL.get(locale), ++columnIdx, row, sheet);
+        addMetaDataColumnHeader(DISPLAY_NAME_LABEL.get(locale), ++columnIdx, row);
+        addMetaDataColumnHeader(DEVICE_IDENTIFIER_LABEL.get(locale), ++columnIdx, row);
+        addMetaDataColumnHeader(INSTANCE_LABEL.get(locale), ++columnIdx, row);
+        addMetaDataColumnHeader(SUB_DATE_LABEL.get(locale), ++columnIdx, row);
+        addMetaDataColumnHeader(SUBMITTER_LABEL.get(locale), ++columnIdx, row);
+        addMetaDataColumnHeader(DURATION_LABEL.get(locale), ++columnIdx, row);
         //Always put something in the top-left corner for the comment
         if (doGroupHeaders) {
             row = getRow(0, sheet);
-            addMetaDataColumnHeader(METADATA_LABEL, 0, row, sheet); //constant (locale is going away)           
+            addMetaDataColumnHeader(METADATA_LABEL, 0, row); //constant (locale is going away)           
             sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, columnIdx));
         }
         return columnIdx;

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -263,7 +263,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
                     }
                     //May add data to instanceData and rows to allRows
                     pos = parseRepeatsForInstance(instanceData, repSheet,
-                            pos, repMetadataIndex, repFirstQIdx,
+                            pos, repMetadataIndex,
                             questionIdToQuestionDto, repQMap,
                             optionNodes, allRows);
                     sheetPosition.put(repSheet, pos); //replace with new pos; might be any value
@@ -414,7 +414,6 @@ public class RawDataSpreadsheetImporter implements DataImporter {
             Sheet repSheet,
             int currentRowIndex,
             Map<String, Integer> metadataColumnHeaderIndex2,
-            int firstQuestionColumnIndex2,
             Map<Long, QuestionDto> questionIdToQuestionDto,
             Map<Integer, Long> columnIndexToQuestionId,
             Map<Long, List<QuestionOptionDto>> optionNodes,


### PR DESCRIPTION
Before the PR (what is the issue or what needed to be done)

Data cleaning reports were hard to use.
The solution

Reorganise the repeatable question groups, putting their responses on separate sheets.
Also added headers for each group
Screenshots (if appropriate)

Test plan:

    make a data cleaning report.
    change a value.
    import it back into Flow and check that only that value was changed.
    make a raw data report with advanced setting "for use with external system" (setting the useQuestionId option, which outputs the "variable names" as column headings).
    check that it still has the old format.


## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
