### PR TITLE
Copy the date object when creating new datapoint objects (connect #2709)

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
+++ b/GAE/src/com/gallatinsystems/surveyal/app/web/SurveyalRestServlet.java
@@ -18,6 +18,7 @@ package com.gallatinsystems.surveyal.app.web;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
@@ -284,7 +285,7 @@ public class SurveyalRestServlet extends AbstractRestApiServlet {
         locale.addContributingSurveyInstance(surveyInstance.getKey().getId());
 
         // last update of the locale information
-        locale.setLastSurveyedDate(surveyInstance.getCollectionDate());
+        locale.setLastSurveyedDate(new Date(surveyInstance.getCollectionDate().getTime()));
         locale.setLastSurveyalInstanceId(surveyInstance.getKey().getId());
 
         log.log(Level.FINE, "SurveyLocale at this point " + locale.toString());

--- a/GAE/src/org/waterforpeople/mapping/app/web/RawDataRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/RawDataRestServlet.java
@@ -238,6 +238,7 @@ public class RawDataRestServlet extends AbstractRestApiServlet {
                 locale.assembleDisplayName(
                         qDao.listDisplayNameQuestionsBySurveyId(s.getKey().getId()), updatedAnswers);
 
+                updateDataPointLocation(locale, updatedAnswers);
                 locale = slDao.save(locale);
                 instance.setSurveyedLocaleId(locale.getKey().getId());
                 instanceDao.save(instance);


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* Importing new data through spreadsheets caused an error to occur due to sharing a reference of the object class between `SurveyInstance` and `SurveyedLocale` entity objects

#### The solution
* We copy the date value but create a new object for it. 

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
