### PR TITLE
[#2807] Tell git to always use LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Tell git to always use LF for shell scripts 

See #2807 