### PR TITLE
Do not clear cartodb maps when clicking on a point (connect #2661)

### DIFF
--- a/Dashboard/app/js/lib/views/maps/map-views-common.js
+++ b/Dashboard/app/js/lib/views/maps/map-views-common.js
@@ -156,10 +156,6 @@ FLOW.NavMapsView = FLOW.View.extend({
 
     FLOW.router.mapsController.set('map', this.map);
 
-    this.map.on('click', function(e) {
-      self.clearMap(); //remove any previously loaded point data
-    });
-
     this.map.on('zoomend', function() {
       $('body, html, #flowMap').scrollTop(0);
     });


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* An on click handler is defined to clear the map when clicked.  This also causes the maps points to be removed. 

#### The solution
* Take out the on click handler. 

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
