### PR TITLE
Cannot delete data point via monitoring tab (connect #2261)

### DIFF
--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -271,7 +271,6 @@ FLOW.dialogControl = Ember.Object.create({
   delDeviceGroup: "delDeviceGroup",
   delSI: "delSI",
   delSI2: "delSI2",
-  delSL: "delSL",
   delCR: "delCR",
   delForm: "delForm",
   showDialog: false,
@@ -336,12 +335,6 @@ FLOW.dialogControl = Ember.Object.create({
       this.set('showDialog', true);
       break;
 
-    case "delSL":
-        this.set('header', Ember.String.loc('_delete_data_point_header'));
-        this.set('message', Ember.String.loc('_are_you_sure_delete_this_data_point'));
-        this.set('showDialog', true);
-        break;
-
     case "delForm":
       this.set('header', "Delete form");
       this.set('message', "Are you sure you want to delete this form?");
@@ -402,12 +395,7 @@ FLOW.dialogControl = Ember.Object.create({
       this.set('showDialog', false);
       view.deleteSI.apply(view, arguments);
       break;
-
-    case "delSL":
-        this.set('showDialog', false);
-        view.deleteSL.apply(view, arguments);
-        break;
-
+      
     case "delForm":
       this.set('showDialog', false);
       FLOW.surveyControl.deleteForm();

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -110,10 +110,6 @@ FLOW.DataPointView = FLOW.View.extend({
 
     showDataApprovalBlock: false,
 
-    showSurveyedLocaleDeleteButton: function() {
-        return FLOW.router.surveyedLocaleController.get('userCanDelete');
-    }.property(),
-
     showApprovalStatusColumn: function () {
         return this.get('parentView').get('showApprovalStatusColumn');
     }.property(),

--- a/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
@@ -14,12 +14,6 @@
 
     <td class="action">
         <a {{action showDetailsDialog this target="view.parentView" }}>{{t _view_details}}</a>
-
-        {{#if view.showSurveyedLocaleDeleteButton }}
-        {{#view FLOW.DataLocaleItemView contentBinding="this"}}
-            <a {{action confirm FLOW.dialogControl.delSL target="FLOW.dialogControl" }}>{{t _delete}}</a>
-        {{/view}}
-        {{/if}}
     </td>
 </tr>
 

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -93,9 +93,6 @@
                 <a {{action showSurveyInstanceDetails SI target="this"}}>
                   {{t _view_details}}
                 </a>
-                {{#if view.showSurveyedLocaleDeleteButton }} {{#view FLOW.DataItemView contentBinding="SI"}}<a {{action confirm FLOW.dialogControl.delSI2 target="FLOW.dialogControl" }}>
-                  {{t _delete}}
-                </a>{{/view}} {{/if}}
               </td>
             </tr>
             <tr class="si_details" style="background: #fff; display:none;" data-flow-id="si_details_{{unbound SI.id}}">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Delete option was present at the monitoring tab and in the details dialog. However , the option wasn't working and the action point was to remove it all together to reduce data loss risks.
#### The solution
Removed the delete options in the monitoring templates and removed the delete function in the monitoring view.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
