### PR TITLE
Remove caddisfly file reference in exporterapplet build file (connect #2333)

### DIFF
--- a/GAE/appletBuild.xml
+++ b/GAE/appletBuild.xml
@@ -64,7 +64,6 @@
                 <include name="*.vm" />
             </fileset>
         </copy>
-        <copy file="src/resources/caddisfly/caddisfly-tests.json" tofile="${build}/resources/caddisfly/caddisfly-tests.json" />
         <jar destfile="${dist}/exporterapplet.jar" basedir="${build}" />
     </target>
 


### PR DESCRIPTION
#### The solution

* There is one more reference to the caddisfly test file that prevents the exporterarpplet.jar from being build correctly

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation