### PR TITLE
Stop autochecking "Use as data point location" (Connect #2517)

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -153,13 +153,6 @@ FLOW.QuestionView = FLOW.View.extend({
         || this.type.get('value') == 'CASCADE';
   }.property('this.type').cacheable(),
 
-  // when we change the question type to GEO, we turn on the
-  // localeLocationFLag by default. If we change to something else, we
-  // turn the flag of.
-  enableLocaleLocation: function() {
-    this.set('localeLocationFlag', this.type.get('value') == 'GEO');
-  }.observes('this.type'),
-
   // TODO dependencies
   // TODO options
   doQuestionEdit: function () {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Geolocation questions having the locale flag toggled by default regardless of whether or not user had unchecked "Use as data point location"
#### The solution
Remove code responsible for this
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
