### PR TITLE
Options reposition in translations page (connect #1983)

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1588,7 +1588,7 @@ FLOW.translationControl = Ember.ArrayController.create({
         tempArray.push(Ember.Object.create({
           keyId: item.get('keyId'),
           type: "QO",
-          order: 1000000 * qgOrder + 1000 * qOrder + parseInt(item.get('order'), 10),
+          order: 1000000 * qgOrder + 1000 * qOrder + parseInt(item.get('order'), 10) + 1,
           displayOrder: item.get('order'),
           qoText: item.get('text'),
           isQO: true


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When a user moved a question prior to selecting manage translations, the options questions appeared out of order in the form translations, with some options appearing above their respective question and in some cases below
#### The solution
Changed the equation for question order in survey-controllers.js by adding 1 in order to guarantee that the questionOption appear below the questions.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
