### PR TITLE
[#2347]Exclude datatexport files from GAE build. (Connect #2347)

### DIFF
--- a/GAE/build.xml
+++ b/GAE/build.xml
@@ -120,7 +120,9 @@
 			</fileset>
 		</copy>
 		<javac source="1.7" target="1.7" encoding="UTF8" srcdir="src" destdir="${app_classes_dir}"
-			   classpathref="project.classpath" debug="on" includeantruntime="false" />
+			   classpathref="project.classpath" debug="on" includeantruntime="false"
+			   excludes="**/dataexport/*.java"
+ />
 	</target>
 
 	<target name="translate" depends="compile" description="Generates the en.properties file from handlebars template and JS files">

--- a/GAE/build.xml
+++ b/GAE/build.xml
@@ -121,8 +121,10 @@
 		</copy>
 		<javac source="1.7" target="1.7" encoding="UTF8" srcdir="src" destdir="${app_classes_dir}"
 			   classpathref="project.classpath" debug="on" includeantruntime="false"
-			   excludes="**/dataexport/*.java"
- />
+ >
+		  <exclude name="org/waterforpeople/mapping/dataexport/*.java" />
+
+		</javac>
 	</target>
 
 	<target name="translate" depends="compile" description="Generates the en.properties file from handlebars template and JS files">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Java 8 features would not compile for GAE
#### The solution
Exclude them
#### Screenshots (if appropriate)

## Checklist
* [X] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
