### PR TITLE
Bulk reorder questions and question groups (connect #1393 #2523)

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -896,18 +896,10 @@ FLOW.questionControl = Ember.ArrayController.create({
     qOrder = question.get('order');
     question.deleteRecord();
 
-    // restore order
-    questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
-      return item.get('questionGroupId') == qgId;
-    });
+    //reorder the rest of the questions
+    FLOW.questionControl.reorderQuestions(qgId, qOrder, "up");
+    FLOW.questionControl.submitBulkQuestionsReorder([qgId]);
 
-    questionsInGroup.forEach(function (item) {
-      if (item.get('order') > qOrder) {
-        item.set('order', item.get('order') - 1);
-      }
-    });
-    // restore order in case the order has gone haywire
-    this.restoreOrder(questionsInGroup);
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();
   },

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1014,7 +1014,7 @@ FLOW.questionControl = Ember.ArrayController.create({
 
   submitBulkQuestionGroupsReorder: function (surveyId) {
     this.set('bulkCommit', true);
-    var questionGroupsInSurvey = FLOW.store.filter(FLOW.Question, function (item) {
+    var questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
       return item.get('surveyId') == surveyId;
     });
     // restore order in case the order has gone haywire

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -979,7 +979,6 @@ FLOW.questionControl = Ember.ArrayController.create({
   }.observes('FLOW.selectedControl.selectedQuestion'),
 
   reorderQuestions: function (qgId, reorderPoint, reorderDirection) {
-    FLOW.store.adapter.set('bulkCommit', true);
     var questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
       return item.get('questionGroupId') == qgId;
     });
@@ -996,14 +995,20 @@ FLOW.questionControl = Ember.ArrayController.create({
         }
       }
     });
+  },
 
-    questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
-      return item.get('questionGroupId') == qgId;
-    });
-    // restore order in case the order has gone haywire
-    FLOW.questionControl.restoreOrder(questionsInGroup);
+  submitBulkQuestionsReorder: function (qgIds) {
+    this.set('bulkCommit', true);
+    for (var i=0; i>qgIds.length; i++) {
+      var questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
+        return item.get('questionGroupId') == qgIds[i];
+      });
+      // restore order in case the order has gone haywire
+      FLOW.questionControl.restoreOrder(questionsInGroup);
+    }
     FLOW.store.commit();
     FLOW.store.adapter.set('bulkCommit', false);
+    this.set('bulkCommit', false);
   },
 
   reorderQuestionGroups: function (surveyId, reorderPoint, reorderDirection) {

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -850,6 +850,7 @@ FLOW.questionControl = Ember.ArrayController.create({
   sortProperties: ['order'],
   sortAscending: true,
   preflightQId: null,
+  bulkCommit: false,
 
   populateAllQuestions: function () {
     var sId;

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -977,6 +977,33 @@ FLOW.questionControl = Ember.ArrayController.create({
     }
   }.observes('FLOW.selectedControl.selectedQuestion'),
 
+  reorderQuestions: function (qgId, reorderPoint, reorderDirection) {
+    FLOW.store.adapter.set('bulkCommit', true);
+    var questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
+      return item.get('questionGroupId') == qgId;
+    });
+
+    // move items up to make space
+    questionsInGroup.forEach(function (item) {
+      if (reorderDirection == "down") {
+        if (item.get('order') > reorderPoint) {
+          item.set('order', item.get('order') + 1);
+        }
+      } else if (reorderDirection == "up") {
+        if (item.get('order') > reorderPoint) {
+          item.set('order', item.get('order') - 1);
+        }
+      }
+    });
+
+    questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
+      return item.get('questionGroupId') == qgId;
+    });
+    // restore order in case the order has gone haywire
+    FLOW.questionControl.restoreOrder(questionsInGroup);
+    FLOW.store.commit();
+    FLOW.store.adapter.set('bulkCommit', false);
+  },
 
 
   // true if all items have been saved

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1020,8 +1020,6 @@ FLOW.questionControl = Ember.ArrayController.create({
         }
       }
     });
-
-    this.submitBulkQuestionGroupsReorder(surveyId);
   },
 
   submitBulkQuestionGroupsReorder: function (surveyId) {

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1005,6 +1005,34 @@ FLOW.questionControl = Ember.ArrayController.create({
     FLOW.store.adapter.set('bulkCommit', false);
   },
 
+  reorderQuestionGroups: function (surveyId, reorderPoint, reorderDirection) {
+    FLOW.store.adapter.set('bulkCommit', true);
+    var questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
+      return item.get('surveyId') == surveyId;
+    });
+
+    // move items up to make space
+    questionGroupsInSurvey.forEach(function (item) {
+      if (reorderDirection == "down") {
+        if (item.get('order') > reorderPoint) {
+          item.set('order', item.get('order') + 1);
+        }
+      } else if (reorderDirection == "up") {
+        if (item.get('order') > reorderPoint) {
+          item.set('order', item.get('order') - 1);
+        }
+      }
+    });
+
+    questionGroupsInSurvey = FLOW.store.filter(FLOW.Question, function (item) {
+      return item.get('surveyId') == surveyId;
+    });
+    // restore order in case the order has gone haywire
+    FLOW.questionControl.restoreOrder(questionGroupsInSurvey);
+    FLOW.store.commit();
+    FLOW.store.adapter.set('bulkCommit', false);
+  },
+
 
   // true if all items have been saved
   // used in models.js

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -821,20 +821,10 @@ FLOW.questionGroupControl = Ember.ArrayController.create({
 
     questionGroup.deleteRecord();
 
-    // restore order of remaining groups
-    questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
-      return item.get('surveyId') == sId;
-    });
+    // reorder the rest of the question groups
+    FLOW.questionControl.reorderQuestionGroups(sId, qgOrder, "up");
+    FLOW.questionControl.submitBulkQuestionGroupsReorder(sId);
 
-    // restore order
-    questionGroupsInSurvey.forEach(function (item) {
-      if (item.get('order') > qgOrder) {
-        item.set('order', item.get('order') - 1);
-      }
-    });
-
-    // restore order in case the order has gone haywire
-    FLOW.questionControl.restoreOrder(questionGroupsInSurvey);
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();
   }

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -1012,7 +1012,6 @@ FLOW.questionControl = Ember.ArrayController.create({
   },
 
   reorderQuestionGroups: function (surveyId, reorderPoint, reorderDirection) {
-    FLOW.store.adapter.set('bulkCommit', true);
     var questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
       return item.get('surveyId') == surveyId;
     });
@@ -1030,13 +1029,19 @@ FLOW.questionControl = Ember.ArrayController.create({
       }
     });
 
-    questionGroupsInSurvey = FLOW.store.filter(FLOW.Question, function (item) {
+    this.submitBulkQuestionGroupsReorder(surveyId);
+  },
+
+  submitBulkQuestionGroupsReorder: function (surveyId) {
+    this.set('bulkCommit', true);
+    var questionGroupsInSurvey = FLOW.store.filter(FLOW.Question, function (item) {
       return item.get('surveyId') == surveyId;
     });
     // restore order in case the order has gone haywire
     FLOW.questionControl.restoreOrder(questionGroupsInSurvey);
     FLOW.store.commit();
     FLOW.store.adapter.set('bulkCommit', false);
+    this.set('bulkCommit', false);
   },
 
 

--- a/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
+++ b/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
@@ -241,5 +241,34 @@ DS.FLOWRESTAdapter = DS.RESTAdapter.extend({
         this.didUpdateRecords(store, type, records, json);
       }
     });
+  },
+
+  deleteRecords: function(store, type, records) {
+    //do not bulk commit when deleting questions and question groups
+    if (FLOW.questionControl.get('bulkCommit')) {
+      this.set('bulkCommit', false);
+    }
+
+    if (get(this, 'bulkCommit') === false) {
+      return this._super(store, type, records);
+    }
+
+    var root = this.rootForType(type),
+        plural = this.pluralize(root),
+        serializer = get(this, 'serializer');
+
+    var data = {};
+    data[plural] = [];
+    records.forEach(function(record) {
+      data[plural].push(serializer.serializeId( get(record, 'id') ));
+    });
+
+    this.ajax(this.buildURL(root, 'bulk'), "DELETE", {
+      data: data,
+      context: this,
+      success: function(json) {
+        this.didDeleteRecords(store, type, records, json);
+      }
+    });
   }
 });

--- a/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
+++ b/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
@@ -193,14 +193,22 @@ DS.FLOWRESTAdapter = DS.RESTAdapter.extend({
       plural = this.pluralize(root);
 
     var data = {};
-    data[plural] = [];
-    records.forEach(function (record) {
-      data[plural].push(this.serialize(record, {
-        includeId: true
-      }));
-    }, this);
-
-    this.ajax(this.buildURL(root, 'bulk'), "POST", {
+    if (root === "question") {
+      data[root] = {};
+      records.forEach(function (record) {
+        data[root] = this.serialize(record, {
+          includeId: true
+        });
+      }, this);
+    } else {
+      data[plural] = [];
+      records.forEach(function (record) {
+        data[plural].push(this.serialize(record, {
+          includeId: true
+        }));
+      }, this);
+    }
+    this.ajax(this.buildURL(root, (root === "question") ? '' : 'bulk'), "POST", {
       data: data,
       context: this,
       success: function (json) {

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -713,7 +713,7 @@ FLOW.QuestionView = FLOW.View.extend({
       "questionGroupId": qgId
     });
 
-    // restore order
+    // reorder the rest of the questions
     FLOW.questionControl.reorderQuestions(qgId, insertAfterOrder, "down");
 
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -584,18 +584,19 @@ FLOW.QuestionView = FLOW.View.extend({
         qgIdSource = FLOW.selectedControl.selectedForMoveQuestion.get('questionGroupId');
         qgIdDest = FLOW.selectedControl.selectedQuestionGroup.get('keyId');
 
+        // restore order
+        FLOW.questionControl.reorderQuestions(qgIdSource, selectedOrder, "up");
+        FLOW.questionControl.reorderQuestions(qgIdDest, insertAfterOrder, "down");
+
         // move question
         selectedQ.set('order', insertAfterOrder + 1);
         selectedQ.set('questionGroupId', qgIdDest);
 
-        // restore order
-        FLOW.questionControl.reorderQuestions(qgIdSource, selectedOrder, "up");
-        FLOW.questionControl.reorderQuestions(qgIdDest, insertAfterOrder, "down");
+        FLOW.questionControl.submitBulkQuestionsReorder([qgIdSource, qgIdDest]);
       }
     // if we are not moving to another group, we must be moving inside a group
     // only do something if we are not moving to the same place
     } else if (!((selectedOrder == insertAfterOrder) || (selectedOrder == (insertAfterOrder + 1)))) {
-      FLOW.store.adapter.set('bulkCommit', true);
       selectedQ = FLOW.store.find(FLOW.Question, FLOW.selectedControl.selectedForMoveQuestion.get('keyId'));
       if (selectedQ !== null) {
         // restore order
@@ -629,17 +630,11 @@ FLOW.QuestionView = FLOW.View.extend({
           }
         });
 
-        questionsInGroup = FLOW.store.filter(FLOW.Question, function (item) {
-        	return item.get('questionGroupId') == qgId;
-       	});
-
-        // restore order in case the order has gone haywire
-        FLOW.questionControl.restoreOrder(questionsInGroup);
+        FLOW.questionControl.submitBulkQuestionsReorder([qgId]);
       }
     }
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();
-    FLOW.store.adapter.set('bulkCommit', false);
     FLOW.selectedControl.set('selectedForMoveQuestion', null);
   },
 
@@ -664,6 +659,9 @@ FLOW.QuestionView = FLOW.View.extend({
     // restore order
     qgId = FLOW.selectedControl.selectedQuestionGroup.get('keyId');
 
+    // restore order
+    FLOW.questionControl.reorderQuestions(qgId, insertAfterOrder, "down");
+
     question = FLOW.selectedControl.get('selectedForCopyQuestion');
     // create copy of Question item in the store
     FLOW.store.createRecord(FLOW.Question, {
@@ -673,12 +671,10 @@ FLOW.QuestionView = FLOW.View.extend({
       "sourceId":question.get('keyId')
     });
 
-    // restore order
-    FLOW.questionControl.reorderQuestions(qgId, insertAfterOrder, "down");
+    FLOW.questionControl.submitBulkQuestionsReorder([qgId]);
 
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();
-
     FLOW.selectedControl.set('selectedForCopyQuestion', null);
   },
 
@@ -703,6 +699,9 @@ FLOW.QuestionView = FLOW.View.extend({
 
     qgId = FLOW.selectedControl.selectedQuestionGroup.get('keyId');
 
+    // reorder the rest of the questions
+    FLOW.questionControl.reorderQuestions(qgId, insertAfterOrder, "down");
+
     // create new Question item in the store
     FLOW.store.createRecord(FLOW.Question, {
       "order": insertAfterOrder + 1,
@@ -713,8 +712,7 @@ FLOW.QuestionView = FLOW.View.extend({
       "questionGroupId": qgId
     });
 
-    // reorder the rest of the questions
-    FLOW.questionControl.reorderQuestions(qgId, insertAfterOrder, "down");
+    FLOW.questionControl.submitBulkQuestionsReorder([qgId]);
 
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();

--- a/Dashboard/app/js/lib/views/surveys/survey-details-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-details-views.js
@@ -384,6 +384,9 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
       // restore order
       sId = FLOW.selectedControl.selectedSurvey.get('keyId');
 
+      // reorder the rest of the question groups
+      FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
+
       // create new QuestionGroup item in the store
       FLOW.store.createRecord(FLOW.QuestionGroup, {
         "code": Ember.String.loc('_new_group_please_change_name'),
@@ -394,8 +397,7 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
         "surveyId": FLOW.selectedControl.selectedSurvey.get('keyId')
       });
 
-      // reorder the rest of the question groups
-      FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
+      FLOW.questionControl.submitBulkQuestionGroupsReorder(sId);
 
       FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
       FLOW.store.commit();
@@ -543,6 +545,9 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
 
     sId = FLOW.selectedControl.selectedSurvey.get('keyId');
 
+    // restore order
+    FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
+
     FLOW.store.createRecord(FLOW.QuestionGroup, {
       "order": insertAfterOrder + 1,
       "code": FLOW.selectedControl.selectedForCopyQuestionGroup.get('code'),
@@ -554,8 +559,7 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
       "repeatable":FLOW.selectedControl.selectedForCopyQuestionGroup.get('repeatable')
     });
 
-    // restore order
-    FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
+    FLOW.questionControl.submitBulkQuestionGroupsReorder(sId);
 
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();

--- a/Dashboard/app/js/lib/views/surveys/survey-details-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-details-views.js
@@ -371,7 +371,7 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
 
   // insert group
   doInsertQuestionGroup: function () {
-    var insertAfterOrder, path, sId, questionGroupsInSurvey;
+    var insertAfterOrder, path, sId;
     path = FLOW.selectedControl.selectedSurveyGroup.get('code') + "/" + FLOW.selectedControl.selectedSurvey.get('name');
     if (FLOW.selectedControl.selectedSurvey.get('keyId')) {
 
@@ -383,16 +383,6 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
 
       // restore order
       sId = FLOW.selectedControl.selectedSurvey.get('keyId');
-      questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
-        return item.get('surveyId') == sId;
-      });
-
-      // move items up to make space
-      questionGroupsInSurvey.forEach(function (item) {
-        if (item.get('order') > insertAfterOrder) {
-          item.set('order', item.get('order') + 1);
-        }
-      });
 
       // create new QuestionGroup item in the store
       FLOW.store.createRecord(FLOW.QuestionGroup, {
@@ -404,13 +394,8 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
         "surveyId": FLOW.selectedControl.selectedSurvey.get('keyId')
       });
 
-      // get the question groups again, now it contains the new one as well
-      questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
-        return item.get('surveyId') == sId;
-      });
-
-      // restore order in case the order has gone haywire
-      FLOW.questionControl.restoreOrder(questionGroupsInSurvey);
+      // reorder the rest of the question groups
+      FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
 
       FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
       FLOW.store.commit();
@@ -548,7 +533,7 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
 
   // execute group copy to selected location
   doQGroupCopyHere: function () {
-    var insertAfterOrder, path, sId, questionGroupsInSurvey;
+    var insertAfterOrder, path, sId;
     path = FLOW.selectedControl.selectedSurveyGroup.get('code') + "/" + FLOW.selectedControl.selectedSurvey.get('name');
 
     if (this.get('zeroItem')) {
@@ -558,16 +543,6 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
     }
 
     sId = FLOW.selectedControl.selectedSurvey.get('keyId');
-    questionGroupsInSurvey = FLOW.store.filter(FLOW.QuestionGroup, function (item) {
-      return item.get('surveyId') === sId;
-    });
-
-    // restore order - move items up to make space
-    questionGroupsInSurvey.forEach(function (item) {
-      if (item.get('order') > insertAfterOrder) {
-        item.set('order', item.get('order') + 1);
-      }
-    });
 
     FLOW.store.createRecord(FLOW.QuestionGroup, {
       "order": insertAfterOrder + 1,
@@ -579,6 +554,9 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
       "sourceId":FLOW.selectedControl.selectedForCopyQuestionGroup.get('keyId'),
       "repeatable":FLOW.selectedControl.selectedForCopyQuestionGroup.get('repeatable')
     });
+
+    // restore order
+    FLOW.questionControl.reorderQuestionGroups(sId, insertAfterOrder, "down");
 
     FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
     FLOW.store.commit();

--- a/Dashboard/app/js/lib/views/surveys/survey-details-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-details-views.js
@@ -481,8 +481,7 @@ FLOW.QuestionGroupItemView = FLOW.View.extend({
           }
         });
 
-        // restore order in case the order has gone haywire
-        FLOW.questionControl.restoreOrder(questionGroupsInSurvey);
+        FLOW.questionControl.submitBulkQuestionGroupsReorder(sId);
 
         FLOW.selectedControl.selectedSurvey.set('status', 'NOT_PUBLISHED');
         FLOW.store.commit();

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -31,13 +31,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
 import org.waterforpeople.mapping.app.web.dto.DataProcessorRequest;
 import org.waterforpeople.mapping.app.web.dto.SurveyTaskRequest;
 import org.waterforpeople.mapping.app.web.rest.dto.QuestionGroupListPayload;
 import org.waterforpeople.mapping.app.web.rest.dto.QuestionGroupPayload;
-import org.waterforpeople.mapping.app.web.rest.dto.QuestionListPayload;
 import org.waterforpeople.mapping.app.web.rest.dto.RestStatusDto;
 import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
 
@@ -55,7 +53,6 @@ import com.google.appengine.api.taskqueue.TaskOptions;
 @Controller
 @RequestMapping("/question_groups")
 public class QuestionGroupRestService {
-
     private QuestionGroupDao questionGroupDao = new QuestionGroupDao();
 
     private QuestionDao questionDao = new QuestionDao();

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2017 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2012-2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -260,9 +260,8 @@ public class QuestionGroupRestService {
                         if (qg != null) {
                             // copy the properties, except the createdDateTime property,
                             // because it is set in the Dao.
-                            BeanUtils.copyProperties(questionGroupDto, qg, new String[] {
-                                    "createdDateTime"
-                            });
+                            BeanUtils.copyProperties(questionGroupDto, qg,
+                                    new String[] {"createdDateTime", "status"});
                             qg = questionGroupDao.save(qg);
         
                         } else { //missing in db - fail

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -31,10 +31,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
 import org.waterforpeople.mapping.app.web.dto.DataProcessorRequest;
 import org.waterforpeople.mapping.app.web.dto.SurveyTaskRequest;
+import org.waterforpeople.mapping.app.web.rest.dto.QuestionGroupListPayload;
 import org.waterforpeople.mapping.app.web.rest.dto.QuestionGroupPayload;
+import org.waterforpeople.mapping.app.web.rest.dto.QuestionListPayload;
 import org.waterforpeople.mapping.app.web.rest.dto.RestStatusDto;
 import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
 
@@ -228,6 +231,56 @@ public class QuestionGroupRestService {
         }
         response.put("meta", statusDto);
         response.put("question_group", dto);
+        return response;
+    }
+
+    // update several existing question groups
+    @RequestMapping(method = RequestMethod.PUT, value = "/bulk")
+    @ResponseBody
+    public Map<String, Object> saveExistingQuestionGroups(
+            @RequestBody QuestionGroupListPayload payLoad) {
+        final Map<String, Object> response = new HashMap<String, Object>();
+        RestStatusDto statusDto = new RestStatusDto();
+        statusDto.setStatus("failed");
+        statusDto.setMessage("No question groups to change");
+
+        //Loop over question groups
+        final List<QuestionGroupDto> requestList = payLoad.getQuestionGroups();
+        if (requestList != null && requestList.size() > 0) {
+            for (final QuestionGroupDto questionGroupDto : requestList) {
+    
+                if (questionGroupDto != null) {
+                    Long keyId = questionGroupDto.getKeyId();
+                    QuestionGroup qg;
+        
+                    // if the questionGroupDto has a key, try to get the question group.
+                    if (keyId != null) {
+                        qg = questionGroupDao.getByKey(keyId);
+                        // if we find the question, update it's properties
+                        if (qg != null) {
+                            // copy the properties, except the createdDateTime property,
+                            // because it is set in the Dao.
+                            BeanUtils.copyProperties(questionGroupDto, qg, new String[] {
+                                    "createdDateTime"
+                            });
+                            qg = questionGroupDao.save(qg);
+        
+                        } else { //missing in db - fail
+                            statusDto.setMessage("Cannot change unknown question group " + keyId);
+                            response.put("meta", statusDto);
+                            return response;                            
+                        }
+                    } else  { //no db key - fail
+                        statusDto.setMessage("Cannot change question group without id");
+                        response.put("meta", statusDto);
+                        return response;                            
+                    }
+                }
+            }
+            statusDto.setStatus("ok");
+            statusDto.setMessage("");
+        }
+        response.put("meta", statusDto);
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionGroupRestService.java
@@ -242,7 +242,7 @@ public class QuestionGroupRestService {
         statusDto.setMessage("No question groups to change");
 
         //Loop over question groups
-        final List<QuestionGroupDto> requestList = payLoad.getQuestionGroups();
+        final List<QuestionGroupDto> requestList = payLoad.getQuestion_groups();
         if (requestList != null && requestList.size() > 0) {
             for (final QuestionGroupDto questionGroupDto : requestList) {
     

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -276,7 +276,7 @@ public class QuestionRestService {
         return response;
     }
 
-    // update existing questions
+    // update several existing questions
     // questionOptions are saved and updated on their own
     @RequestMapping(method = RequestMethod.PUT, value = "/bulk")
     @ResponseBody
@@ -290,8 +290,6 @@ public class QuestionRestService {
         //Loop over questions
         final List<QuestionDto> requestList = payLoad.getQuestions();
         if (requestList != null && requestList.size() > 0) {
-            final List<QuestionDto> responseList = new ArrayList<>();
-
             for (final QuestionDto questionDto : requestList) {
     
                 if (questionDto != null) {
@@ -314,7 +312,6 @@ public class QuestionRestService {
         
                             q = questionDao.save(q);
         
-                            responseList.add(QuestionDtoMapper.transform(q));
                         } else { //missing in db - fail
                             statusDto.setMessage("Cannot change unknown question " + keyId);
                             response.put("meta", statusDto);
@@ -327,7 +324,6 @@ public class QuestionRestService {
                     }
                 }
             }
-            response.put("questions", responseList);
         }
         statusDto.setStatus("ok");
         statusDto.setMessage("");

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.app.web.rest.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
+
+public class QuestionGroupListPayload implements Serializable {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    List<QuestionGroupDto> questiongroups = null;
+
+    public List<QuestionGroupDto> getQuestionGroups() {
+        return questiongroups;
+    }
+
+    public void setQuestionGroups(List<QuestionGroupDto> questiongroups) {
+        this.questiongroups = questiongroups;
+    }
+}

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
@@ -27,13 +27,13 @@ public class QuestionGroupListPayload implements Serializable {
      * 
      */
     private static final long serialVersionUID = 1L;
-    List<QuestionGroupDto> questiongroups = null;
+    List<QuestionGroupDto> question_groups = null;
 
     public List<QuestionGroupDto> getQuestionGroups() {
-        return questiongroups;
+        return question_groups;
     }
 
-    public void setQuestionGroups(List<QuestionGroupDto> questiongroups) {
-        this.questiongroups = questiongroups;
+    public void setQuestionGroups(List<QuestionGroupDto> question_groups) {
+        this.question_groups = question_groups;
     }
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionGroupListPayload.java
@@ -29,11 +29,11 @@ public class QuestionGroupListPayload implements Serializable {
     private static final long serialVersionUID = 1L;
     List<QuestionGroupDto> question_groups = null;
 
-    public List<QuestionGroupDto> getQuestionGroups() {
+    public List<QuestionGroupDto> getQuestion_groups() {
         return question_groups;
     }
 
-    public void setQuestionGroups(List<QuestionGroupDto> question_groups) {
+    public void setQuestion_groups(List<QuestionGroupDto> question_groups) {
         this.question_groups = question_groups;
     }
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionListPayload.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/dto/QuestionListPayload.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.app.web.rest.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
+
+public class QuestionListPayload implements Serializable {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    List<QuestionDto> questions = null;
+
+    public List<QuestionDto> getQuestions() {
+        return questions;
+    }
+
+    public void setQuestions(List<QuestionDto> questions) {
+        this.questions = questions;
+    }
+}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When reordering questions/question groups, calls would be made for each question/question group which would be strenuous on the browser and would sometimes break in case of network failure
#### The solution
Bulk submit questions/question groups to reorder in a single call
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
