### PR TITLE
Add no results found under data monitoring tab(connect #1868)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3392,6 +3392,11 @@ label.collectedTo {
     }
 }
 
+#monitoringData div.noResults {
+    color: red;
+    text-align: center;
+  }
+
 div.chooseLocationData {
     position: relative;
     display: block;

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -65,6 +65,13 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
           FLOW.router.userListController.set('content', FLOW.User.find());
       }
   },
+  
+  noResults: function () {
+    var content = FLOW.router.surveyedLocaleController.get('content');
+    if (content && content.get('isLoaded')) {
+        return content.get('length') === 0;
+    }
+  }.property('FLOW.router.surveyedLocaleController.content','FLOW.router.surveyedLocaleController.content.isLoaded'),
 
   doNextPage: function () {
 	var cursorArray, cursorStart;

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -21,7 +21,11 @@
           size=30}}
       </div>
       <a {{action "findSurveyedLocale" target="this"}} class="findData standardBtn btnAboveTable">{{t _find}}</a>
-    </div>
+  </div>
+    {{#if view.noResults}}
+      <div class="noResults">{{t _no_results_found}}</div>
+    {{/if}}
+    
     <section class="fullWidth " id="devicesList">
       <table class="dataTable" id="surveyDataTable">
         <thead>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When a user tried to find data points under the monitoring tab without specifying any survey, no result would be returned and there was no indication that no results were found
#### The solution
Added a function, noResults, in monitoring-data-table-view.js that searches for content and if none is found, returns true, this result is checked in the handle bars template,monitoring-data.handlebars, is true, a div element showing No Results Found is displayed
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
