### PR TITLE
Indicate form must be selected in inspect data tab (connect #2454)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3343,6 +3343,7 @@ div.chooseSurveyData {
     border-color: red;
     padding-top: 8px;
     padding-bottom: 5px;
+    width: 99% !important;
 }
 
 .filterData {

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,14 @@ div.chooseSurveyData {
     }
 }
 
+.redBorder {
+    border-width: 1px;
+    border-style: solid;
+    border-color: red;
+    padding-top: 8px;
+    padding-bottom: 5px;
+}
+
 .filterData {
     border: thin solid rgb(224, 224, 224);
     border-top: 1px solid white;

--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -15,6 +15,7 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   selectedSurveyInstanceId: null,
   selectedSurveyInstanceNum: null,
   siString: null,
+  missingSurvey: false,
 
   form: function() {
     if (FLOW.selectedControl.get('selectedSurvey')) {
@@ -35,10 +36,15 @@ FLOW.inspectDataTableView = FLOW.View.extend({
 
   // do a new query
   doFindSurveyInstances: function () {
-    FLOW.surveyInstanceControl.get('sinceArray').clear();
-    FLOW.surveyInstanceControl.set('pageNumber', -1);
-    FLOW.metaControl.set('since', null);
-    this.doNextPage();
+    if (FLOW.selectedControl.get('selectedSurvey') === null) {
+      this.set('missingSurvey', true);
+    } else {
+      this.set('missingSurvey', false);
+      FLOW.surveyInstanceControl.get('sinceArray').clear();
+      FLOW.surveyInstanceControl.set('pageNumber', -1);
+      FLOW.metaControl.set('since', null);
+      this.doNextPage();
+    }
   },
 
   doInstanceQuery: function () {
@@ -247,6 +253,9 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   }.property('this.surveyInstanceId'),
 
   noResults: function() {
+    if (FLOW.selectedControl.get('selectedSurvey') === null) {
+      return;
+    }
     var content = FLOW.surveyInstanceControl.get('content');
     if (content && content.get('isLoaded')) {
       return content.get('length') === 0;

--- a/Dashboard/app/js/templates/navData/inspect-data.handlebars
+++ b/Dashboard/app/js/templates/navData/inspect-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.inspectDataTableView}}
 <section class="" id="inspectData">
     <div class="floats-in filterData" id="dataFilter">
-        <div class="chooseSurveyData">
+        <div {{bindAttr class=":chooseSurveyData view.missingSurvey:redBorder"}}>
           {{#unless FLOW.projectControl.isLoading}}
             {{view FLOW.SurveySelectionView}}
           {{/unless}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When the 'Find' option was selected with no survey selected, it would return No results found.
The proposed solution was to highlight the border of entire stretch for survey selection to cater especially for cases where final form selection went to another line
#### The solution
Created a css class for the red border effect
Added a property, misssingSurvey that is set to true in the view function when the function dealing with Find is called but no survey is selected. missingSurvey is set back to false when the surveys are all selected.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
