### PR TITLE
[#2628] Upgrade curl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=ruby-deps /usr/local/bundle /usr/local/bundle
 RUN set -ex ; \
     apk add --no-cache \
     bash=4.4.19-r1 \
-    curl=7.60.0-r0 \
+    curl=7.60.0-r1 \
     git=2.15.0-r1 \
     nodejs=8.9.3-r1 \
     openjdk8=8.151.12-r0 \


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* Builds are not working due to unavailable curl version.

```
 ---> Running in 1ae1ad89c8c8
+ apk add --no-cache bash=4.4.19-r1 curl=7.60.0-r0 git=2.15.0-r1 nodejs=8.9.3-r1 openjdk8=8.151.12-r0 openssh-client=7.5_p1-r8 python2=2.7.14-r2 py-crcmod=1.7-r0 py-openssl=17.2.0-r0 maven=3.5.2-r0 libc6-compat=1.1.18-r3 su-exec=0.2-r0 shadow=4.5-r0 zip=3.0-r4
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  curl-7.60.0-r1:
    breaks: world[curl=7.60.0-r0]
```

#### The solution

* Upgrade the curl version
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
