### PR TITLE
Use fuzzy version for apk packages (connect #2704)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: java
+language: generic
 
 sudo: required
 
@@ -15,4 +15,3 @@ script:
 
 before_cache:
  - find $HOME/.m2 -name resolver-status.properties -exec rm {} \;
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,20 @@ COPY --from=ruby-deps /usr/local/bundle /usr/local/bundle
 
 RUN set -ex ; \
     apk add --no-cache \
-    bash=4.4.19-r1 \
-    curl=7.60.0-r1 \
-    git \
-    nodejs=8.9.3-r1 \
-    openjdk8=8.151.12-r0 \
-    openssh-client=7.5_p1-r8 \
-    python2=2.7.14-r2 \
-    py-crcmod=1.7-r0 \
-    py-openssl=17.2.0-r0 \
-    maven=3.5.2-r0 \
-    libc6-compat=1.1.18-r3 \
-    su-exec=0.2-r0 \
-    shadow=4.5-r0 \
-    zip=3.0-r4 && \
+    bash~=4.4 \
+    curl~=7 \
+    git~=2 \
+    nodejs~=8 \
+    openjdk8~=8 \
+    openssh-client~=7 \
+    python2~=2.7 \
+    py-crcmod~=1.7 \
+    py-openssl~=17.2 \
+    maven~=3.5 \
+    libc6-compat~=1.1 \
+    su-exec~=0.2 \
+    shadow~=4.5 \
+    zip~=3.0 && \
     curl -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" && \
     tar xzf "google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" && \
     rm "google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" && \


### PR DESCRIPTION
* By using major or major.minor versions on apk packages we reduce
  the amount of broken builds. apk will work in _fuzzy_ mode filling
  the blanks of the rest of the available packages
* Since we're building a docker container with all dependencies, there
  is no need to set the travis build to be a java one. No java setup
  is needed.

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
