### PR TITLE
Fix alignment of the answers on the monitoring tab (connect #2387)

### DIFF
--- a/Dashboard/app/js/templates/navData/question-answer.handlebars
+++ b/Dashboard/app/js/templates/navData/question-answer.handlebars
@@ -1,7 +1,7 @@
 <tr>
     <td class="device" style="width:10%">{{view.question.order}}</td>
     <td class="survey" style="text-align:left;width:40%">{{view.question.text}}</td>
-    <td {{bindAttr class=":submitter view.isMultipleSelectOption:multiple-option"}}>
+    <td {{bindAttr class=":submitter view.isMultipleSelectOption:multiple-option"}} style="text-align:left">
         {{#if view.inEditMode}}
             {{#if view.isOptionType}}
                     {{#if view.isMultipleSelectOption}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Both views are however quite inconsistent in how we show a form submission. In the Inspect data tab we show question groups and the questions that belong in them. In Monitoring tab we do not and the questions seem to appear in a random order.
#### The solution
The  repeated question groups are also shown properly with the repetition number.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
