### PR TITLE
 Add question group to submission view in monitoring tab (connect #2387)

### DIFF
--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -289,7 +289,7 @@ FLOW.questionAnswerControl = Ember.ArrayController.create({
     if (content) {
 		var surveyQuestions = FLOW.questionControl.get('content');
 		var groups = FLOW.questionGroupControl.get('content');
-
+      
 		var allResponses = [];
 		var groupResponses = [];
 		var answersInGroup = [];

--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -289,7 +289,6 @@ FLOW.questionAnswerControl = Ember.ArrayController.create({
     if (content) {
 		var surveyQuestions = FLOW.questionControl.get('content');
 		var groups = FLOW.questionGroupControl.get('content');
-      
 		var allResponses = [];
 		var groupResponses = [];
 		var answersInGroup = [];

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -127,15 +127,10 @@ FLOW.QuestionAnswerView = Ember.View.extend({
     var isEditableQuestionType, canEditFormResponses;
     isEditableQuestionType = this.nonEditableQuestionTypes.indexOf(this.get('questionType')) < 0;
     if (!isEditableQuestionType) {
-      console.log('i have no powers of editing!!!')
       return false; // no need to check permissions
     }
-
+    
     canEditFormResponses = FLOW.permControl.canEditResponses(this.get('form'));
-    //test this in the morning tab n inspect-data-tab.
-    if (canEditFormResponses) { //it z true...
-      console.log('yep, i can go on and edit stuff!!!')
-    }
     return isEditableQuestionType && canEditFormResponses;
   }.property('this.questionType,this.form'),
 

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -584,14 +584,11 @@ FLOW.QuestionAnswerInspectDataView = FLOW.QuestionAnswerView.extend({
   templateName: 'navData/question-answer',
 });
 
-//what baout the monitoring data tab part.
 FLOW.QuestionAnswerMonitorDataView = FLOW.QuestionAnswerView.extend({
   templateName: 'navData/question-answer',
   
-   doEdit : function (){
-     //testing whether this action can override the action in parentView(FLOW.QuestionAnswerView)
+  doEdit : function (){ //override the doEdit action in the parentView
       this._super();
-      console.log('monitoring activity!!!!!')
       this.set('inEditMode', false)
-   }
+  }
 })

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -129,7 +129,6 @@ FLOW.QuestionAnswerView = Ember.View.extend({
     if (!isEditableQuestionType) {
       return false; // no need to check permissions
     }
-    
     canEditFormResponses = FLOW.permControl.canEditResponses(this.get('form'));
     return isEditableQuestionType && canEditFormResponses;
   }.property('this.questionType,this.form'),

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -127,10 +127,15 @@ FLOW.QuestionAnswerView = Ember.View.extend({
     var isEditableQuestionType, canEditFormResponses;
     isEditableQuestionType = this.nonEditableQuestionTypes.indexOf(this.get('questionType')) < 0;
     if (!isEditableQuestionType) {
+      console.log('i have no powers of editing!!!')
       return false; // no need to check permissions
     }
 
     canEditFormResponses = FLOW.permControl.canEditResponses(this.get('form'));
+    //test this in the morning tab n inspect-data-tab.
+    if (canEditFormResponses) { //it z true...
+      console.log('yep, i can go on and edit stuff!!!')
+    }
     return isEditableQuestionType && canEditFormResponses;
   }.property('this.questionType,this.form'),
 
@@ -578,3 +583,15 @@ FLOW.QuestionAnswerMultiOptionEditView = Ember.CollectionView.extend({
 FLOW.QuestionAnswerInspectDataView = FLOW.QuestionAnswerView.extend({
   templateName: 'navData/question-answer',
 });
+
+//what baout the monitoring data tab part.
+FLOW.QuestionAnswerMonitorDataView = FLOW.QuestionAnswerView.extend({
+  templateName: 'navData/question-answer',
+  
+   doEdit : function (){
+     //testing whether this action can override the action in parentView(FLOW.QuestionAnswerView)
+      this._super();
+      console.log('monitoring activity!!!!!')
+      this.set('inEditMode', false)
+   }
+})

--- a/Dashboard/app/js/lib/views/data/question-answer-view.js
+++ b/Dashboard/app/js/lib/views/data/question-answer-view.js
@@ -583,7 +583,7 @@ FLOW.QuestionAnswerMonitorDataView = FLOW.QuestionAnswerView.extend({
   templateName: 'navData/question-answer',
   
   doEdit : function (){ //override the doEdit action in the parentView
-      this._super();
-      this.set('inEditMode', false)
+    this._super();
+    this.set('inEditMode', false)
   }
 })

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -113,22 +113,20 @@
             <tbody>
                 {{#each responseSublist in FLOW.questionAnswerControl.contentByGroup}}
                    {{#each iterations in responseSublist}}
-                      <tr><td colspan="3" style="text-align:left"></td><h3 class="questionGroupName">{{iterations.groupName}}</h3></tr>
-                          {{each iterations itemViewClass = "FLOW.QuestionAnswerMonitorDataView"}}
+                       <tr><td colspan="3" style="text-align:left"><h3 class="questionGroupName">{{iterations.groupName}}</h3></td></tr>
+                            {{each iterations itemViewClass = "FLOW.QuestionAnswerMonitorDataView"}}
                    {{/each}}
                 {{/each}}
             </tbody>
             <!-- TABLE FOOTER-->
-        </table>
+          </table>
               </td>
             </tr>
-            {{/each}}
+          {{/each}}
         </tbody>
       </table>
-      <ul class="prevNext">
-      </ul>
-         </div>
-      </div>
+     </div>
     </div>
+  </div>
 </section>
 {{/view}}

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -104,54 +104,18 @@
             <!-- TABLE HEADER-->
             <thead>
                 <tr>
+                    <th class="noArrows" style="width:10%"></th>
                     <th class="noArrows">{{t _question}}</th>
                     <th class="noArrows">{{t _answer}}</th>
                 </tr>
             </thead>
             <!-- TABLE BODY: MAIN CONTENT-->
             <tbody>
-                {{#each QA in FLOW.questionAnswerControl}}
-                  {{#view FLOW.QuestionAnswerView contentBinding="QA"}}
-                    <tr>
-                      <td class="survey" style="text-align:left;">{{QA.questionText}}</td>
-                      <td class="submitter" style="text-align:left;">
-                        {{#if view.isPhotoType}}
-                          {{view.photoUrl}}  <a {{bindAttr href="view.photoUrl"}} target="_blank">{{t _open_photo}}</a>
-                          {{#if view.photoLocation}}
-                              <br>{{view.photoLocation}}
-                          {{/if}}
-                        {{else}} {{#if view.isVideoType}}
-                          {{view.photoUrl}} <a {{bindAttr href="view.photoUrl" }} target="_blank">{{t _open_video}}</a>
-                          {{#if view.photoLocation}}
-                              <br>{{view.photoLocation}}
-                          {{/if}}
-                        {{else}} {{#if view.isGeoShapeType}}
-                          {{view FLOW.GeoshapeMapView}}
-                        {{else}} {{#if view.isCascadeType}}
-                          <span>{{view.cascadeValue}}</span>
-                        {{else}} {{#if view.isOptionType}}
-                          {{view FLOW.QuestionAnswerOptionListView contentBinding="view.optionValue"}}
-                        {{else}} {{#if view.isDateType}}
-                          {{#with QA}}{{date3 value}}{{/with}}
-                        {{else}} {{#if view.isSignatureType}}
-                            {{#if view.signatureImageSrc}}
-                                <div class="signatureImage"><img {{bindAttr src="view.signatureImageSrc"}} /></div>
-                                <div class="signedBySection">{{t _signed_by}}: {{view.signatureSignatory}}</div>
-                            {{else}}
-                                {{t _no_signature_found}}
-                            {{/if}}
-                        {{else}} {{#if view.isCaddisflyType}}
-                            <div class=""><strong>{{view.testName}}</strong></div>
-                            {{#each result in view.testResult}}
-                                <br><div>{{result.name}} : {{result.value}} {{result.unit}}</div>
-                            {{/each}}<br>
-                            <div class="signatureImage"><img {{bindAttr src="view.caddisflyImageURL"}} /></div>
-                        {{else}}
-                          <span>{{QA.value}} {{#with QA}}{{if_blank value}}{{/with}}</span>
-                        {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}} {{/if}}
-                    </td>
-                    </tr>
-                    {{/view}}
+                {{#each responseSublist in FLOW.questionAnswerControl.contentByGroup}}
+                   {{#each iterations in responseSublist}}
+                      <tr><td colspan="3" style="text-align:left"></td><h3 class="questionGroupName">{{iterations.groupName}}</h3></tr>
+                          {{each iterations itemViewClass = "FLOW.QuestionAnswerMonitorDataView"}}
+                   {{/each}}
                 {{/each}}
             </tbody>
             <!-- TABLE FOOTER-->


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Both views are however quite inconsistent in how we show a form submission. In the Inspect data tab we show question groups and the questions that belong in them. In Monitoring tab we do not and the questions seem to appear in a random order.
#### The solution
 The  repeated question groups are also shown properly with the repetition number.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
