### PR TITLE
Added Pijin and Tok Pisin to list of languages in form translations(connect #2202)

### DIFF
--- a/Dashboard/app/js/lib/controllers/languages.js
+++ b/Dashboard/app/js/lib/controllers/languages.js
@@ -499,6 +499,10 @@ FLOW.isoLanguagesDict = {
     "name": "Persian",
     "nativeName": "فارسی"
   },
+  "pis": {
+    "name": "Pijin",
+    "nativeName": "Pijin"
+  },
   "pl": {
     "name": "Polish",
     "nativeName": "polski"
@@ -634,6 +638,10 @@ FLOW.isoLanguagesDict = {
   "bo": {
     "name": "Tibetan Standard, Tibetan, Central",
     "nativeName": "བོད་ཡིག"
+  },
+  "tpi": {
+    "name": "Tok Pisin",
+    "nativeName": "Tok Pisin"
   },
   "tk": {
     "name": "Turkmen",


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Pijin and Tok Pisin languages were not available in the list of languages under form translations
#### The solution
Added Pijin and Tok Pisin to the languages object, FLOW.isoLangiagesDict in controllers/languages.js file.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
