### PR TITLE
Document workflow when working with Java Report classes

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -394,21 +394,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Then read the Flow Services documentation for the Flow Services specific instruc
 The DNS alias is required because the UI is sending to Flow Services the baseUrl of the Flow service, which Flow Services needs to resolve to the Flow container.
 The way Docker works, this baseUrl cannot be "localhost", as "localhost" for the Flow Service container is itself. 
 Adding a DNS entry allows for one level of indirection where "akvoflow.local" will be resolved to "127.0.0.1" for the Browser, while it resolves to the flow container for the flow-services container.
+
+#### Changing report Java classes
+
+Once you have both flow and flow services running, if you are making changes to the Java report classes used in flow-services, 
+you will need to run:
+
+    docker-compose exec -u akvo akvo-flow /bin/bash -c "cd GAE && mvn install"
+
+To package and install the Flow jar in your local maven repository. Then you can use this Flow jar as a dependency 
+in your local Flow Services dev environment. See Flow Services README for how to set it up.
+
        
 ---
 


### PR DESCRIPTION
Also, removing gpg as it breaks when running "mvn install" locally and it
is not being used during deployment

Fixes #2748