### PR TITLE
Added logic to check for new androidBuildVersion param (connect #2603)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/DeviceApplicationRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DeviceApplicationRestService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012,2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/DeviceApplicationRestRequest.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/DeviceApplicationRestRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012,2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/DeviceApplicationRestRequest.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/DeviceApplicationRestRequest.java
@@ -16,10 +16,11 @@
 
 package org.waterforpeople.mapping.app.web.dto;
 
-import javax.servlet.http.HttpServletRequest;
-
 import com.gallatinsystems.framework.rest.RestError;
 import com.gallatinsystems.framework.rest.RestRequest;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * encapsulates request to the devapp service
@@ -31,16 +32,21 @@ public class DeviceApplicationRestRequest extends RestRequest {
     private static final long serialVersionUID = -158448412036367889L;
 
     public static final String GET_LATEST_VERSION_ACTION = "getLatestVersion";
-    public static final String DEV_TYPE_PARAM = "deviceType";
-    public static final String APP_CODE_PARAM = "appCode";
+    private static final String DEV_TYPE_PARAM = "deviceType";
+    private static final String APP_CODE_PARAM = "appCode";
+    private static final String ANDROID_BUILD_VERSION_PARAM = "androidBuildVersion";
 
     private String deviceType;
     private String appCode;
+
+    @Nullable
+    private String androidBuildVersion;
 
     @Override
     protected void populateFields(HttpServletRequest req) throws Exception {
         deviceType = req.getParameter(DEV_TYPE_PARAM);
         appCode = req.getParameter(APP_CODE_PARAM);
+        androidBuildVersion = req.getParameter(ANDROID_BUILD_VERSION_PARAM);
     }
 
     @Override
@@ -73,4 +79,12 @@ public class DeviceApplicationRestRequest extends RestRequest {
         this.appCode = appCode;
     }
 
+    @Nullable
+    public String getAndroidBuildVersion() {
+        return androidBuildVersion;
+    }
+
+    public void setAndroidBuildVersion(@Nullable String androidBuildVersion) {
+        this.androidBuildVersion = androidBuildVersion;
+    }
 }

--- a/GAE/src/org/waterforpeople/mapping/dao/DeviceApplicationDao.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/DeviceApplicationDao.java
@@ -1,18 +1,18 @@
 
 package org.waterforpeople.mapping.dao;
 
+import com.gallatinsystems.framework.dao.BaseDAO;
+import com.gallatinsystems.framework.servlet.PersistenceFilter;
+import org.waterforpeople.mapping.domain.DeviceApplication;
+
+import javax.jdo.PersistenceManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.jdo.PersistenceManager;
-
-import org.waterforpeople.mapping.domain.DeviceApplication;
-
-import com.gallatinsystems.framework.dao.BaseDAO;
-import com.gallatinsystems.framework.servlet.PersistenceFilter;
-
 public class DeviceApplicationDao extends BaseDAO<DeviceApplication> {
+
+    private static final String LATEST_SUPPORTED_VERSION = "2.4.8";
 
     public DeviceApplicationDao() {
         super(DeviceApplication.class);
@@ -23,11 +23,11 @@ public class DeviceApplicationDao extends BaseDAO<DeviceApplication> {
             String deviceType, String appCode, int maxResults) {
         PersistenceManager pm = PersistenceFilter.getManager();
         javax.jdo.Query query = pm.newQuery(DeviceApplication.class);
-        Map<String, Object> paramMap = null;
+        Map<String, Object> paramMap;
 
         StringBuilder filterString = new StringBuilder();
         StringBuilder paramString = new StringBuilder();
-        paramMap = new HashMap<String, Object>();
+        paramMap = new HashMap<>();
 
         appendNonNullParam("deviceType", filterString, paramString, "String",
                 deviceType, paramMap);
@@ -40,4 +40,32 @@ public class DeviceApplicationDao extends BaseDAO<DeviceApplication> {
         return (List<DeviceApplication>) query.executeWithMap(paramMap);
     }
 
+    @SuppressWarnings("unchecked")
+    public DeviceApplication listAppVersionForUnsupportedDevices(String deviceType,
+            String appCode) {
+        PersistenceManager pm = PersistenceFilter.getManager();
+        javax.jdo.Query query = pm.newQuery(DeviceApplication.class);
+        Map<String, Object> paramMap;
+
+        StringBuilder filterString = new StringBuilder();
+        StringBuilder paramString = new StringBuilder();
+        paramMap = new HashMap<>();
+        appendNonNullParam("deviceType", filterString, paramString, "String",
+                deviceType, paramMap);
+        appendNonNullParam("appCode", filterString, paramString, "String",
+                appCode, paramMap);
+        appendNonNullParam("version", filterString, paramString, "String",
+                LATEST_SUPPORTED_VERSION, paramMap);
+        query.setFilter(filterString.toString());
+        query.setOrdering("createdDateTime desc");
+        query.declareParameters(paramString.toString());
+        query.setRange(0, 1);
+        List<DeviceApplication> deviceApplications = (List<DeviceApplication>) query
+                .executeWithMap(paramMap);
+
+        if (deviceApplications == null || deviceApplications.size() == 0) {
+            return null;
+        }
+        return deviceApplications.get(0);
+    }
 }

--- a/GAE/src/org/waterforpeople/mapping/dao/DeviceApplicationDao.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/DeviceApplicationDao.java
@@ -1,4 +1,18 @@
-
+/*
+ *  Copyright (C) 2018 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
 package org.waterforpeople.mapping.dao;
 
 import com.gallatinsystems.framework.dao.BaseDAO;

--- a/GAE/src/org/waterforpeople/mapping/domain/DeviceApplication.java
+++ b/GAE/src/org/waterforpeople/mapping/domain/DeviceApplication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012,2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -16,9 +16,9 @@
 
 package org.waterforpeople.mapping.domain;
 
-import javax.jdo.annotations.PersistenceCapable;
-
 import com.gallatinsystems.framework.domain.BaseDomain;
+
+import javax.jdo.annotations.PersistenceCapable;
 
 @PersistenceCapable
 public class DeviceApplication extends BaseDomain {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Old android devices will be deprecated in android 2.5.0 and have to be always served with 2.4.8 (latest version available for them)
#### The solution
the app will now send the android api code:
https://github.com/akvo/akvo-flow-mobile/issues/1091
the param is:
`&androidBuildVersion=27`
We need to check for this value and
if missing param -> latest version is 2.4.8 or empty if missing from datastore
if androidBuildVersion < 15 -> latest version is 2.4.8 or empty if missing from datastore
otherwise -> get the latest version from the datastore
#### Screenshots (if appropriate)
NA
## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
