### PR TITLE
 Submission lists remain on monitoring tab after navigation(connect #2531)

### DIFF
--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -98,6 +98,10 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
   hasPrevPage: function () {
     return FLOW.router.surveyedLocaleController.get('pageNumber');
   }.property('FLOW.router.surveyedLocaleController.pageNumber'),
+  
+  willDestroyElement: function () {
+    FLOW.router.surveyedLocaleController.set('currentContents', null)
+  }
 });
 
 /**

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -100,7 +100,9 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
   }.property('FLOW.router.surveyedLocaleController.pageNumber'),
   
   willDestroyElement: function () {
-    FLOW.router.surveyedLocaleController.set('currentContents', null)
+    FLOW.router.surveyedLocaleController.set('currentContents', null);
+    FLOW.metaControl.set('numSLLoaded',null)
+    FLOW.router.surveyedLocaleController.set('pageNumber',0)
   }
 });
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Similar to this issue: https://github.com/akvo/akvo-flow/issues/2372 the same happens for the Monitoring tab. The expectation is that once I go away from the Monitoring tab and then come back I will have no data points listed in the screen as I have not selected my survey yet and hit find. 
#### The solution
Once the user navigates to another page in Flow, the list of submissions does not show if he  comes back to the monitoring data  tab.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
