### PR TITLE
Permissions set at root level override permissions set down the nest (Connect #1582)

### DIFF
--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -205,9 +205,13 @@ FLOW.permControl = Ember.Controller.create({
   /* takes a form (ember object) and checks with user permissions
   whether the current user has edit permissions for the form */
   canEditForm: function(form) {
-    var permissions;
+    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(form)) {
-      permissions = this.permissions(form);
+      if (form.get("keyId") in userPerms) {
+        permissions = userPerms[form.get("keyId")];
+      } else {
+        permissions = this.permissions(form);
+      }
     }
     return permissions && permissions.indexOf("FORM_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -146,11 +146,6 @@ FLOW.permControl = Ember.Controller.create({
 
     if (!currentUserPermissions || !entity) { return []; }
 
-    // return superAdmin permissions
-    if ("0" in currentUserPermissions){
-      return currentUserPermissions["0"];
-    }
-
     // first check current object id
     keyId = entity.get('keyId');
     if (keyId in currentUserPermissions) {
@@ -176,6 +171,15 @@ FLOW.permControl = Ember.Controller.create({
       }
     }
 
+    // return superAdmin permissions
+    if ("0" in currentUserPermissions){
+      currentUserPermissions["0"].forEach(function(item){
+        if (permissions.indexOf(item) < 0) {
+          permissions.push(item);
+        }
+      });
+    }
+
     return permissions;
   },
 
@@ -197,11 +201,7 @@ FLOW.permControl = Ember.Controller.create({
   canEditSurvey: function(survey) {
     var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(survey)) {
-      if (survey.get("keyId") in userPerms) {
-        permissions = userPerms[survey.get("keyId")];
-      } else {
-        permissions = this.permissions(survey);
-      }
+      permissions = this.permissions(survey);
     }
     return permissions && permissions.indexOf("PROJECT_FOLDER_UPDATE") > -1;
   },
@@ -211,11 +211,7 @@ FLOW.permControl = Ember.Controller.create({
   canEditForm: function(form) {
     var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(form)) {
-      if (form.get("keyId") in userPerms) {
-        permissions = userPerms[form.get("keyId")];
-      } else {
-        permissions = this.permissions(form);
-      }
+      permissions = this.permissions(form);
     }
     return permissions && permissions.indexOf("FORM_UPDATE") > -1;
   },
@@ -223,11 +219,7 @@ FLOW.permControl = Ember.Controller.create({
   canEditResponses: function (form) {
     var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(form)) {
-      if (form.get("keyId") in userPerms) {
-        permissions = userPerms[form.get("keyId")];
-      } else {
-        permissions = this.permissions(form);
-      }
+      permissions = this.permissions(form);
     }
     return permissions && permissions.indexOf("DATA_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -195,9 +195,13 @@ FLOW.permControl = Ember.Controller.create({
   /* takes a survey (ember object) and checks whether the current user
     has edit permissions for the survey */
   canEditSurvey: function(survey) {
-    var permissions;
+    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(survey)) {
-      permissions = this.permissions(survey);
+      if (survey.get("keyId") in userPerms) {
+        permissions = userPerms[survey.get("keyId")];
+      } else {
+        permissions = this.permissions(survey);
+      }
     }
     return permissions && permissions.indexOf("PROJECT_FOLDER_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -217,9 +217,13 @@ FLOW.permControl = Ember.Controller.create({
   },
 
   canEditResponses: function (form) {
-    var permissions;
+    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
     if (!Ember.none(form)) {
-      permissions = this.permissions(form);
+      if (form.get("keyId") in userPerms) {
+        permissions = userPerms[form.get("keyId")];
+      } else {
+        permissions = this.permissions(form);
+      }
     }
     return permissions && permissions.indexOf("DATA_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -158,8 +158,7 @@ FLOW.permControl = Ember.Controller.create({
       return permissions;
     }
 
-    var i;
-    for(i = 0; i < ancestorIds.length; i++){
+    for(var i = 0; i < ancestorIds.length; i++){
       if (ancestorIds[i] in currentUserPermissions) {
         if (currentUserPermissions[ancestorIds[i]]) {
           currentUserPermissions[ancestorIds[i]].forEach(function(item){
@@ -169,15 +168,6 @@ FLOW.permControl = Ember.Controller.create({
           });
         }
       }
-    }
-
-    // return superAdmin permissions
-    if ("0" in currentUserPermissions){
-      currentUserPermissions["0"].forEach(function(item){
-        if (permissions.indexOf(item) < 0) {
-          permissions.push(item);
-        }
-      });
     }
 
     return permissions;
@@ -199,7 +189,7 @@ FLOW.permControl = Ember.Controller.create({
   /* takes a survey (ember object) and checks whether the current user
     has edit permissions for the survey */
   canEditSurvey: function(survey) {
-    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
+    var permissions;
     if (!Ember.none(survey)) {
       permissions = this.permissions(survey);
     }
@@ -209,7 +199,7 @@ FLOW.permControl = Ember.Controller.create({
   /* takes a form (ember object) and checks with user permissions
   whether the current user has edit permissions for the form */
   canEditForm: function(form) {
-    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
+    var permissions;
     if (!Ember.none(form)) {
       permissions = this.permissions(form);
     }
@@ -217,7 +207,7 @@ FLOW.permControl = Ember.Controller.create({
   },
 
   canEditResponses: function (form) {
-    var permissions, userPerms = FLOW.currentUser.get('pathPermissions');
+    var permissions;
     if (!Ember.none(form)) {
       permissions = this.permissions(form);
     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Permission set at root level overriding permissions set for specific surveys and forms down the folder structure
#### The solution
When loading specific forms and surveys, check if there are specific permissions set beyond the root level
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
