### PR TITLE
Disable copying survey to root folder (connect #2464)

### DIFF
--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -14,6 +14,7 @@
       </nav>
       {{#if view.projectListView}}
         {{#if FLOW.projectControl.moveTarget}}
+          {{#unless view.disableAddSurveyButtonInRoot}}
           <nav class="menuTopbar actionHighLighted">
             <ul>
               <li><p>{{t _moving}} <span class="itemMoved">{{FLOW.projectControl.moveTarget.code}}</span> {{FLOW.projectControl.moveTargetType}}</p></li>
@@ -21,8 +22,10 @@
               <li><a class="redCancel  btnOutline" {{action "cancelMoveProject" target="FLOW.projectControl"}}>{{t _cancel}}</a></li>
             </ul>
           </nav>
+          {{/unless}}
         {{else}}
           {{#if FLOW.projectControl.copyTarget}}
+            {{#unless view.disableAddSurveyButtonInRoot}}
             <nav class="menuTopbar actionHighLighted">
               <ul>
                 <li><p>{{t _copying}} <span class="itemMoved">{{FLOW.projectControl.copyTarget.code}}</span></p></li>
@@ -30,6 +33,7 @@
                 <li><a class="redCancel btnOutline" {{action "cancelCopyProject" target="FLOW.projectControl"}}>{{t _cancel}}</a></li>
               </ul>
             </nav>
+            {{/unless}}
           {{else}}
             <nav class="menuTopbar">
               <ul>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Users were able to copy and move surveys to root folder
#### The solution
Disabled ability to copy survey to root folder by only availing the option when user is in destination folder
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
