### PR TITLE
Upgrading to the latest mapbox library(connect #2769)

### DIFF
--- a/Dashboard/app/dashboard.html
+++ b/Dashboard/app/dashboard.html
@@ -40,8 +40,8 @@
 
     <script>
       //default leaflet library
-      var jsSrc = "https://api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.js";
-      var cssSrc = "https://api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.css";
+      var jsSrc = "https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js";
+      var cssSrc = "https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css";
       var jsIntegrity = 'integrity="sha384-DmQhW9kLmOXK0xubm8w+Bd34nJq7Plt9clKmd2XxjgUNuoHcWdxV3GCeO7YSFc74" crossorigin="anonymous"';
       var cssIntegrity = 'integrity="sha384-codniTXEGsozlodYdGbtcNHSm0452RDVJyCJ3eEw+jagZXmaz9RIFHaBD+g/wrvS" crossorigin="anonymous"';
       switch (FLOW.Env.mapsProvider) {
@@ -58,8 +58,8 @@
               document.write('<script src="https://maps.google.com/maps/api/js?key=AIzaSyBZU7kLJ75VlTlC5Qrfi1n1N-5hJYProuQ' + region + '"><\/script>');
               break;
       }
-      document.write("<link rel=\"stylesheet\" href=\""+cssSrc+"\" "+cssIntegrity+"/>");
-      document.write("<script type=\"text/javascript\" src=\""+jsSrc+"\" "+jsIntegrity+"><\/script>");
+      document.write("<link rel=\"stylesheet\" href=\""+cssSrc+"\"/>");
+      document.write("<script type=\"text/javascript\" src=\""+jsSrc+"\"><\/script>");
     </script>
     <script src="/vendorjs/js/vendor/Google.js"></script>
 

--- a/Dashboard/app/js/lib/views/maps/map-views-common-public.js
+++ b/Dashboard/app/js/lib/views/maps/map-views-common-public.js
@@ -61,18 +61,20 @@ FLOW.NavMapsView = FLOW.View.extend({
         'Terrain': terrain
       }, {}));
     } else {
-      // insert the map
+      // insert the map for the mapbox
       var options = {
-          minZoom: 2,
+          minZoom: 10,
           maxZoom: 18
       };
+      L.mapbox.accessToken = 'pk.eyJ1IjoiYWt2byIsImEiOiJzUFVwR3pJIn0.8dLa4fHG19fBwwBUJMDOSQ';
+      var baseLayers = {
+        Terrain: L.mapbox.tileLayer('akvo.he30g8mm'),
+        Streets: L.mapbox.tileLayer('akvo.he2pdjhk'),
+        Satellite: L.mapbox.tileLayer('akvo.he30neh4')
+      }
+      
       this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm', options).setView([-0.703107, 36.765], 2);
-
-      L.control.layers({
-        'Terrain': L.mapbox.tileLayer('akvo.he30g8mm').addTo(this.map),
-        'Streets': L.mapbox.tileLayer('akvo.he2pdjhk'),
-        'Satellite': L.mapbox.tileLayer('akvo.he30neh4')
-      }).addTo(this.map);
+      L.control.layers(baseLayers).addTo(this.map)
     }
 
     // add scale indication to map

--- a/Dashboard/app/js/lib/views/maps/map-views-common.js
+++ b/Dashboard/app/js/lib/views/maps/map-views-common.js
@@ -83,14 +83,23 @@ FLOW.NavMapsView = FLOW.View.extend({
   insertMapboxMap: function() {
       var options = {
           minZoom: 2,
-          maxZoom: 18
+          maxZoom: 18,
+          attributionControl: false
       };
-    this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm', options).setView([-0.703107, 36.765], 2);
-    L.control.layers({
-      'Terrain': L.mapbox.tileLayer('akvo.he30g8mm'),
-      'Streets': L.mapbox.tileLayer('akvo.he2pdjhk'),
-      'Satellite': L.mapbox.tileLayer('akvo.he30neh4')
-    }).addTo(this.map);
+
+      L.mapbox.accessToken = 'pk.eyJ1IjoiYWt2byIsImEiOiJzUFVwR3pJIn0.8dLa4fHG19fBwwBUJMDOSQ';
+      var baseLayers = {
+         Terrain: L.mapbox.tileLayer('akvo.he30g8mm'),
+         Streets: L.mapbox.tileLayer('akvo.he2pdjhk'),
+         Satellite: L.mapbox.tileLayer('akvo.he30neh4')
+      };
+
+      this.map = L.mapbox.map('flowMap', 'akvo.he30g8mm', options).setView([-0.703107, 36.765], 2);
+       this.map.addControl(L.control.attribution({
+         position: 'bottomright',
+         prefix: ''
+      }))
+      L.control.layers(baseLayers).addTo(this.map);
   },
 
   insertCartodbMap: function() {
@@ -146,7 +155,7 @@ FLOW.NavMapsView = FLOW.View.extend({
 
     var baseLayers = {
 			"Normal": normal,
-            "Terrain": terrain,
+      "Terrain": terrain,
 			"Satellite": satellite
 		};
 

--- a/Dashboard/app/public.html
+++ b/Dashboard/app/public.html
@@ -22,8 +22,8 @@
     <![endif]-->
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/publicmap/css/screen.css"  media="screen,projection" />
-    <script src='https://api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.js' integrity="sha384-DmQhW9kLmOXK0xubm8w+Bd34nJq7Plt9clKmd2XxjgUNuoHcWdxV3GCeO7YSFc74" crossorigin="anonymous"></script>
-    <link href='https://api.tiles.mapbox.com/mapbox.js/v1.6.1/mapbox.css' rel='stylesheet' integrity="sha384-codniTXEGsozlodYdGbtcNHSm0452RDVJyCJ3eEw+jagZXmaz9RIFHaBD+g/wrvS" crossorigin="anonymous"/>
+    <script src='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js'></script>
+    <link href='https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' rel='stylesheet'/>
   </head>
   <body class="publicPage">
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
We are currently using mapbox v1.6.1 that is based on leaflet.js 0.7.2. The latest version of mapbox is v3.1.1 that includes improved features provided by leaflet.js and other new leaflet plugins, e.g. clustering plugins, placemarker plugins, and vector maps. We could build a simple prototype to see whether it takes a lot of effort to upgrade the library.
#### The solution
I changed the mapbox library from v1.6.1 to latest version v3.1.1
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
