### PR TITLE
Remove sentry errors for "Value is not a valid timestamp" (Connect #2717)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/ExportImportUtils.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/ExportImportUtils.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2015-2017 Stichting Akvo (Akvo Foundation)
+/*  Copyright (C) 2015-2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -130,7 +130,7 @@ public class ExportImportUtils {
         try {
             return new Date(Long.valueOf(value));
         } catch (NumberFormatException e) {
-            log.error("Value is not a valid timestamp: " + value);
+            log.info("Value is not a valid timestamp: " + value);
         }
 
         // Value is not a timestamp. Try to parse as a spreadsheet value


### PR DESCRIPTION
Fixes #2717.

Log issue at info level instead of error level

* [x] Connect the issue
* [ ] Test plan
* [x] Copyright header
* [x] Code formatting
* [ ] Documentation