### PR TITLE
Indicate geoshape question must be selected in exports tab(connect #2479)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,10 +3337,8 @@ div.chooseSurveyData {
     }
 }
 
-.redBorderColor {
-    .ember-select {
-        border-color: red;
-    }
+.red-border {
+    border-color: red;
 }
 
 .filterData {

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,12 @@ div.chooseSurveyData {
     }
 }
 
+.redBorderColor {
+    .ember-select {
+        border-color: red;
+    }
+}
+
 .filterData {
     border-top: 1px solid white;
     .dataDeviceId {

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -158,6 +158,7 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
+  missingQuestion: false,
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -208,13 +209,18 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showGeoshapeReport: function () {
     var sId = this.get('selectedSurvey');
     var qId = this.get('selectedQuestion');
-    if (!sId || !qId) {
+    if (!sId) {
       this.showWarningMessage(
         Ember.String.loc('_export_data'),
         Ember.String.loc('_select_survey_and_geoshape_question_warning')
       );
       return;
     }
+    if (!qId) {
+      this.set("missingQuestion", true);
+      return;
+    }
+    this.set("missingQuestion", false);
     FLOW.ReportLoader.load('GEOSHAPE', sId, {"questionId": qId});
   },
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -158,7 +158,7 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
-  missingQuestion: false,
+  redBorder: false,
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -217,10 +217,10 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
       return;
     }
     if (!qId) {
-      this.set("missingQuestion", true);
+      this.set("redBorder", true);
       return;
     }
-    this.set("missingQuestion", false);
+    this.set("redBorder", false);
     FLOW.ReportLoader.load('GEOSHAPE', sId, {"questionId": qId});
   },
 

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -78,7 +78,7 @@
           <li class="geoShapeDataExp trigger"  onclick="openExportOptions(event, 'geoShapeDataExp_options')">
             <h2>{{t _geoshape_data}}</h2>
             <p class="expDescr">{{t _geojson}}</p>
-              <div {{bindAttr class=":geoshapeSelect view.missingQuestion:redBorderColor"}}>
+              <div class="geoshapeSelect">
               {{#if FLOW.selectedControl.selectedSurvey}}
                 {{view Ember.Select
                     contentBinding="FLOW.questionControl.geoshapeContent"
@@ -86,7 +86,8 @@
                     optionLabelPath="content.text"
                     optionValuePath="content.keyId"
                     prompt=""
-                    promptBinding="Ember.STRINGS._select_question"}}
+                    promptBinding="Ember.STRINGS._select_question"
+                    classBinding="view.redBorder"}}
               {{/if}}
             </div>
             <div id="geoShapeDataExp_options" class="options">

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -78,7 +78,7 @@
           <li class="geoShapeDataExp trigger"  onclick="openExportOptions(event, 'geoShapeDataExp_options')">
             <h2>{{t _geoshape_data}}</h2>
             <p class="expDescr">{{t _geojson}}</p>
-              <div class="geoshapeSelect">
+              <div {{bindAttr class=":geoshapeSelect view.missingQuestion:redBorderColor"}}>
               {{#if FLOW.selectedControl.selectedSurvey}}
                 {{view Ember.Select
                     contentBinding="FLOW.questionControl.geoshapeContent"


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When a user hit the Download button for geoshape Data without selecting the geoshape question, a pop up notification with a message 'select form or geoshape question' would be displayed
#### The solution
The solution was to get rid of the pop up notification when a question isn't selected and highlight the select question drop down instead.
Added a css class to change the border color of the select question drop down.
Used bindAttr to set the class of the responsible element dynamically basing on a missingQuestion property defined in the export-reports-view.js

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
