### PR TITLE
Validate against empty question text (connect #2221)

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -765,7 +765,14 @@ FLOW.QuestionView = FLOW.View.extend({
   },
 
   validateQuestionObserver: function () {
-      this.set('questionValidationFailure', (this.text != null && this.text.length > 500));
+      this.set('questionValidationFailure', ((this.text && this.text.length > 500) || !this.text || this.text == ""));
+      if (this.text && this.text.length > 500) {
+        this.set('questionValidationFailureReason', Ember.String.loc('_question_over_500_chars_header'));
+      } else {
+        if (!this.text || this.text == "") {
+          this.set('questionValidationFailureReason', Ember.String.loc('_question_text_empty'));
+        }
+      }
   }.observes('this.text'),
 
   validateQuestionTooltipObserver: function(){

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -5,7 +5,7 @@
     <h1 class="questionNbr"><span>{{view.content.order}}} </span>{{view.content.text}}</h1>
     <label>{{t _question_text}}:
     {{#if view.questionValidationFailure }}
-      <span style="color:red">{{t _question_over_500_chars_header}}</span>
+      <span style="color:red">{{view.questionValidationFailureReason}}</span>
       {{/if}}
       {{view Ember.TextField valueBinding="view.text" size=100 }}</label>
     <label>{{t _question_help_tooltip}}: <span class="fadedText">({{t _optional}})</span>
@@ -170,7 +170,11 @@
         {{#if view.variableNameValidationFailure }}
         <li><a class="button noChanges" id="standardBtn_01">{{t _save_question}}</a> </li>
         {{else}}
+        {{#if view.questionValidationFailure }}
+        <li><a class="button noChanges" id="standardBtn_01">{{t _save_question}}</a> </li>
+        {{else}}
         <li><a class="button" id="standardBtn_01" {{action "doSaveEditQuestion" target="this"}}>{{t _save_question}}</a> </li>
+        {{/if}}
         {{/if}}
         <li><a class="cancel" id="standardBtn_01" {{action "doCancelEditQuestion" target="this"}}>{{t _cancel}}</a> </li>
       </ul>

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -359,6 +359,7 @@ Question = Question
 Question\ help\ tooltip = Question help tooltip
 Question\ help\ tooltip:\ (optional) = Question help tooltip: (optional)
 Question\ text = Question text
+Question\ text\ cannot\ be\ empty = Question text cannot be empty
 Question\ text\ too\ long = Question text too long
 Question\ type = Question type
 Questions = Questions

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -381,6 +381,7 @@ _question_is_being_saved_text = The question is currently being saved. Please wa
 _question_over_500_chars_header = Question text too long
 _question_over_500_chars_text = The question text should be less than 500 characters long. Please shorten it.
 _question_text = Question text
+_question_text_empty = Question text cannot be empty
 _question_type = Question type
 _question_type_date_tooltip = The date format is DD-MM-YYYY.
 _question_type_geoshape_tooltip = A geographic shape can be a point, a line or a polygon which you mark on the map. This question type enables you to map a set of points, a certain area, or lines, and view that information as a layer on the map. It is useful if you want to map out an area such as a group of water taps, walking paths, a protected forest, a palm oil plantation or an urban area.


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Users were able to save questions even is the question text was empty
#### The solution
Prevent this by validating and disabling the save button if question text is empty
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
