### PR TITLE
[#2633] .dockerignore all files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+/GAE
+/Config
+/Dashboard/.sass-cache
+/Dashboard/tmp
+/.git
+/scripts
+/tests


### PR DESCRIPTION
docker is sending the whole current directory when doing a build and the
current directory can get quite big (up to 2gb) after compiling all the
classes and running some of the data scripts.

For building the images, we only really use the Dashboard/Gemfile*. All
other files are made available to Docker because we mount the whole source
directory.

Fixes #2633