### PR TITLE
Fixed layout issue in manual survey transfer tab(connect #2276)

### DIFF
--- a/Dashboard/app/js/templates/navDevices/bootstrap-tab/survey-bootstrap.handlebars
+++ b/Dashboard/app/js/templates/navDevices/bootstrap-tab/survey-bootstrap.handlebars
@@ -2,7 +2,8 @@
 <section class="fullWidth manualTransfer" id="assignSurveys">
     <form>
       <div class="fieldSetWrap floats-in">
-        <fieldset id="surveySelect" class="formLeftPanel floats-in">
+      <div class="formLeftPanel">
+        <fieldset id="surveySelect" class="floats-in">
           <h2>01. {{t _select_survey}}:</h2>
           <span class="infoText">{{t _cant_find_your_survey_}}</span>
           <div class="">
@@ -30,7 +31,9 @@
       <a {{action addSelectedSurveys target="this"}}  class="AddBtn">{{t _add_selected_forms}}</a>
           </div>
         </fieldset>
-        <fieldset id="surveyPreview" class="formRightPanel">
+      </div>
+      <div class="formRightPanel">
+        <fieldset id="surveyPreview" class="floats-in">
           <h2>{{t _preview_survey_selection}}:</h2>
           <div class="">
             <!-- DEVICES TABLE-->
@@ -62,6 +65,7 @@
             </table>
           </div>
         </fieldset>
+      </div>
       </div>
 
     <div class="fieldSetWrap makeWhite noBG">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Under the manual survey transfer tab (under Devices) , Select Survey and Preview Survey Selection were on opposites sides of the page. Preview Survey Selection is supposed to float next to survey selection section
#### The solution
Added enclosing div tags around the fieldset tags  for select survey and previewSurvey . Transferred classes affecting alignment from the fieldset tags to the div tags.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
