### PR TITLE
In monitoring tab remove question ID (connect #2385)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3300,6 +3300,8 @@ table.dataTable.notificationTable thead tr th {
 
 table.dataTable.notificationTable thead tr th.noArrows {
     background: #3A3A3A;
+    text-align: left;
+    font-weight: bold;
 }
 
 table.dataTable.notificationTable thead tr th a,

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -100,8 +100,8 @@
             <!-- TABLE HEADER-->
             <thead>
                 <tr>
-                    <th class="noArrows" style="text-align:left;font-weight:bold;">{{t _question}}</th>
-                    <th class="noArrows" style="text-align:left;font-weight:bold;">{{t _answer}}</th>
+                    <th class="noArrows">{{t _question}}</th>
+                    <th class="noArrows">{{t _answer}}</th>
                 </tr>
             </thead>
             <!-- TABLE BODY: MAIN CONTENT-->

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -100,7 +100,6 @@
             <!-- TABLE HEADER-->
             <thead>
                 <tr>
-                    <th class="noArrows">{{t _id}}</th>
                     <th class="noArrows">{{t _question}}</th>
                     <th class="noArrows">{{t _answer}}</th>
                 </tr>
@@ -110,7 +109,6 @@
                 {{#each QA in FLOW.questionAnswerControl}}
                   {{#view FLOW.QuestionAnswerView contentBinding="QA"}}
                     <tr>
-                      <td class="device">{{QA.keyId}}</td>
                       <td class="survey" style="text-align:left;">{{QA.questionText}}</td>
 
                     <td class="submitter" style="text-align:left;">

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -100,8 +100,8 @@
             <!-- TABLE HEADER-->
             <thead>
                 <tr>
-                    <th class="noArrows">{{t _question}}</th>
-                    <th class="noArrows">{{t _answer}}</th>
+                    <th class="noArrows" style="text-align:left;font-weight:bold;">{{t _question}}</th>
+                    <th class="noArrows" style="text-align:left;font-weight:bold;">{{t _answer}}</th>
                 </tr>
             </thead>
             <!-- TABLE BODY: MAIN CONTENT-->
@@ -110,8 +110,7 @@
                   {{#view FLOW.QuestionAnswerView contentBinding="QA"}}
                     <tr>
                       <td class="survey" style="text-align:left;">{{QA.questionText}}</td>
-
-                    <td class="submitter" style="text-align:left;">
+                      <td class="submitter" style="text-align:left;">
                         {{#if view.isPhotoType}}
                           {{view.photoUrl}}  <a {{bindAttr href="view.photoUrl"}} target="_blank">{{t _open_photo}}</a>
                           {{#if view.photoLocation}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
In the detailed submission view the user does not need to see the Question ID, as this is an internal item we use and makes no sense or gives no value to the user. It only clutters her screen. The idea is to remove the question ID column to only show Questions and Answer.
#### The solution
Removed the question ID column to only show Question and Answer
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
