### PR TITLE
Preload surveys on dashboard load (connect #2754)

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -615,6 +615,10 @@ FLOW.surveyControl = Ember.ArrayController.create({
     }
   }.observes('FLOW.selectedControl.selectedSurveyGroup'),
 
+  populateAll: function () {
+    FLOW.store.find(FLOW.Survey);
+  },
+
   populate: function () {
 
     var id;

--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -98,6 +98,7 @@ FLOW.Router = Ember.Router.extend({
             name: 'navSurveysMain'
           });
           FLOW.projectControl.populate();
+          FLOW.surveyControl.populateAll();
           FLOW.cascadeResourceControl.populate();
           FLOW.projectControl.set('currentProject', null);
           FLOW.projectControl.set('newlyCreated', null);


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Only survey groups and cascade resources pulled when dashboard is loaded
#### The solution
Add surveys to items pulled on dashboard load
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
