### PR TITLE
Move reports to under data tab (connect #2555)

### DIFF
--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -269,6 +269,14 @@ FLOW.Router = Ember.Router.extend({
         router.transitionTo('navData.monitoringData');
       },
 
+      doExportReports: function (router, event) {
+        router.transitionTo('navData.exportReports');
+      },
+
+      doChartReports: function (router, event) {
+        router.transitionTo('navData.chartReports');
+      },
+
       doDataApproval: function (router, event) {
           router.transitionTo('navData.dataApproval.listApprovalGroups');
       },
@@ -319,6 +327,24 @@ FLOW.Router = Ember.Router.extend({
           router.get('navDataController').connectOutlet('monitoringData');
           router.set('datasubnavController.selected', 'monitoringData');
           router.resetState();
+        }
+      }),
+
+      exportReports: Ember.Route.extend({
+        route: '/exportreports',
+        connectOutlets: function (router, context) {
+          router.get('navDataController').connectOutlet('exportReports');
+          router.set('datasubnavController.selected', 'exportReports');
+          router.resetState();
+        }
+      }),
+
+      chartReports: Ember.Route.extend({
+        route: '/chartreports',
+        connectOutlets: function (router, context) {
+          router.resetState();
+          router.get('navDataController').connectOutlet('chartReports');
+          router.set('datasubnavController.selected', 'chartReports');
         }
       }),
 
@@ -383,47 +409,6 @@ FLOW.Router = Ember.Router.extend({
               },
           }),
       }),
-    }),
-
-    // ************************** REPORTS ROUTER **********************************
-    navReports: Ember.Route.extend({
-      route: '/reports',
-      connectOutlets: function (router, context) {
-        router.get('applicationController').connectOutlet('navReports');
-        router.resetState();
-        router.set('navigationController.selected', 'navReports');
-      },
-
-      doExportReports: function (router, event) {
-        router.transitionTo('navReports.exportReports');
-      },
-
-      doChartReports: function (router, event) {
-        router.transitionTo('navReports.chartReports');
-      },
-
-      index: Ember.Route.extend({
-        route: '/',
-        redirectsTo: 'exportReports'
-      }),
-
-      exportReports: Ember.Route.extend({
-        route: '/exportreports',
-        connectOutlets: function (router, context) {
-          router.get('navReportsController').connectOutlet('exportReports');
-          router.set('reportsSubnavController.selected', 'exportReports');
-          router.resetState();
-        }
-      }),
-
-      chartReports: Ember.Route.extend({
-        route: '/chartreports',
-        connectOutlets: function (router, context) {
-          router.resetState();
-          router.get('navReportsController').connectOutlet('chartReports');
-          router.set('reportsSubnavController.selected', 'chartReports');
-        }
-      })
     }),
 
     // ************************** MAPS ROUTER **********************************

--- a/Dashboard/app/js/templates/application/navigation.handlebars
+++ b/Dashboard/app/js/templates/application/navigation.handlebars
@@ -10,9 +10,6 @@
 	{{#view view.NavItemView item="navData" }}
     <a {{action doNavData}}>{{t _data}}</a>
   {{/view}}
-	{{#view view.NavItemView item="navReports" }}
-    <a {{action doNavReports}}>{{t _reports}}</a>
-  {{/view}}
   {{#if view.showMapsButton}}
   {{#view view.NavItemView item="navMaps" }}
     <a {{action doNavMaps}}>{{t _maps}}</a>

--- a/Dashboard/app/js/templates/navData/data-subnav.handlebars
+++ b/Dashboard/app/js/templates/navData/data-subnav.handlebars
@@ -7,6 +7,12 @@
         <a {{action doMonitoringData}}>{{t _monitoring}}</a>
       {{/view}}
     {{/if}}
+    {{#view view.NavItemView item="chartReports" }}
+      <a {{action doChartReports}}>{{t _charts}}</a>
+    {{/view}}
+    {{#view view.NavItemView item="exportReports" }}
+    	<a {{action doExportReports}}>{{t _export_reports}}</a>
+    {{/view}}
     {{#view view.NavItemView item="bulkUpload" }}
     <a {{action doBulkUpload}}>{{t _bulk_upload_data}}</a>
     {{/view}} 

--- a/Dashboard/app/js/templates/navReports/reports-subnav.handlebars
+++ b/Dashboard/app/js/templates/navReports/reports-subnav.handlebars
@@ -1,8 +1,3 @@
 <ul>
-    {{#view view.NavItemView item="exportReports" }}
-    	<a {{action doExportReports}}>{{t _export_reports}}</a>
-    {{/view}} 
-    {{#view view.NavItemView item="chartReports" }}
-      <a {{action doChartReports}}>{{t _charts}}</a>
-    {{/view}} 
+     
 </ul>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Charts and report exports were under the reports tab on the main navigation
#### The solution
Move charts and report exports to under the data tab
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
