### PR TITLE
Move monitoring tab after inspect data tab(connect #2467)

### DIFF
--- a/Dashboard/app/js/templates/navData/data-subnav.handlebars
+++ b/Dashboard/app/js/templates/navData/data-subnav.handlebars
@@ -2,6 +2,11 @@
     {{#view view.NavItemView item="inspectData" }}
     <a {{action doInspectData}}>{{t _inspect_data}}</a>
     {{/view}}
+    {{#if FLOW.Env.showMonitoringFeature}}
+      {{#view view.NavItemView item="monitoringData" }}
+        <a {{action doMonitoringData}}>{{t _monitoring}}</a>
+      {{/view}}
+    {{/if}}
     {{#view view.NavItemView item="bulkUpload" }}
     <a {{action doBulkUpload}}>{{t _bulk_upload_data}}</a>
     {{/view}} 
@@ -10,11 +15,6 @@
         <a {{action doDataCleaning}}>{{t _data_cleaning}}</a>
         {{/if}}
     {{/view}}
-    {{#if FLOW.Env.showMonitoringFeature}}
-      {{#view view.NavItemView item="monitoringData" }}
-        <a {{action doMonitoringData}}>{{t _monitoring}}</a>
-      {{/view}}
-    {{/if}}
     {{#view view.NavItemView item="cascadeResources" }}
         {{#if view.showCascadeResourcesButton}}
         <a {{action doCascadeResources}}>{{t _cascade_resources}}</a>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Bulk upload tab was right after the Inspect data tab under the Data sub-navigation.
#### The solution
Changed the position of Monitoring tab code in the data-subnav.handlebars file to right after the Inspect tab code
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
