### PR TITLE
Indicate survey must be selected in monitoring tab(connect #2455)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3343,6 +3343,7 @@ div.chooseSurveyData {
     border-color: red;
     padding-top: 8px;
     padding-bottom: 5px;
+    width: 99% !important;
 }
 
 .filterData {

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,14 @@ div.chooseSurveyData {
     }
 }
 
+.redBorder {
+    border-width: 1px;
+    border-style: solid;
+    border-color: red;
+    padding-top: 8px;
+    padding-bottom: 5px;
+}
+
 .filterData {
     border: thin solid rgb(224, 224, 224);
     border-top: 1px solid white;

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -1,6 +1,7 @@
 FLOW.MonitoringDataTableView = FLOW.View.extend({
   showingDetailsDialog: false,
   cursorStart: null,
+  missingSurvey: false,
 
   pageNumber: function(){
 	return FLOW.router.surveyedLocaleController.get('pageNumber');
@@ -28,6 +29,10 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
   },
 
   findSurveyedLocale: function (evt) {
+      if (FLOW.selectedControl.get('selectedSurveyGroup') === null) {
+         this.set('missingSurvey', true)
+      } else {
+          this.set('missingSurvey', false);
 	  var ident = this.get('identifier'),
 	      displayName = this.get('displayName'),
 	      sgId = FLOW.selectedControl.get('selectedSurveyGroup'),
@@ -64,12 +69,17 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
       if(Ember.empty(FLOW.router.userListController.get('content'))) {
           FLOW.router.userListController.set('content', FLOW.User.find());
       }
+    }
   },
   
   noResults: function () {
+    if (FLOW.selectedControl.get('selectedSurveyGroup') === null) {
+        return;
+     } else {
     var content = FLOW.router.surveyedLocaleController.get('content');
-    if (content && content.get('isLoaded')) {
-        return content.get('length') === 0;
+        if (content && content.get('isLoaded')) {
+            return content.get('length') === 0;
+        }
     }
   }.property('FLOW.router.surveyedLocaleController.content','FLOW.router.surveyedLocaleController.content.isLoaded'),
 

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.MonitoringDataTableView}}
 <section class="" id="monitoringData">
     <div class="floats-in filterData" id="dataFilter">
-      <div class="chooseSurveyData">
+      <div {{bindAttr class=":chooseSurveyData view.missingSurvey:redBorder"}}>
       {{#unless FLOW.projectControl.isLoading}}
         {{view FLOW.SurveySelectionView showMonitoringSurveysOnly=true}}
       {{/unless}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When the 'Find' option was selected with no survey selected, it would return No results found. 
The proposed solution was to highlight the border of  entire stretch for survey selection to cater especially for cases where final form selection went to another line
#### The solution
Created a css class for the red border effect
Added  a property, misssingSurvey that is set to true in the view function when the function dealing with Find is called but no survey is selected. missingSurvey is set back to false when the surveys are all selected. 
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
