### PR TITLE
Remove unneeded div tag (connect #2353)

### DIFF
--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -1026,7 +1026,6 @@ FLOW.DataCleaningSurveySelectionView = Ember.ContainerView.extend({
     this.get('childViews').pushObject(FLOW.SelectFolder.create({
       parentId: 0, // start with the root folder
       idx: 0,
-      tagName: 'div',
       showMonitoringSurveysOnly: this.get('showMonitoringSurveysOnly') || false,
       selectionFilter : FLOW.projectControl.dataCleaningEnabled
     }));


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* The introduction of the `tagName` property in the controller class was causing the survey selector to crash when loading.

#### The solution
* We remove the unneeded tag.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
