### PR TITLE
Display copied forms for users (connect #1765)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
@@ -360,6 +360,7 @@ public class ActionRestService {
         surveysAncestorIds.add(savedProjectCopy.getKey().getId());
 
         for (Survey sourceSurvey : sourceSurveys) {
+            sourceSurvey.setAncestorIds(surveysAncestorIds);
             SurveyDto surveyDto = new SurveyDto();
             surveyDto.setCode(sourceSurvey.getCode());
             surveyDto.setName(sourceSurvey.getName());
@@ -367,7 +368,6 @@ public class ActionRestService {
             surveyDto.setSurveyGroupId(savedProjectCopy.getKey().getId());
             Survey surveyCopy = SurveyUtils.copySurvey(sourceSurvey, surveyDto);
             surveyCopy.setSurveyGroupId(savedProjectCopy.getKey().getId());
-            sourceSurvey.setAncestorIds(surveysAncestorIds);
             long copyId = surveyDao.save(surveyCopy).getKey().getId();
             if (isRegistrationFormId(sourceSurvey.getKey().getId(),
                     projectSource.getNewLocaleSurveyId())) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
@@ -360,13 +360,13 @@ public class ActionRestService {
         surveysAncestorIds.add(savedProjectCopy.getKey().getId());
 
         for (Survey sourceSurvey : sourceSurveys) {
-            sourceSurvey.setAncestorIds(surveysAncestorIds);
             SurveyDto surveyDto = new SurveyDto();
             surveyDto.setCode(sourceSurvey.getCode());
             surveyDto.setName(sourceSurvey.getName());
             surveyDto.setPath(projectCopy.getPath() + "/" + sourceSurvey.getName());
             surveyDto.setSurveyGroupId(savedProjectCopy.getKey().getId());
             Survey surveyCopy = SurveyUtils.copySurvey(sourceSurvey, surveyDto);
+            surveyCopy.setAncestorIds(surveysAncestorIds);
             surveyCopy.setSurveyGroupId(savedProjectCopy.getKey().getId());
             long copyId = surveyDao.save(surveyCopy).getKey().getId();
             if (isRegistrationFormId(sourceSurvey.getKey().getId(),


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Copied forms we're not always displaying for all users
#### The solution
Set the ancestor IDs of copied forms before triggering the survey copy
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
