### PR TITLE
Allow form editing when creating new form (connect #2677)

### DIFF
--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -201,11 +201,7 @@ FLOW.permControl = Ember.Controller.create({
   canEditForm: function(form) {
     var permissions;
     if (!Ember.none(form)) {
-      if (!Ember.none(form.get("keyId"))) {
-        permissions = this.permissions(form);
-      } else {
-        return true; //no formId passed so new form being created
-      }
+      permissions = this.permissions(form);
     }
     return permissions && permissions.indexOf("FORM_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -201,7 +201,11 @@ FLOW.permControl = Ember.Controller.create({
   canEditForm: function(form) {
     var permissions;
     if (!Ember.none(form)) {
-      permissions = this.permissions(form);
+      if (!Ember.none(form.get("keyId"))) {
+        permissions = this.permissions(form);
+      } else {
+        return true; //no formId passed so new form being created
+      }
     }
     return permissions && permissions.indexOf("FORM_UPDATE") > -1;
   },

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -674,6 +674,8 @@ FLOW.surveyControl = Ember.ArrayController.create({
   createForm: function() {
     var code = Ember.String.loc('_new_form').trim();
     var path = FLOW.projectControl.get('currentProjectPath') + "/" + code;
+    var ancestorIds = FLOW.selectedControl.selectedSurveyGroup.get('ancestorIds');
+    ancestorIds.push(FLOW.selectedControl.selectedSurveyGroup.get('keyId'));
     FLOW.store.createRecord(FLOW.Survey, {
       "name": code,
       "code": code,
@@ -682,7 +684,8 @@ FLOW.surveyControl = Ember.ArrayController.create({
       "requireApproval": false,
       "status": "NOT_PUBLISHED",
       "surveyGroupId": FLOW.selectedControl.selectedSurveyGroup.get('keyId'),
-      "version":"1.0"
+      "version":"1.0",
+      "ancestorIds": ancestorIds
     });
     FLOW.projectControl.get('currentProject').set('deleteDisabled', true);
     FLOW.store.commit();


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When creating a form, formId is not generated till the form has been created in the database
#### The solution
~Assume new form is being created if a form object without a formId is passed for checking~
Add `ancestorIds` to the newly created form, so that parent permissions are applied to the new form.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
