### PR TITLE
Remove no additional settings for questions with no extra settings (connect #2319)

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -113,15 +113,12 @@ FLOW.QuestionView = FLOW.View.extend({
 	}
   }.property('this.type').cacheable(),
 
-  hasExtraSettings: function(){
+  hasExtraSettings: function () {
     var val;
     if (!Ember.none(this.type)) {
       val = this.type.get('value');
-      if(val === 'PHOTO' || val === 'VIDEO' || val === 'DATE' || val === 'SIGNATURE'){
-        return false;
-      }else{
-        return true;
-      }
+      return val === 'GEOSHAPE' || val === 'CASCADE' || val === 'NUMBER' || val === 'GEO' 
+      || val === 'FREE_TEXT' || val === 'SCAN' || val === 'OPTION' || val === 'CADDISFLY';
     }
   }.property('this.type').cacheable(),
 

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -113,14 +113,6 @@ FLOW.QuestionView = FLOW.View.extend({
 	}
   }.property('this.type').cacheable(),
 
-  amNoOptionsType: function () {
-    var val;
-    if (!Ember.none(this.type)) {
-      val = this.type.get('value');
-      return val === 'PHOTO' || val === 'VIDEO' || val === 'DATE' || val === 'SIGNATURE';
-    }
-  }.property('this.type').cacheable(),
-
   hasExtraSettings: function(){
     var val;
     if (!Ember.none(this.type)) {

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -121,6 +121,18 @@ FLOW.QuestionView = FLOW.View.extend({
     }
   }.property('this.type').cacheable(),
 
+  hasExtraSettings: function(){
+    var val;
+    if (!Ember.none(this.type)) {
+      val = this.type.get('value');
+      if(val === 'PHOTO' || val === 'VIDEO' || val === 'DATE' || val === 'SIGNATURE'){
+        return false;
+      }else{
+        return true;
+      }
+    }
+  }.property('this.type').cacheable(),
+
   amGeoshapeType: function () {
     if (this.type) {
 	  return this.type.get('value') == 'GEOSHAPE';

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -62,8 +62,10 @@
   {{/if}}
 
     <!-- Question specific material -->
+{{#unless view.amNoOptionsType}}
+<div class="questionOption floats-in">
     {{#if view.amOptionType}}
-      <div class="questionOption floats-in">
+      
       <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowMultipleFlag"}}{{t _allow_multiple}} </label></li>
@@ -75,25 +77,19 @@
     	  {{view FLOW.OptionListView contentBinding="FLOW.questionOptionsControl"}}
     	  <a {{action addOption target="FLOW.questionOptionsControl"}} class="optionAdd">{{t _add_option}}</a>
       </div>
-      </div>
     {{/if}}
     {{#if view.amFreeTextType}}
-    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}:</h1>
     <label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.requireDoubleEntry"}}{{t _require_double_entry}} {{tooltip _require_double_entry_tooltip}}</label>
-    </div>
     {{/if}}
     {{#if view.amBarcodeType}}
-    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowMultipleFlag"}}{{t _enable_bulk_barcode_scan}} </label></li>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label></li>
       </ul>
-    </div>
     {{/if}}
     {{#if view.amNumberType}}
-    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowSign"}}{{t _allow_sign}} </label></li>
@@ -105,13 +101,10 @@
         <li><label class="minValNumb">{{t _min_val}}: {{view Ember.TextField valueBinding="view.minVal" size=10 }}</label></li>
         <li><label class="maxValNumb">{{t _max_val}}: {{view Ember.TextField valueBinding="view.maxVal" size=10 }}</label></li>
       </ul>
-    </div>
     {{/if}}
      {{#if view.amGeoType}}
-     <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label>
-     </div>
     {{/if}}
 
     {{#if view.amTextType}}
@@ -121,7 +114,6 @@
     {{/if}}
 
     {{#if view.amCascadeType}}
-    <div class="questionOption floats-in">
         <h1 class="answerNbr">{{t _settings}}: </h1>
          <label class="selectinLabel dependencySelect"> {{t _choose_cascade_question_resource}}: {{tooltip _choose_cascade_question_resource_tooltip}}
         {{view Ember.Select
@@ -131,10 +123,8 @@
         optionValuePath="content.keyId"
         prompt=""
         promptBinding="Ember.STRINGS._select_cascade"}}</label>
-    </div>
     {{/if}}
     {{#if view.amCaddisflyType}}
-    <div class="questionOption floats-in">
         <h1 class="answerNbr">{{t _settings}}: </h1>
          <label class="selectinLabel dependencySelect">
          {{#if view.showCaddisflyTests}}
@@ -149,11 +139,9 @@
         {{else}}
         <div class="errorLoading">{{t _failed_load_caddisfly_tests}}</div>
         {{/if}}
-        </label>
-    </div>
+        </label
     {{/if}}
     {{#if view.amGeoshapeType}}
-    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowPoints"}}{{t _allow_points}} </label></li>
@@ -161,9 +149,9 @@
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowPolygon"}}{{t _allow_polygon}} </label></li>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label></li>
       </ul>
-    </div>
     {{/if}}
-
+</div>
+{{/unless}}
 <!-- End of question specific material -->
 <div class="dependencyBlock">
     <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.dependentFlag"}}{{t _dependent}}

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -62,9 +62,8 @@
   {{/if}}
 
     <!-- Question specific material -->
-<div class="questionOption floats-in">
-
     {{#if view.amOptionType}}
+      <div class="questionOption floats-in">
       <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowMultipleFlag"}}{{t _allow_multiple}} </label></li>
@@ -76,19 +75,25 @@
     	  {{view FLOW.OptionListView contentBinding="FLOW.questionOptionsControl"}}
     	  <a {{action addOption target="FLOW.questionOptionsControl"}} class="optionAdd">{{t _add_option}}</a>
       </div>
+      </div>
     {{/if}}
     {{#if view.amFreeTextType}}
+    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}:</h1>
     <label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.requireDoubleEntry"}}{{t _require_double_entry}} {{tooltip _require_double_entry_tooltip}}</label>
+    </div>
     {{/if}}
     {{#if view.amBarcodeType}}
+    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowMultipleFlag"}}{{t _enable_bulk_barcode_scan}} </label></li>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label></li>
       </ul>
+    </div>
     {{/if}}
     {{#if view.amNumberType}}
+    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowSign"}}{{t _allow_sign}} </label></li>
@@ -100,10 +105,13 @@
         <li><label class="minValNumb">{{t _min_val}}: {{view Ember.TextField valueBinding="view.minVal" size=10 }}</label></li>
         <li><label class="maxValNumb">{{t _max_val}}: {{view Ember.TextField valueBinding="view.maxVal" size=10 }}</label></li>
       </ul>
+    </div>
     {{/if}}
      {{#if view.amGeoType}}
+     <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label>
+     </div>
     {{/if}}
 
     {{#if view.amTextType}}
@@ -113,6 +121,7 @@
     {{/if}}
 
     {{#if view.amCascadeType}}
+    <div class="questionOption floats-in">
         <h1 class="answerNbr">{{t _settings}}: </h1>
          <label class="selectinLabel dependencySelect"> {{t _choose_cascade_question_resource}}: {{tooltip _choose_cascade_question_resource_tooltip}}
         {{view Ember.Select
@@ -122,8 +131,10 @@
         optionValuePath="content.keyId"
         prompt=""
         promptBinding="Ember.STRINGS._select_cascade"}}</label>
+    </div>
     {{/if}}
     {{#if view.amCaddisflyType}}
+    <div class="questionOption floats-in">
         <h1 class="answerNbr">{{t _settings}}: </h1>
          <label class="selectinLabel dependencySelect">
          {{#if view.showCaddisflyTests}}
@@ -139,8 +150,10 @@
         <div class="errorLoading">{{t _failed_load_caddisfly_tests}}</div>
         {{/if}}
         </label>
+    </div>
     {{/if}}
     {{#if view.amGeoshapeType}}
+    <div class="questionOption floats-in">
     <h1 class="answerNbr">{{t _settings}}: </h1>
       <ul>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowPoints"}}{{t _allow_points}} </label></li>
@@ -148,15 +161,10 @@
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.allowPolygon"}}{{t _allow_polygon}} </label></li>
         <li><label class="labelcheckbox"> {{view Ember.Checkbox checkedBinding="view.geoLocked"}}{{t _disable_manual_geo_edit}} </label></li>
       </ul>
+    </div>
     {{/if}}
 
-    {{#if view.amNoOptionsType}}
-    <p class="noOptions">
-      {{t _no_additional_settings_for_this_type_of_question}}
-    </p>
-    {{/if}}
-
-</div>
+<!-- End of question specific material -->
 <div class="dependencyBlock">
     <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.dependentFlag"}}{{t _dependent}}
     </label>

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -139,7 +139,7 @@
         {{else}}
         <div class="errorLoading">{{t _failed_load_caddisfly_tests}}</div>
         {{/if}}
-        </label
+        </label>
     {{/if}}
     {{#if view.amGeoshapeType}}
     <h1 class="answerNbr">{{t _settings}}: </h1>

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -62,7 +62,7 @@
   {{/if}}
 
     <!-- Question specific material -->
-{{#unless view.amNoOptionsType}}
+{{#if view.hasExtraSettings}}
 <div class="questionOption floats-in">
     {{#if view.amOptionType}}
       
@@ -151,7 +151,7 @@
       </ul>
     {{/if}}
 </div>
-{{/unless}}
+{{/if}}
 <!-- End of question specific material -->
 <div class="dependencyBlock">
     <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.dependentFlag"}}{{t _dependent}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When adding a question to a form, after selecting the question type, additional settings may be displayed in a grey text box. 
For question types with no additional settings e..g. video,date,signature,photo, a grey text box with "No additional settings for this type of question" is displayed. This was to be removed in this issue

#### The solution
Removed the {#if} clause displaying the message "No additional settings for this question type" from question-view.handlebars .
Added a function in question-view.js to identify question types with extra settings in the template.
Added a condition for extra settings to be displayed in question-view.handlebars: {{if view.hasExtraSettings}}, thus the div with extra settings is displayed unless the question type has no extra settings
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
