### PR TITLE
Fixed collection date set for both export options (connect #2363)

### DIFF
--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -199,9 +199,9 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-  var opts = {from:this.get("reportFromDate"), to:this.get("reportToDate")};
-  var sId = this.get('selectedSurvey');
-  FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
+    var opts = {from:this.get("reportFromDate"), to:this.get("reportToDate")};
+    var sId = this.get('selectedSurvey');
+    FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
 
   showDataAnalysisReport: function () {
@@ -212,7 +212,6 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
 
   showComprehensiveReport: function () {
     var opts = {}, sId = this.get('selectedSurvey');
-
     FLOW.ReportLoader.load('COMPREHENSIVE', sId, opts);
   },
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -149,13 +149,13 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   reportToDate: undefined,
   
   setMinDate: function () {
-    if (this.get('reportFromDate') !== "") {
+    if (this.get('reportFromDate')) {
       this.$(".to_date").datepicker("option", "minDate", this.get("reportFromDate"))
     }
   }.observes('this.reportFromDate'),
 
   setMaxDate: function () {
-    if (this.get('reportToDate') !== "") { 
+    if (this.get('reportToDate')) {
      this.$(".from_date").datepicker("option", "maxDate", this.get("reportToDate"))
     }
   }.observes('this.reportToDate'),

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -150,21 +150,13 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   
   setMinDate: function () {
     if (this.get('reportFromDate') !== "") {
-      if (this.get("dataCleaningSection")) {   
-        $("#to_date02").datepicker("option", "minDate", this.get("reportFromDate")) 
-      } else {   
-        $("#to_date").datepicker("option", "minDate", this.get("reportFromDate")) 
-      }
+      this.$(".to_date").datepicker("option", "minDate", this.get("reportFromDate"))
     }
   }.observes('this.reportFromDate'),
 
   setMaxDate: function () {
-    if (this.get('reportToDate') !== "") {
-      if (this.get("dataCleaningSection")) {
-        $("#from_date02").datepicker("option", "maxDate", this.get("reportToDate"))
-      } else {
-        $("#from_date").datepicker("option", "maxDate", this.get("reportToDate"))
-      }  
+    if (this.get('reportToDate') !== "") { 
+     this.$(".from_date").datepicker("option", "maxDate", this.get("reportToDate"))
     }
   }.observes('this.reportToDate'),
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -67,19 +67,6 @@ FLOW.ReportLoader = Ember.Object.create({
     }
 
     criteria.opts.lastCollection = '' + (exportType === 'DATA_CLEANING' && FLOW.selectedControl.get('selectedSurveyGroup').get('monitoringGroup') && !!FLOW.editControl.lastCollection);
-
-    var fromDate = FLOW.dateControl.get('fromDate');
-    if (fromDate == null) {
-      delete criteria.opts.from;
-    } else {
-      criteria.opts.from = fromDate;
-    }
-    var toDate = FLOW.dateControl.get('toDate');
-    if (toDate == null) {
-      delete criteria.opts.to;
-    } else {
-      criteria.opts.to = toDate;
-    }
     criteria.opts.email = FLOW.currentUser.email;
     criteria.opts.flowServices = FLOW.Env.flowServices;
 
@@ -158,6 +145,28 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
+  reportFromDate: undefined,
+  reportToDate: undefined,
+  
+  setMinDate: function () {
+    if (this.get('reportFromDate') !== "") {
+      if (this.get("dataCleaningSection")) {   
+        $("#to_date02").datepicker("option", "minDate", this.get("reportFromDate")) 
+      } else {   
+        $("#to_date").datepicker("option", "minDate", this.get("reportFromDate")) 
+      }
+    }
+  }.observes('this.reportFromDate'),
+
+  setMaxDate: function () {
+    if (this.get('reportToDate') !== "") {
+      if (this.get("dataCleaningSection")) {
+        $("#from_date02").datepicker("option", "maxDate", this.get("reportToDate"))
+      } else {
+        $("#from_date").datepicker("option", "maxDate", this.get("reportToDate"))
+      }  
+    }
+  }.observes('this.reportToDate'),
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -190,12 +199,14 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
-	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
+  var opts = {from:this.get("reportFromDate"), to:this.get("reportToDate")};
+  var sId = this.get('selectedSurvey');
+  FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
 
   showDataAnalysisReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
+    var opts = {from:this.get("reportFromDate"), to:this.get("reportToDate")};
+    var sId = this.get('selectedSurvey');
     FLOW.ReportLoader.load('DATA_ANALYSIS', sId, opts);
   },
 

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -31,17 +31,17 @@
         document.getElementById(exportName).style.display = "block";
         evt.currentTarget.className += " active";
        }
-    </script>      
+    </script>
     <section class="exportContainer">
       <ul class="exportSelect">
         <li class="dataCleanExp trigger" onclick="openExportOptions(event, 'dataCleanExp_options')">
           <h2>{{t _data_cleaning_export}}</h2>
           <h6>{{t _importable_back_to_akvo_flow}}</h6>
           <p class="expDescr">{{t _combines_options}}</p>
-        {{#view FLOW.ExportReportsAppletView dataCleaningSection=true}}
+        {{#view FLOW.ExportReportsAppletView}}
           <div id="dataCleanExp_options" class="options">
               <div class="dataCollectedDate">
-                <p>{{t _collection_period}}</p>  
+                <p>{{t _collection_period}}</p>
                 <label class="collectedFrom">
                   {{view FLOW.DateField2 valueBinding="view.reportFromDate" class="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
                 </label>
@@ -57,7 +57,7 @@
           <h2>{{t _data_analysis_export}}</h2>
           <h6>{{t _not_importable_back}}</h6>
           <p class="expDescr">{{t _replaces_question}}</p>  
-          {{#view FLOW.ExportReportsAppletView dataAnalysisSection=true }}
+          {{#view FLOW.ExportReportsAppletView}}
             <div id="dataAnalyseExp_options" class="options">
               <div class="dataCollectedDate">
                 <p>{{t _collection_period}}</p>

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -16,6 +16,7 @@
         {{/if}}
       </nav>
     </div>
+  {{/view}}
     <script>
       function openExportOptions(evt, exportName) {
         var i, options, trigger;
@@ -30,50 +31,56 @@
         document.getElementById(exportName).style.display = "block";
         evt.currentTarget.className += " active";
        }
-    </script> 
+    </script>      
     <section class="exportContainer">
       <ul class="exportSelect">
         <li class="dataCleanExp trigger" onclick="openExportOptions(event, 'dataCleanExp_options')">
           <h2>{{t _data_cleaning_export}}</h2>
           <h6>{{t _importable_back_to_akvo_flow}}</h6>
           <p class="expDescr">{{t _combines_options}}</p>
+        {{#view FLOW.ExportReportsAppletView dataCleaningSection=true}}
           <div id="dataCleanExp_options" class="options">
               <div class="dataCollectedDate">
-                <p>{{t _collection_period}}</p>
+                <p>{{t _collection_period}}</p>  
                 <label class="collectedFrom">
-                  {{view FLOW.DateField minDate=false valueBinding="FLOW.dateControl.fromDate" elementId="from_date02" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
+                  {{view FLOW.DateField2 valueBinding="view.reportFromDate" elementId="from_date02" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
                 </label>
                 <label class="collectedTo">
-                  {{view FLOW.DateField minDate=false valueBinding="FLOW.dateControl.toDate" elementId="to_date02" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
+                  {{view FLOW.DateField2 valueBinding="view.reportToDate" elementId="to_date02" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
                 </label>
             </div>
             <a {{action showDataCleaningReport target="this"}} class="button trigger2">{{t _download}}</a>
           </div>
+        {{/view}}
         </li>
         <li class="dataAnalyseExp trigger" onclick="openExportOptions(event, 'dataAnalyseExp_options')">
           <h2>{{t _data_analysis_export}}</h2>
           <h6>{{t _not_importable_back}}</h6>
-          <p class="expDescr">{{t _replaces_question}}</p>
+          <p class="expDescr">{{t _replaces_question}}</p>  
+          {{#view FLOW.ExportReportsAppletView dataAnalysisSection=true }}
             <div id="dataAnalyseExp_options" class="options">
               <div class="dataCollectedDate">
                 <p>{{t _collection_period}}</p>
                 <label class="collectedFrom">
-                   {{view FLOW.DateField minDate=false valueBinding="FLOW.dateControl.fromDate" elementId="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
+                   {{view FLOW.DateField2 minDate=false valueBinding="view.reportFromDate" elementId="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
                 </label>
                 <label class="collectedTo">
-                  {{view FLOW.DateField minDate=false valueBinding="FLOW.dateControl.toDate" elementId="to_date" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
+                  {{view FLOW.DateField2 minDate=false valueBinding="view.reportToDate" elementId="to_date" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
                 </label>
               </div>
               <a {{action showDataAnalysisReport target="this"}} class="button trigger2">{{t _download}}</a>
             </div>
+          {{/view}}
           </li>
           <li class="compReportExp trigger"  onclick="openExportOptions(event, 'compReportExp_options')">
             <h2>{{t _comprehensive_report}}</h2>
             <h6>{{t _not_importable_back}}</h6>
             <p class="expDescr">{{t _summarizes_responses}}</p>
+            {{#view FLOW.ExportReportsAppletView}}
             <div id="compReportExp_options" class="options">
               <a {{action showComprehensiveReport target="this"}} class="button trigger2">{{t _download}}</a>
             </div>
+            {{/view}}
           </li>
           <li class="geoShapeDataExp trigger"  onclick="openExportOptions(event, 'geoShapeDataExp_options')">
             <h2>{{t _geoshape_data}}</h2>
@@ -89,21 +96,24 @@
                     promptBinding="Ember.STRINGS._select_question"}}
               {{/if}}
             </div>
+            {{#view FLOW.ExportReportsAppletView}}
             <div id="geoShapeDataExp_options" class="options">
               <a {{action showGeoshapeReport target="this"}} class="button trigger2">{{t _download}}</a>
-          </div>
+            </div>
+            {{/view}}
         </li>
         <li class="surveyFormExp trigger"  onclick="openExportOptions(event, 'surveyFormExp_options')">
           <h2>{{t _survey_form}}</h2>
           <p class="expDescr">{{t _printable}}</p>
+          {{#view FLOW.ExportReportsAppletView}}
           <div id="surveyFormExp_options" class="options">
             <a {{action showSurveyForm target="this"}} class="button trigger2">{{t _download}}</a>
               {{#if view.showSurveyFormApplet }}
                 {{view FLOW.surveyFormApplet}}
               {{/if}}
-        </div>
+          </div>
+          {{/view}}
       </li>
     </ul>
   </section>
-{{/view}}
 </section>

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -43,10 +43,10 @@
               <div class="dataCollectedDate">
                 <p>{{t _collection_period}}</p>  
                 <label class="collectedFrom">
-                  {{view FLOW.DateField2 valueBinding="view.reportFromDate" elementId="from_date02" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
+                  {{view FLOW.DateField2 valueBinding="view.reportFromDate" class="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
                 </label>
                 <label class="collectedTo">
-                  {{view FLOW.DateField2 valueBinding="view.reportToDate" elementId="to_date02" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
+                  {{view FLOW.DateField2 valueBinding="view.reportToDate" class="to_date" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
                 </label>
             </div>
             <a {{action showDataCleaningReport target="this"}} class="button trigger2">{{t _download}}</a>
@@ -62,10 +62,10 @@
               <div class="dataCollectedDate">
                 <p>{{t _collection_period}}</p>
                 <label class="collectedFrom">
-                   {{view FLOW.DateField2 minDate=false valueBinding="view.reportFromDate" elementId="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
+                   {{view FLOW.DateField2 minDate=false valueBinding="view.reportFromDate" class="from_date" placeholder="" placeholderBinding="Ember.STRINGS._collected_from" size=30}}
                 </label>
                 <label class="collectedTo">
-                  {{view FLOW.DateField2 minDate=false valueBinding="view.reportToDate" elementId="to_date" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
+                  {{view FLOW.DateField2 minDate=false valueBinding="view.reportToDate" class="to_date" placeholder="" placeholderBinding="Ember.STRINGS._to" size=30}}
                 </label>
               </div>
               <a {{action showDataAnalysisReport target="this"}} class="button trigger2">{{t _download}}</a>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Under the reports tab, when a user selected a date for the Data Cleaning section, the same date would show up under the data analysis section.
#### The solution
Changed from DateField to DateField2 in export-reports.handlebars in order to use an abstract function for the datepicker.
Changed from one instance of exportReportAppletView in the template to multiple instances for each report section
Added reportFromDate and reportToDate properties in exportReportAppletView and set them as the valueBinding for the date input fields  in the template
Added observers for reportFromDate and reportToDate inorder to change the min  and maxDates for the datepickers 
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
