### PR TITLE
Remove deleted servlet from web.xml (connect #2417)

### DIFF
--- a/GAE/war/WEB-INF/web.xml
+++ b/GAE/war/WEB-INF/web.xml
@@ -353,18 +353,6 @@
 		<url-pattern>/webapp/mapping/summary</url-pattern>
 	</servlet-mapping>
 	<servlet>
-		<servlet-name>SurveyRpcServlet</servlet-name>
-		<servlet-class>org.waterforpeople.mapping.app.gwt.server.survey.SurveyServiceImpl</servlet-class>
-	</servlet>
-	<servlet-mapping>
-		<servlet-name>SurveyRpcServlet</servlet-name>
-		<url-pattern>/org.waterforpeople.mapping.portal.portal/surveyrpcservice</url-pattern>
-	</servlet-mapping>
-	<servlet-mapping>
-		<servlet-name>SurveyRpcServlet</servlet-name>
-		<url-pattern>/org.waterforpeople.mapping.surveyentry.surveyentry/surveyrpcservice</url-pattern>
-	</servlet-mapping>
-	<servlet>
 		<servlet-name>DataSummarization</servlet-name>
 		<servlet-class>org.waterforpeople.mapping.analytics.SurveyDataSummarizationHandler</servlet-class>
 	</servlet>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* In the PR #2430, we deprecated the `SurveyServiceImpl` class and this results in an exception when starting up the application.

#### The solution
* We remove the servlet mapping that uses the deprecated class since its not used.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation