### PR TITLE
Display disabled move/copy buttons when in root folder (connect #2464)

### DIFF
--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -14,26 +14,30 @@
       </nav>
       {{#if view.projectListView}}
         {{#if FLOW.projectControl.moveTarget}}
-          {{#unless view.disableAddSurveyButtonInRoot}}
           <nav class="menuTopbar actionHighLighted">
             <ul>
               <li><p>{{t _moving}} <span class="itemMoved">{{FLOW.projectControl.moveTarget.code}}</span> {{FLOW.projectControl.moveTargetType}}</p></li>
+              {{#if view.disableAddSurveyButtonInRoot}}
+              <li><a class="moveAction button noChanges">{{t _move_here}}</a></li>
+              {{else}}
               <li><a class="moveAction button" {{action "endMoveProject" target="FLOW.projectControl"}}>{{t _move_here}}</a></li>
+              {{/if}}
               <li><a class="redCancel  btnOutline" {{action "cancelMoveProject" target="FLOW.projectControl"}}>{{t _cancel}}</a></li>
             </ul>
           </nav>
-          {{/unless}}
         {{else}}
           {{#if FLOW.projectControl.copyTarget}}
-            {{#unless view.disableAddSurveyButtonInRoot}}
             <nav class="menuTopbar actionHighLighted">
               <ul>
                 <li><p>{{t _copying}} <span class="itemMoved">{{FLOW.projectControl.copyTarget.code}}</span></p></li>
+                {{#if view.disableAddSurveyButtonInRoot}}
+                <li><a class="moveAction button noChanges">{{t _copy_here}}</a></li>
+                {{else}}
                 <li><a class="moveAction button" {{action "endCopyProject" target="FLOW.projectControl"}}>{{t _copy_here}}</a></li>
+                {{/if}}
                 <li><a class="redCancel btnOutline" {{action "cancelCopyProject" target="FLOW.projectControl"}}>{{t _cancel}}</a></li>
               </ul>
             </nav>
-            {{/unless}}
           {{else}}
             <nav class="menuTopbar">
               <ul>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
"Move/Copy here"  buttons not displayed in root folder
#### The solution
Display disabled "Move/Copy here" buttons in root folder
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
