### PR TITLE
Stop refreshing list to check for processed reports (connect #2505)

### DIFF
--- a/Dashboard/app/js/lib/controllers/reports-controllers.js
+++ b/Dashboard/app/js/lib/controllers/reports-controllers.js
@@ -47,15 +47,7 @@ FLOW.ReportsController = Ember.ArrayController.extend({
     if (reports && !reports.isUpdating) {
       this.set('reportsAvailable', reports.content.length > 0);
 
-      var generatingReports = reports.filter(function(report) {
-        return report.get('state') === "IN_PROGRESS" || report.get('state') === "QUEUED";
-      });
-      //if reports are still generating, wait 5s and then reload
-      if (generatingReports.length > 0) {
-        setTimeout(function(){
-          FLOW.router.reportsController.set('content', FLOW.store.find(FLOW.Report));
-        }, 5000);
-      }
+      //TODO refresh reports list after checing if processing has completed
     }
   }.observes('content', 'content.isUpdating')
 });


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Refreshing reports every 5s if a report was in progress or queued. This would however result in looping calls which would weigh down on the browser if a report stays in queue for too long. We need to rethink how to tackle this
#### The solution
Remove the refreshing
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
