### PR TITLE
Remove sentry errors for "Failed to parse the caddisfly response"

### DIFF
--- a/GAE/src/org/akvo/flow/domain/DataUtils.java
+++ b/GAE/src/org/akvo/flow/domain/DataUtils.java
@@ -155,7 +155,7 @@ public class DataUtils {
         try {
             caddisflyResponseMap = JSON_OBJECT_MAPPER.readValue(caddisflyValue, Map.class);
         } catch (IOException e) {
-            log.error("Failed to parse the caddisfly response");
+            log.warn("Failed to parse the caddisfly response");
         }
         if (caddisflyResponseMap != null) {
             return caddisflyResponseMap;


### PR DESCRIPTION
Fixes #2722

The export process ignores any invalid caddisfly value. No action to be performed by developers so changing the log level to warn.