### PR TITLE
Hotfix for 1.9.28 CartoDB libraries integrity check failing (connect #2500)

### DIFF
--- a/Dashboard/app/dashboard.html
+++ b/Dashboard/app/dashboard.html
@@ -49,8 +49,8 @@
               //replace leaflet library
               jsSrc = "https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js";
               cssSrc = "https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css";
-              jsIntegrity = 'integrity="sha384-186Za72/5qVX6enL5hiqq/J50rF6cjyD8swQIHLmLumlwqxV5u0mtPzSZk3VzwQy" crossorigin="anonymous"';
-              cssIntegrity = 'integrity="sha384-2jZemTFA+0G69HaecoRuv5/hO9AA84owVqReLcXX5cb/Dm+9kjKIBKD1oPTZ+Qhm" crossorigin="anonymous"';
+              jsIntegrity = 'integrity="sha384-nrnuEANk1U4jNer7BO0D9qbBQC/FTWOXSqdYEeN1Cutp+7AzPd19Hn4c5crckiTt" crossorigin="anonymous"';
+              cssIntegrity = 'integrity="sha384-2okMniCiL7uKWJ/EVNAcfCaFR3ufkbQfwa/RdHDV5CV8IHT6bdIy87uRC2Jv6/Cs" crossorigin="anonymous"';
               break;
           case 'google':
               var regionBias = FLOW.Env.googleMapsRegionBias;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Akvo Flow Release Notes
 ----
+# Akvo Flow Dashboard v1.9.28.1 - Bent Banana (Hotfix 1)
+Date: 20 February 2018
+## Resolved issues
+* **Integrity check failing for CartoDB libraries** [#2500] - Fixed issue causing maps on CartoDB enabled instances not to work
+
 # Akvo Flow Dashboard v1.9.28 - Bent Banana
 Date: 15 February 2018
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,19 @@
 # Akvo Flow Release Notes
 ----
 # Akvo Flow Dashboard v1.9.28 - Bent Banana
-Date: 15 February 2015
+Date: 15 February 2018
 
 ## New and noteworthy
-* [#2287] - Updated French, Spanish, and Portuguese translations
-* [#2427] - Show frequency table and graphs for cascades
-* [#2443] - Add statistics about collected data to comprehensive report
-* [#2428] - Improve comprehensive report graph styling and display as bar graph
-* [#2467] - Move monitoring tab after inspect data tab
-* Rephrase question ID to variable name [#2143], and update variable name help text [#2444]
+* **Add updated translations of online workspace** - Updated French, Spanish, and Portuguese translations [#2287]
+* **Comprehensive report improvement** - Show frequency table and graphs for cascades [#2427], add statistics about collected data [#2443], and improve graph styling [#2428]
+* **Rearrange data tab** - Moved monitoring tab after inspect data tab [#2467]
+* **Simplify validation** - Rephrased question ID to variable name [#2143], and update variable name help text [#2444]
+
+## Resolved issues
+* **Users unable to delete data under monitoring tab** [#2261] - Removed delete option to reduce the the risk of high data loss
+* **Form version number not incrementing correctly** [#1403] - Set form as not published each time the form basics are changed
+* **Code Cleanup** [#2447],[#555] - Remove unused code
+* **UI** - Remove line above "No results found" in inspect data and monitoring tabs [#2452]
 
 ## Resolved issues
 * Users unable to delete data under monitoring tab [#2261] - Removed delete option to reduce the the risk of high data loss


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Intergrity check on CartoDB libraries was failing causing maps not to load
#### The solution
Update the cryptographic hash for CartoDB libraries
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
