### PR TITLE
Indicate form must be selected in exports page (connect #2380)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3344,6 +3344,10 @@ div.chooseSurveyData {
     width: 98%;
 }
 
+.red-border {
+    border-color:red !important;
+}
+
 .filterData {
     border: thin solid rgb(224, 224, 224);
     border-top: 1px solid white;

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,13 @@ div.chooseSurveyData {
     }
 }
 
+.redErrorBorder {
+    border-style: solid;
+    border-width: 1px;
+    border-color: red;
+    width: 98%;
+}
+
 .filterData {
     border: thin solid rgb(224, 224, 224);
     border-top: 1px solid white;

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -158,6 +158,7 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
+  missingSurvey: false,
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -177,22 +178,11 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurvey'),
 
   incompleteSelection: function () {
-    if (this.get('selectedSurvey') === null){
-      FLOW.dialogControl.set('activeAction', 'ignore');
-		  FLOW.dialogControl.set('header', Ember.String.loc('_survey_type_not_set'));
-		  FLOW.dialogControl.set('message', Ember.String.loc('_survey_type_not_set_text'));
-		  FLOW.dialogControl.set('showCANCEL', false);
-      FLOW.dialogControl.set('showDialog', true);
+    if (FLOW.selectedControl.get('selectedSurvey') === null){
+      this.set('missingSurvey',true);
+      console.log(this.get('missingSurvey'));
       return true;
     }
-    if (Ember.none(FLOW.dateControl.get('toDate')) || Ember.none(FLOW.dateControl.get('fromDate'))) {
-		  FLOW.dialogControl.set('activeAction', 'ignore');
-		  FLOW.dialogControl.set('header', Ember.String.loc('_date_not_set'));
-		  FLOW.dialogControl.set('message', Ember.String.loc('_date_not_set_text'));
-		  FLOW.dialogControl.set('showCANCEL', false);
-		  FLOW.dialogControl.set('showDialog', true);
-		  return true;
-	  }
     return false;
   },
 
@@ -210,9 +200,10 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-    if (this.incompleteSelection()){
-      return;
-    }
+  if(this.incompleteSelection()){
+    console.log("ok");
+    return;
+  }
 	var opts = {}, sId = this.get('selectedSurvey');
 	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -180,7 +180,6 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   incompleteSelection: function () {
     if (FLOW.selectedControl.get('selectedSurvey') === null){
       this.set('missingSurvey',true);
-      console.log(this.get('missingSurvey'));
       return true;
     }
     return false;
@@ -200,44 +199,49 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-  if(this.incompleteSelection()){
-    console.log("ok");
-    return;
-  }
-	var opts = {}, sId = this.get('selectedSurvey');
-	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
+    if (this.incompleteSelection()){
+      return;
+    }
+    this.set('missingSurvey',false);
+	  var opts = {}, sId = this.get('selectedSurvey');
+    FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
 
   showDataAnalysisReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
+    if (this.incompleteSelection()){
+      return;
+    } 
+    this.set('missingSurvey', false)
+    var opts = {}, sId = this.get('selectedSurvey');
     FLOW.ReportLoader.load('DATA_ANALYSIS', sId, opts);
   },
 
   showComprehensiveReport: function () {
+    if (this.incompleteSelection()){
+      return;
+    }
+    this.set('missingSurvey', false)
     var opts = {}, sId = this.get('selectedSurvey');
-
     FLOW.ReportLoader.load('COMPREHENSIVE', sId, opts);
   },
 
   showGeoshapeReport: function () {
     var sId = this.get('selectedSurvey');
     var qId = this.get('selectedQuestion');
-    if (!sId || !qId) {
-      this.showWarningMessage(
-        Ember.String.loc('_export_data'),
-        Ember.String.loc('_select_survey_and_geoshape_question_warning')
-      );
+    if (!sId) {
+      this.set("missingSurvey", true);
       return;
-    }
+    } 
+    this.set("missingSurvey", false);
     FLOW.ReportLoader.load('GEOSHAPE', sId, {"questionId": qId});
   },
 
   showSurveyForm: function () {
-	var sId = this.get('selectedSurvey');
-    if (!sId) {
-      this.showWarning();
+    if (this.incompleteSelection()) {
       return;
     }
+	  var sId = this.get('selectedSurvey');
+    this.set("missingSurvey", false)
     FLOW.ReportLoader.load('SURVEY_FORM', sId);
   },
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -176,6 +176,26 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
     }
   }.property('FLOW.selectedControl.selectedSurvey'),
 
+  incompleteSelection: function () {
+    if (this.get('selectedSurvey') === null){
+      FLOW.dialogControl.set('activeAction', 'ignore');
+		  FLOW.dialogControl.set('header', Ember.String.loc('_survey_type_not_set'));
+		  FLOW.dialogControl.set('message', Ember.String.loc('_survey_type_not_set_text'));
+		  FLOW.dialogControl.set('showCANCEL', false);
+      FLOW.dialogControl.set('showDialog', true);
+      return true;
+    }
+    if (Ember.none(FLOW.dateControl.get('toDate')) || Ember.none(FLOW.dateControl.get('fromDate'))) {
+		  FLOW.dialogControl.set('activeAction', 'ignore');
+		  FLOW.dialogControl.set('header', Ember.String.loc('_date_not_set'));
+		  FLOW.dialogControl.set('message', Ember.String.loc('_date_not_set_text'));
+		  FLOW.dialogControl.set('showCANCEL', false);
+		  FLOW.dialogControl.set('showDialog', true);
+		  return true;
+	  }
+    return false;
+  },
+
   selectedQuestion: function () {
     if (!Ember.none(FLOW.selectedControl.get('selectedQuestion'))
         && !Ember.none(FLOW.selectedControl.selectedQuestion.get('keyId'))){
@@ -190,6 +210,9 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
+    if (this.incompleteSelection()){
+      return;
+    }
 	var opts = {}, sId = this.get('selectedSurvey');
 	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -1,6 +1,6 @@
 <section class="fullWidth reportTools" id="reportBlocks">
   {{#view FLOW.ExportReportsAppletView}}
-    <div class="surveySelect">
+    <div {{bindAttr class=":surveySelect view.missingSurvey:redErrorBorder"}}>
       <nav class="breadCrumb floats-in">
         {{#unless FLOW.projectControl.isLoading}}
           {{view FLOW.SurveySelectionView}}

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -86,7 +86,8 @@
                     optionLabelPath="content.text"
                     optionValuePath="content.keyId"
                     prompt=""
-                    promptBinding="Ember.STRINGS._select_question"}}
+                    promptBinding="Ember.STRINGS._select_question"
+                    classBinding="view.redBorder"}}
               {{/if}}
             </div>
             <div id="geoShapeDataExp_options" class="options">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Under the export reports tab, if one of the download options was selected without first selecting the survey:
-Data cleaning export:  nothing would happen
-Data analysis export: a pop up dialog with the message error generating report would be displayed
-Comprehensive report:  a pop up dialog with the message 'your report is being prepared' would be displayed
-Geoshape data: a pop up dialog with the message 'please select a form and a geoshape question' would be displayed
-Survey Form: a pop up dialog with the message 'you must select a survey to run a report' would be displayed
The forwarded solution was to highlight the entire survey selection area when a survey wasn't selected
#### The solution
Added a css class to create a red border around the survey selection area
Added a function in export-reports-views.js to check if a survey had been selected when the functions for download were called
Added a property missingSurvey that is used to set the survey selection area classes dynamically basing on it's value
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
