### PR TITLE
[#2779]Add a delay. Use int instead of Long. (Connect #2779)

### DIFF
--- a/GAE/src/org/akvo/flow/rest/dto/ReportTaskRequest.java
+++ b/GAE/src/org/akvo/flow/rest/dto/ReportTaskRequest.java
@@ -38,7 +38,7 @@ public class ReportTaskRequest extends RestRequest {
     private String message;
     private String filename;
     private String baseUrl;
-    private Long attempt;
+    private int attempt;
 
     @Override
     protected void populateErrors() {
@@ -60,7 +60,9 @@ public class ReportTaskRequest extends RestRequest {
             setId(new Long(req.getParameter(ID_PARAM)));
         }
         if (req.getParameter(ATTEMPT_PARAM) == null) { //May be old entry from before we counted attempts
-            setAttempt(1L);
+            setAttempt(1);
+        } else {
+            setAttempt(new Integer(req.getParameter(ATTEMPT_PARAM)));
         }
         setBaseUrl(req.getParameter(BASE_URL_PARAM));
     }
@@ -105,11 +107,11 @@ public class ReportTaskRequest extends RestRequest {
 		this.filename = filename;
 	}
 
-    public Long getAttempt() {
+    public int getAttempt() {
         return attempt;
     }
 
-    public void setAttempt(Long attempt) {
+    public void setAttempt(int attempt) {
         this.attempt = attempt;
     }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
We should delay successive attempts so that transient problems have time to clear up.
Also, after a closer look, Long is not needed for attempt counting. 
#### The solution
Add a 30s delay. Switch to int.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
