### PR TITLE
Fix data point shown in wrong location (connect #2518)

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
+++ b/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
@@ -222,7 +222,6 @@ public class SurveyalRestServlet extends AbstractRestApiServlet {
      * surveyInstance. This method is unlikely to run in under 1 minute (based on datastore latency)
      * so it is best invoked via a task queue
      *
-     * @param surveyInstanceId
      */
     private void ingestSurveyInstance(SurveyInstance surveyInstance) {
         Boolean adaptClusterData = Boolean.FALSE;
@@ -235,14 +234,9 @@ public class SurveyalRestServlet extends AbstractRestApiServlet {
                     + "for SurveyInstance " + surveyInstance.toString());
         }
 
-        // try to construct geoPlace. Geo information can come from two sources:
-        // 1) the META_GEO information in the surveyInstance, and
-        // 2) a geo question.
-        // If we can't find geo information in 1), we try 2)
-
         GeoPlace geoPlace = null;
-        Double latitude = UNSET_VAL;
-        Double longitude = UNSET_VAL;
+        Double latitude;
+        Double longitude;
         Map<String, Object> geoLocationMap = null;
 
         try {

--- a/GAE/src/org/waterforpeople/mapping/domain/SurveyInstance.java
+++ b/GAE/src/org/waterforpeople/mapping/domain/SurveyInstance.java
@@ -16,6 +16,22 @@
 
 package org.waterforpeople.mapping.domain;
 
+import com.gallatinsystems.device.domain.DeviceFiles;
+import com.gallatinsystems.framework.domain.BaseDomain;
+import com.gallatinsystems.gis.map.MapUtils;
+import com.gallatinsystems.survey.dao.QuestionDao;
+import com.gallatinsystems.survey.dao.SurveyDAO;
+import com.gallatinsystems.survey.domain.Question;
+import org.akvo.flow.domain.DataUtils;
+import org.akvo.flow.domain.SecuredObject;
+import org.apache.commons.lang.StringUtils;
+import org.waterforpeople.mapping.analytics.dao.SurveyQuestionSummaryDao;
+import org.waterforpeople.mapping.analytics.domain.SurveyQuestionSummary;
+
+import javax.jdo.annotations.IdentityType;
+import javax.jdo.annotations.NotPersistent;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,26 +39,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.jdo.annotations.IdentityType;
-import javax.jdo.annotations.NotPersistent;
-import javax.jdo.annotations.PersistenceCapable;
-import javax.jdo.annotations.Persistent;
-
-import org.akvo.flow.domain.DataUtils;
-import org.akvo.flow.domain.SecuredObject;
-import org.apache.commons.lang.StringUtils;
-import org.waterforpeople.mapping.analytics.dao.SurveyQuestionSummaryDao;
-import org.waterforpeople.mapping.analytics.domain.SurveyQuestionSummary;
-import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto.QuestionType;
-import org.waterforpeople.mapping.dao.SurveyInstanceDAO;
-
-import com.gallatinsystems.device.domain.DeviceFiles;
-import com.gallatinsystems.framework.domain.BaseDomain;
-import com.gallatinsystems.gis.map.MapUtils;
-import com.gallatinsystems.survey.dao.QuestionDao;
-import com.gallatinsystems.survey.dao.SurveyDAO;
-import com.gallatinsystems.survey.domain.Question;
 
 import static com.gallatinsystems.common.Constants.MAX_LENGTH;
 
@@ -256,7 +252,6 @@ public class SurveyInstance extends BaseDomain implements SecuredObject {
     /**
      * Extract geolocation information from a survey instance
      *
-     * @param surveyInstance
      * @return a map containing latitude and longitude entries null if a null string is provided
      */
     public static Map<String, Object> retrieveGeoLocation(
@@ -268,25 +263,13 @@ public class SurveyInstance extends BaseDomain implements SecuredObject {
         // if the GEO information was present as Meta data, get it from there
         if (StringUtils.isNotBlank(surveyInstance.getLocaleGeoLocation())) {
             geoLocationString = surveyInstance.getLocaleGeoLocation();
-        } else {
-            // else, try to look for a GEO question
-            List<QuestionAnswerStore> geoAnswers = new SurveyInstanceDAO()
-                    .listQuestionAnswerStoreByType(surveyInstance.getKey()
-                            .getId(), QuestionType.GEO.toString());
-            if (geoAnswers != null && !geoAnswers.isEmpty()) {
-                geoLocationString = geoAnswers.get(0).getValue();
-            }
         }
 
         String[] tokens = StringUtils.split(geoLocationString, "\\|");
         if (tokens != null && tokens.length >= 2) {
-            geoLocationMap = new HashMap<String, Object>();
+            geoLocationMap = new HashMap<>();
             geoLocationMap.put(MapUtils.LATITUDE, Double.parseDouble(tokens[0]));
             geoLocationMap.put(MapUtils.LONGITUDE, Double.parseDouble(tokens[1]));
-            // if(tokens.length > 2) {
-            // TODO: currently a string is generated for altitude. need to fix
-            // geoLocationMap.put(ALTITUDE, Long.parseLong(tokens[2]));
-            // }
         }
 
         return geoLocationMap;

--- a/GAE/src/org/waterforpeople/mapping/domain/SurveyInstance.java
+++ b/GAE/src/org/waterforpeople/mapping/domain/SurveyInstance.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2016 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2016,2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Data point geo location gets overriden when another question has a geolocation data even if it does not belong to the registration form
#### The solution
For the datapoint location, only use the geolocation data from a registration form and only if it is set as "use as datapoint location".
I have been digging and found where the SurveyedLocale geolocation gets updated but I am not sure I did not introduce any side effects. Would appreciate any extra suggestion.
#### Screenshots (if appropriate)
NA
## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
