### PR TITLE
Monitoring tab data point numbering shows as NaN (connect #2386 )

### DIFF
--- a/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data-row.handlebars
@@ -1,8 +1,8 @@
 <tr>
     <td class="device">{{view.dataPointRowNumber}}</td>
-    <td class="displayName" style="text-align:left;">{{item.displayName}}</td>
-    <td class="identifier" style="text-align:left;">{{item.identifier}}</td>
-    <td class="collected">{{#with item}}{{date1 lastUpdateDateTime}}{{/with}}</td>
+    <td class="displayName" style="text-align:left;">{{displayName}}</td>
+    <td class="identifier" style="text-align:left;">{{identifier}}</td>
+    <td class="collected">{{date1 lastUpdateDateTime}}</td>
 
     {{#if view.parentView.showApprovalStatusColumn}}
     <td class="approvalStatus">

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -41,8 +41,8 @@
           </tr>
         </thead>
         <tbody>
-          {{#each item in FLOW.router.surveyedLocaleController.currentContents}}
-           {{view FLOW.DataPointView contentBinding="item"}}
+          {{#each FLOW.router.surveyedLocaleController.currentContents}}
+           {{view FLOW.DataPointView contentBinding="this"}}
           {{/each}}
         </tbody>
       </table>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Once the user selects her survey and form in the Monitoring tab, she sees a list of data points. The first column in the list show the order/count of data points. This now shows as Not A Number.
The  submission lists were not loading in the detailed views


#### The solution
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
