### PR TITLE
Restrict file type validation to bulk upload tab (connect #2471)

### DIFF
--- a/Dashboard/app/js/lib/views/data/bulk-upload-view.js
+++ b/Dashboard/app/js/lib/views/data/bulk-upload-view.js
@@ -48,6 +48,8 @@ FLOW.uploader = Ember.Object.create({
     return this.get('r').addFile(file);
   },
 
+  bulkUpload: null,
+
   registerEvents: function () {
     var r = this.get('r');
 
@@ -63,8 +65,7 @@ FLOW.uploader = Ember.Object.create({
       }
 
       // Add the file to the list
-      if (file.file.type !== "application/zip" && file.file.type !== "application/x-zip-compressed") {
-        $(".resumable-progress").hide();
+      if (file.file.type !== "application/zip" && file.file.type !== "application/x-zip-compressed" && FLOW.uploader.get('bulkUpload')) {
         $("#resumable-file-"+ file.uniqueIdentifier).html(
           "<span class='resumable-file-name'>"+file.fileName+"</span>"
                 +  Ember.String.loc('_unsupported_file_type')
@@ -74,7 +75,6 @@ FLOW.uploader = Ember.Object.create({
         });
         r.removeFile(file); //remove file
       } else {
-        $('.resumable-progress').show();
         $("#resumable-file-"+ file.uniqueIdentifier).html(
           '<span class="resumable-file-name">'+file.fileName+'</span>'
           +'<span id="resumable-file-progress-'+file.uniqueIdentifier+'" class="uploadStatus"></span>'

--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -816,6 +816,13 @@ FLOW.DatasubnavView = FLOW.View.extend({
     classNameBindings: 'isActive:active'.w(),
 
     isActive: function () {
+      if (this.get('item') === this.get('parentView.selected') && this.get('parentView.selected') === "bulkUpload") {
+        FLOW.uploader.set('bulkUpload', true);
+      } else {
+        if (this.get('parentView.selected') !== "bulkUpload") {
+          FLOW.uploader.set('bulkUpload', false);
+        }
+      }
       return this.get('item') === this.get('parentView.selected');
     }.property('item', 'parentView.selected').cacheable(),
 

--- a/Dashboard/app/js/templates/navData/cascade-resources.handlebars
+++ b/Dashboard/app/js/templates/navData/cascade-resources.handlebars
@@ -67,12 +67,6 @@
 								{{t _import_help_text}}
 							</p>
 						</div>
-						<div class="resumable-progress">
-							<h5>{{t _progress}}</h5>
-							<div class="progress-container">
-								<div class="progress-bar"></div>
-							</div>
-						</div>
 						<ul class="resumable-list"></ul>
 						{{else}}
 						<div class="resumable-error">{{t

--- a/Dashboard/app/js/templates/navData/data-cleaning.handlebars
+++ b/Dashboard/app/js/templates/navData/data-cleaning.handlebars
@@ -35,10 +35,6 @@
       {{#if FLOW.uploader.support}}
         <p><input id="raw-data-import-file" type="file"/></p>
         <a {{action importFile target="this"}} class="standardBtn"> {{t _import}}</a>
-        <div class="resumable-progress">
-          <h5>{{t _progress}}</h5>
-          <div class="progress-container"><div class="progress-bar"></div></div>
-        </div>
         <ul class="resumable-list"></ul>
       {{else}}
        <div class="resumable-error">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
File type validation changes made in #2554 affected cascade resources and data cleaning tabs
#### The solution
Restrict file type validation to the bulk upload page. However the styling changes effected in #2554 apply globally
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
