### PR TITLE
Exclude config file in current war directory (connect #2406)

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -324,6 +324,7 @@
                     </includes>
                     <excludes>
                       <exclude>/WEB-INF/appengine-generated/**</exclude>
+                      <exclude>/WEB-INF/appengine-web.xml</exclude>
                     </excludes>
                 </resource>
             </webResources>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The maven build was copying `appengine-web.xml` files in the existing `GAE/war` directory and overwriting any new config files that had been copied when executing the command `mvn appengine:update -DappId=<app_id>`

#### The solution
* In the maven packaging phase we exclude a config file if it exists in the current `GAE/war` directory

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
