### PR TITLE
Remove the last collected data option from the data cleaning report (connect #2339)

### DIFF
--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -47,9 +47,6 @@
                   {{view FLOW.DateField minDate=false valueBinding="FLOW.dateControl.toDate" elementId="to_date02" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
                 </label>
             </div>
-            <div class="latestOption">
-              <label for="lastCollection">{{t _latest_data}}</label>{{view Ember.Checkbox checkedBinding="FLOW.editControl.lastCollection" id="lastCollection"}}
-            </div>
             <a {{action showDataCleaningReport target="this"}} onclick="displayFeedbackTxt()" class="button trigger2">{{t _download}}</a>
             <div class="downFeedback" style="display: none;">
               <em>{{t _preparing_report}}</em>


### PR DESCRIPTION
#### The solution
* Remove the option to include only last monitoring form submissions in the report

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation