### PR TITLE
Submission lists remains on Monitoring tab after navigation (connect # 2531)

### DIFF
--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -29,7 +29,7 @@ FLOW.inspectDataTableView = FLOW.View.extend({
     FLOW.dateControl.set('toDate', null);
     FLOW.dateControl.set('fromDate', null);
     FLOW.surveyInstanceControl.set('pageNumber', 0);
-    FLOW.surveyInstanceControl.set('currentContents', null)
+    FLOW.surveyInstanceControl.set('currentContents', null);
     FLOW.locationControl.set('selectedLevel1', null);
     FLOW.locationControl.set('selectedLevel2', null);
   },

--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -29,6 +29,7 @@ FLOW.inspectDataTableView = FLOW.View.extend({
     FLOW.dateControl.set('toDate', null);
     FLOW.dateControl.set('fromDate', null);
     FLOW.surveyInstanceControl.set('pageNumber', 0);
+    FLOW.surveyInstanceControl.set('currentContents', null)
     FLOW.locationControl.set('selectedLevel1', null);
     FLOW.locationControl.set('selectedLevel2', null);
   },


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
After fixing this issue and made this PR :https://github.com/akvo/akvo-flow/pull/2541  to clear the submission lists that remain after navigating away from the monitoring data tab.
Another bug came up where after viewing one submission list in detail in the monitoring data tab, it resurfaces  and appears in the inspect data tab when you navigate there.
#### The solution
Cleared the one submission list  that appears in the inspect data tab that comes as result of viewing the record in the monitoring data tab 

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
