### PR TITLE
Changed Add level text design (Connect #2268)

### DIFF
--- a/Dashboard/app/js/templates/navData/cascade-resources.handlebars
+++ b/Dashboard/app/js/templates/navData/cascade-resources.handlebars
@@ -92,7 +92,7 @@
 							{{/view}}
 						{{/each}}
 					</ul>
-					<div class="addLevelBtn"><a {{action "addLevel" target="this"}} class="addLevel btn addBtn">{{t _add_level}}</a></div>
+					<div class="addLevelBtn"><a {{action "addLevel" target="this"}} class="smallButton">{{t _add_level}}</a></div>
 	            </nav>
 	        </section>
 			<section {{bindAttr class="view.showImportDialog:hidden:shown  :levelColumns :floats-in"}}>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Add level option under the Cascade tab appeared as clickable text. The issue required for this to be changed and make it look like a button so that it stands out.
#### The solution
Changed the CSS class of the <a> tag to an already existing class that had style specifications that could work: smallButton. This gave it the style of a button
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
