### PR TITLE
Indicate form must be selected in exports page 2 (connect #2380)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3337,6 +3337,13 @@ div.chooseSurveyData {
     }
 }
 
+.redErrorBorder {
+    border-style: solid;
+    border-width: 1px;
+    border-color: red;
+    width: 98%;
+}
+
 .filterData {
     border-top: 1px solid white;
     .dataDeviceId {

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -49,6 +49,10 @@ FLOW.ReportLoader = Ember.Object.create({
       return;
     }
 
+    if (!surveyId) {
+      return;
+    }
+
     Ember.assert('exportType param is required', exportType !== undefined);
     Ember.assert('surveyId param is required', surveyId !== undefined);
 
@@ -158,6 +162,8 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
   showComprehensiveDialog: false,
   showRawDataImportApplet: false,
   showGoogleEarthButton: false,
+  missingSurvey: false,
+  downloadCall: false,
 
   didInsertElement: function () {
     FLOW.selectedControl.set('surveySelection', FLOW.SurveySelection.create());
@@ -185,45 +191,52 @@ FLOW.ExportReportsAppletView = FLOW.View.extend({
     }
   }.property('FLOW.selectedControl.selectedQuestion'),
 
+  checkSurveySelection: function() {
+    if (this.get("downloadCall")) {
+      if (!this.get('selectedSurvey')){
+        this.set('missingSurvey',true);
+      } else {
+          this.set('missingSurvey',false);
+      }
+    }
+      this.set("downloadCall", false);
+  }.observes("this.downloadCall"),
+
   showLastCollection: function () {
     return FLOW.Env.showMonitoringFeature && FLOW.selectedControl.selectedSurveyGroup && FLOW.selectedControl.selectedSurveyGroup.get('monitoringGroup');
   }.property('FLOW.selectedControl.selectedSurveyGroup'),
 
   showDataCleaningReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
-	FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
+    this.set('downloadCall', true)
+	  var opts = {}, sId = this.get('selectedSurvey');
+	  FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
 
   showDataAnalysisReport: function () {
-	var opts = {}, sId = this.get('selectedSurvey');
+    this.set('downloadCall', true)
+	  var opts = {}, sId = this.get('selectedSurvey');
     FLOW.ReportLoader.load('DATA_ANALYSIS', sId, opts);
   },
 
   showComprehensiveReport: function () {
+    this.set('downloadCall', true)
     var opts = {}, sId = this.get('selectedSurvey');
-
     FLOW.ReportLoader.load('COMPREHENSIVE', sId, opts);
   },
 
   showGeoshapeReport: function () {
+    this.set('downloadCall', true)
     var sId = this.get('selectedSurvey');
     var qId = this.get('selectedQuestion');
-    if (!sId || !qId) {
-      this.showWarningMessage(
-        Ember.String.loc('_export_data'),
-        Ember.String.loc('_select_survey_and_geoshape_question_warning')
-      );
+    if (!qId) {
       return;
     }
     FLOW.ReportLoader.load('GEOSHAPE', sId, {"questionId": qId});
   },
 
   showSurveyForm: function () {
-	var sId = this.get('selectedSurvey');
-    if (!sId) {
-      this.showWarning();
-      return;
-    }
+    this.set('downloadCall', true)
+	  var sId = this.get('selectedSurvey');
     FLOW.ReportLoader.load('SURVEY_FORM', sId);
   },
 

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -1,6 +1,6 @@
 <section class="fullWidth reportTools" id="reportBlocks">
   {{#view FLOW.ExportReportsAppletView}}
-    <div class="surveySelect">
+    <div {{bindAttr class=":surveySelect view.missingSurvey:redErrorBorder"}}>
       <nav class="breadCrumb floats-in">
         {{#unless FLOW.projectControl.isLoading}}
           {{view FLOW.SurveySelectionView}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Under the export reports tab, if one of the download options was selected without first selecting the survey:
-Data cleaning export: nothing would happen
-Data analysis export: a pop up dialog with the message error generating report would be displayed
-Comprehensive report: a pop up dialog with the message 'your report is being prepared' would be displayed
-Geoshape data: a pop up dialog with the message 'please select a form and a geoshape question' would be displayed
-Survey Form: a pop up dialog with the message 'you must select a survey to run a report' would be displayed
The forwarded solution was to highlight the entire survey selection area when a survey wasn't selected
#### The solution
Added a property 'downloadCall' that is set to true when any of the functions dealing with downloading reports is called 
Created an observer for downloadCall, when downloadCall is true, the value of the selectedSurvey is checked, if it is null, a property 'missingSurvey' is set to true
Missing survey is a property used to add a redError border dynamically in the handlebars  template
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
