### PR TITLE
Remove unnecessary setter (connect #2421)

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/domain/Question.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Question.java
@@ -21,7 +21,6 @@ import com.gallatinsystems.framework.domain.BaseDomain;
 import javax.jdo.annotations.NotPersistent;
 import javax.jdo.annotations.PersistenceCapable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -181,12 +180,6 @@ public class Question extends BaseDomain {
 
     public void setTranslationMap(Map<String, Translation> translationMap) {
         this.translationMap = translationMap;
-    }
-
-    public void setTranslationMap(HashMap<String, Translation> transMap) {
-        if (transMap != null) {
-            translationMap = new TreeMap<String, Translation>(transMap);
-        }
     }
 
     public void addQuestionOption(QuestionOption questionOption) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The extra setter method `Question.setTranslationMap()` resulted in an exception because the property was not properly ignored.

#### The solution

* Remove the extra setter.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
