### PR TITLE
Filter datapoints for maps backend by `surveyId` (connect #2661)

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
+++ b/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
@@ -67,12 +67,12 @@ public class SurveyedLocaleDao extends BaseDAO<SurveyedLocale> {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public List<SurveyedLocale> listLocalesByGeocell(List<String> geocells, int pageSize) {
+    public List<SurveyedLocale> listLocalesByGeocell(Long surveyId, List<String> geocells, int pageSize) {
         PersistenceManager pm = PersistenceFilter.getManager();
-        String queryString = ":p1.contains(geocells)";
+        String queryString = "surveyGroupId == :p1 && :p2.contains(geocells)";
         javax.jdo.Query query = pm.newQuery(SurveyedLocale.class, queryString);
         prepareCursor(null, pageSize, query);
-        List<SurveyedLocale> results = (List<SurveyedLocale>) query.execute(geocells);
+        List<SurveyedLocale> results = (List<SurveyedLocale>) query.execute(surveyId, geocells);
         return results;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
@@ -19,6 +19,7 @@ package org.waterforpeople.mapping.app.web.rest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
@@ -50,6 +50,7 @@ public class PlacemarkRestService {
     @RequestMapping(method = RequestMethod.GET, value = "")
     @ResponseBody
     public Map<String, Object> listPlaceMarks(
+            @RequestParam(value = "surveyId", defaultValue = "-1") Long surveyId, // default to non-existing surveyId
             @RequestParam(value = "bbString", defaultValue = "") String boundingBoxString,
             @RequestParam(value = "gcLevel", defaultValue = "") Integer gcLevel) {
 
@@ -61,7 +62,7 @@ public class PlacemarkRestService {
         List<SurveyedLocale> slList = new ArrayList<>();
 
         if(isAuthorizedUser()) {
-            slList.addAll(listAllDataPoints(geocells));
+            slList.addAll(listAllDataPoints(surveyId, geocells));
         } else {
             slList.addAll(listOnlyPublicDataPoints(geocells));
         }
@@ -88,8 +89,8 @@ public class PlacemarkRestService {
         }
     }
 
-    private List<SurveyedLocale> listAllDataPoints(List<String> geocells) {
-        return localeDao.listLocalesByGeocell(geocells, LIMIT_PLACEMARK_POINTS);
+    private List<SurveyedLocale> listAllDataPoints(Long surveyId, List<String> geocells) {
+        return localeDao.listLocalesByGeocell(surveyId, geocells, LIMIT_PLACEMARK_POINTS);
     }
 
     private List<SurveyedLocale> listOnlyPublicDataPoints(List<String> geocells) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
@@ -25,12 +25,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -63,9 +61,9 @@ public class PlacemarkRestService {
         List<SurveyedLocale> slList = new ArrayList<>();
 
         if(isAuthorizedUser()) {
-            slList.addAll(listAllDataPoints(geocells, gcLevel));
+            slList.addAll(listAllDataPoints(geocells));
         } else {
-            slList.addAll(listOnlyPublicDataPoints(geocells, gcLevel));
+            slList.addAll(listOnlyPublicDataPoints(geocells));
         }
 
         if (slList != null) {
@@ -90,11 +88,11 @@ public class PlacemarkRestService {
         }
     }
 
-    private List<SurveyedLocale> listAllDataPoints(List<String> geocells, Integer gcLevel) {
+    private List<SurveyedLocale> listAllDataPoints(List<String> geocells) {
         return localeDao.listLocalesByGeocell(geocells, LIMIT_PLACEMARK_POINTS);
     }
 
-    private List<SurveyedLocale> listOnlyPublicDataPoints(List<String> geocells, Integer gcLevel) {
+    private List<SurveyedLocale> listOnlyPublicDataPoints(List<String> geocells) {
         return localeDao.listPublicLocalesByGeocell(geocells, LIMIT_PLACEMARK_POINTS);
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/PlacemarkRestService.java
@@ -48,10 +48,12 @@ public class PlacemarkRestService {
 
     private SurveyedLocaleDao localeDao = new SurveyedLocaleDao();
 
+    private final static String DEFAULT_NON_EXISTENT_SURVEY_ID = "-1";
+
     @RequestMapping(method = RequestMethod.GET, value = "")
     @ResponseBody
     public Map<String, Object> listPlaceMarks(
-            @RequestParam(value = "surveyId", defaultValue = "-1") Long surveyId, // default to non-existing surveyId
+            @RequestParam(value = "surveyId", defaultValue = DEFAULT_NON_EXISTENT_SURVEY_ID) Long surveyId,
             @RequestParam(value = "bbString", defaultValue = "") String boundingBoxString,
             @RequestParam(value = "gcLevel", defaultValue = "") Integer gcLevel) {
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* All datapoints returned when a request is made to the maps backend

#### The solution

* We filter datapoints based on a `surveyId` thats provided in the request.  
* When maps are accessed through the publicly visible page, no survey is provided.  Here we return all datapoints but without any details of internal identifiers and therefore a non-authorized user can only see the datapoints but cannot access the associated content. 

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
