### PR TITLE
Indicate form must be selected in data cleaning tab (connect #2456)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,14 @@ div.chooseSurveyData {
     }
 }
 
+.dataCleaningErrorBorder {
+    padding: 8px 0 8px 0%;
+    border-style: solid;
+    border-width: 1px;
+    border-color: red;
+    width: 99%;
+}
+
 .filterData {
     border-top: 1px solid white;
     .dataDeviceId {

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -158,6 +158,7 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
+  missingSurvey: false,
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -176,6 +177,14 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
     }
   }.property('FLOW.selectedControl.selectedSurvey'),
 
+  incompleteSelection: function () {
+    if (FLOW.selectedControl.get('selectedSurvey') === null) {
+      this.set('missingSurvey',true);
+      return true;
+    }
+    return false;
+  },
+
   selectedQuestion: function () {
     if (!Ember.none(FLOW.selectedControl.get('selectedQuestion'))
         && !Ember.none(FLOW.selectedControl.selectedQuestion.get('keyId'))){
@@ -190,8 +199,12 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
-	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
+    if (this.incompleteSelection()) {
+      return;
+    }
+    this.set('missingSurvey',false);
+    var opts = {}, sId = this.get('selectedSurvey');
+    FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
 
   showDataAnalysisReport: function () {

--- a/Dashboard/app/js/templates/navData/data-cleaning.handlebars
+++ b/Dashboard/app/js/templates/navData/data-cleaning.handlebars
@@ -1,6 +1,6 @@
 <section class="fullWidth reportTools" id="reportBlocks">
   {{#view FLOW.ExportReportsAppletView}}
-
+  <div {{bindAttr class="view.missingSurvey:dataCleaningErrorBorder"}}>
     {{#unless FLOW.projectControl.isLoading}}
       {{view FLOW.DataCleaningSurveySelectionView}}
     {{/unless}}
@@ -14,6 +14,7 @@
           prompt=""
           promptBinding="Ember.STRINGS._select_form"}}
     {{/if}}
+  </div>
 
     <div class="rawDataReport block">
       <h3>{{t _data_cleaning_export}}</h3>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When a user tries to download without selecting a survey, nothing happens, there is no error prompt. However, an error is logged in the console, "Cannot read property get of null"
The solution is to highlight the survey selection area by adding a red border around it when a user hits Download without selecting a survey.
#### The solution
Added a css class, dataCleaningErrorBorder in main.scss to create the red border around the survey selection area.
Added  a function in export-reports-view.js, to check if a survey is selected, this function is called in the showDataCleaningReport function
Added a div tag to enclose the survey selection elements and set the errorBorder dynamically in data-cleaning.handlebars
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
