### PR TITLE
Upgrade the version of jts dependency (connect #2809)

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -218,7 +218,7 @@
     <dependency>
         <groupId>com.vividsolutions</groupId>
         <artifactId>jts</artifactId>
-        <version>1.10</version>
+        <version>1.13</version>
     </dependency>
 
 

--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -22,10 +22,6 @@
         <id>bintray.com</id>
         <url>https://dl.bintray.com/meetup/maven/</url>
       </repository>
-      <repository>
-        <id>geotoolkit.org</id>
-        <url>https://nexus.geomatys.com/repository/geotoolkit/</url>
-      </repository>
   </repositories>
 
   <distributionManagement>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The SSL certificate at `https://nexus.geomatys.com/repository/geotoolkit` is expired so we upgrade the `jts` dependency to one available on maven central


#### The solution
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
