### PR TITLE
Load question groups and questions correctly for monitoring tab preview

### DIFF
--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -347,9 +347,18 @@ FLOW.questionAnswerControl = Ember.ArrayController.create({
 	return allIterations;
   },
 
-  doQuestionAnswerQuery: function (surveyInstanceId) {
+  doQuestionAnswerQuery: function (surveyInstance) {
+    var formId = surveyInstance.get('surveyId');
+    var form = FLOW.surveyControl.filter(function (form) {
+      return form.get('keyId') === formId;
+    }).get(0);
+
+    if (formId !== FLOW.selectedControl.selectedSurvey.get('keyId')) {
+      FLOW.selectedControl.set('selectedSurvey', form);
+    }
+
     this.set('content', FLOW.store.findQuery(FLOW.QuestionAnswer, {
-      'surveyInstanceId': surveyInstanceId
+      'surveyInstanceId': surveyInstance.get('keyId')
     }));
   },
 });

--- a/Dashboard/app/js/lib/controllers/data-controllers.js
+++ b/Dashboard/app/js/lib/controllers/data-controllers.js
@@ -283,10 +283,14 @@ FLOW.questionAnswerControl = Ember.ArrayController.create({
   // over a set of responses to questions in a specific question group, ordered
   // by question order. For repeat question groups two adjacent sub lists
   // represent two iterations of responses for that group
-  contentByGroup: Ember.computed('content.isLoaded', function(key, value) {
-    var content = Ember.get(this, 'content'),
-        self = this;
-    if (content) {
+  contentByGroup: Ember.computed('content.isLoaded',
+                                  'FLOW.questionContol.content.isLoaded',
+                                  'FLOW.questionContol.content.isLoaded', function(key, value) {
+    var content = Ember.get(this, 'content'), self = this;
+    var questions = FLOW.questionControl.get('content');
+    var questionGroups = FLOW.questionGroupControl.get('content');
+
+    if (content && questions && questionGroups) {
 		var surveyQuestions = FLOW.questionControl.get('content');
 		var groups = FLOW.questionGroupControl.get('content');
 		var allResponses = [];

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -632,6 +632,7 @@ FLOW.surveyControl = Ember.ArrayController.create({
   }.observes('FLOW.selectedControl.selectedSurveyGroup'),
 
   selectFirstForm: function() {
+    if(FLOW.selectedControl.selectedSurvey) return; // ignore if form is already selected
     if (this.get('content') && this.content.get('isLoaded')) {
       var form = this.content.get('firstObject');
       if (form) {

--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -150,7 +150,7 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   // Survey instance edit popup window
   // TODO solve when popup is open, no new surveyIdQuery is done
   showEditSurveyInstanceWindow: function (event) {
-    FLOW.questionAnswerControl.doQuestionAnswerQuery(event.context.get('keyId'));
+    FLOW.questionAnswerControl.doQuestionAnswerQuery(event.context);
     this.get('alreadyLoaded').push(event.context.get('surveyId'));
     this.set('selectedSurveyInstanceId', event.context.get('keyId'));
     this.set('selectedSurveyInstanceNum', event.context.clientId);
@@ -182,12 +182,13 @@ FLOW.inspectDataTableView = FLOW.View.extend({
           return false;
         }
       });
-      nextSIkeyId = filtered.objectAt(0).get('keyId');
+      var nextSI = filtered.objectAt(0);
+      nextSIkeyId = nextSI.get('keyId');
       this.set('selectedSurveyInstanceId', nextSIkeyId);
       this.set('selectedSurveyInstanceNum', nextItem);
       this.createSurveyInstanceString();
       this.downloadQuestionsIfNeeded();
-      FLOW.questionAnswerControl.doQuestionAnswerQuery(nextSIkeyId);
+      FLOW.questionAnswerControl.doQuestionAnswerQuery(nextSI);
     }
   },
 
@@ -209,12 +210,13 @@ FLOW.inspectDataTableView = FLOW.View.extend({
           return false;
         }
       });
-      nextSIkeyId = filtered.objectAt(0).get('keyId');
+      var nextSI = filtered.objectAt(0);
+      nextSIkeyId = nextSI.get('keyId');
       this.set('selectedSurveyInstanceId', nextSIkeyId);
       this.set('selectedSurveyInstanceNum', nextItem);
       this.createSurveyInstanceString();
       this.downloadQuestionsIfNeeded();
-      FLOW.questionAnswerControl.doQuestionAnswerQuery(nextSIkeyId);
+      FLOW.questionAnswerControl.doQuestionAnswerQuery(nextSI);
     }
   },
 

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -22,7 +22,7 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
   },
 
   showSurveyInstanceDetails: function (evt) {
-    FLOW.questionAnswerControl.doQuestionAnswerQuery(evt.context.get('keyId'));
+    FLOW.questionAnswerControl.doQuestionAnswerQuery(evt.context);
     $('.si_details').hide();
     $('tr[data-flow-id="si_details_' + evt.context.get('keyId') + '"]').show();
   },


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* For previewing response data under the monitoring tab, we required the correct question groups and questions to be loaded, however, the dashboard was loaded by default the questions and question groups from the first selected form in a survey, which did not always correspond to the data being previewed.

#### The solution
* We load the questions and question groups based on the form being previewed under the monitoring tab.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
