### PR TITLE
Remove line above 'No results found' (connect #2452)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3338,7 +3338,6 @@ div.chooseSurveyData {
 }
 
 .filterData {
-    border: thin solid rgb(224, 224, 224);
     border-top: 1px solid white;
     .dataDeviceId {
         display: block;


### PR DESCRIPTION

#### Before the PR (what is the issue or what needed to be done)
When a search was done under the Inspect data tab or Monitoring tab with no results, "No results found" would be displayed with a line above it
#### The solution
Removed the border css code responsible for that line , in class .filterData ,in the main.css file
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
