### PR TITLE
[#839]Caseless search for existing variable names. (Connect #839)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -346,7 +346,7 @@ public class QuestionRestService {
         Map<String, Object> result = new HashMap<String, Object>();
 
         for (Question q : questions) {
-            if (variableName.equals(q.getVariableName())
+            if (variableName.equalsIgnoreCase(q.getVariableName())
                     && !question.getKey().equals(q.getKey())) {
                 result.put("success", false);
                 result.put("reason", "Variable name not unique");


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
You could have two questions with variable names like "age" and "Age" at the same time.
#### The solution
Do a caseless compare when checking for already-existing variable names.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
