### PR TITLE
[#2628] Define entrypoint at runtime instead of Dockerfile (connect #2628)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,3 @@ RUN set -ex ; \
     adduser -D -h /home/akvo -s /bin/bash akvo akvo
 
 WORKDIR /app/src
-ENTRYPOINT /app/src/ci/run-as-user.sh

--- a/ci/bootstrap-build.sh
+++ b/ci/bootstrap-build.sh
@@ -26,6 +26,8 @@ fi
 
 docker run \
        --rm \
+       --volume "${MAVEN_REPO}:/root/.m2:delegated" \
        --volume "${MAVEN_REPO}:/home/akvo/.m2:delegated" \
        --volume "$(pwd):/app/src:delegated" \
+       --entrypoint /app/src/ci/run-as-user.sh \
        akvo/flow-builder "$@"

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -29,6 +29,7 @@ openssl aes-256-cbc -K "$encrypted_ac356ff71e5e_key" -iv "$encrypted_ac356ff71e5
 
 docker run \
     --rm \
+    --volume "${HOME}/.m2:/root/.m2:delegated" \
     --volume "${HOME}/.m2:/home/akvo/.m2:delegated" \
     --volume "$(pwd):/app/src:delegated" \
     --env GH_USER \
@@ -36,4 +37,5 @@ docker run \
     --env CONFIG_REPO \
     --env SERVICE_ACCOUNT_ID \
     --env "PROJECT_ID=${project_id}" \
+    --entrypoint /app/src/ci/run-as-user.sh \
     akvo/flow-builder /app/src/ci/mvn-deploy.sh


### PR DESCRIPTION
- We explicitly use `--entrypoint` pointing to the mounted bash
  script, instead of Dockerfile
- We also mount the host $HOME/.m2 under /root/.m2 just in case
  someone wants to run the build in MacOS

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
