### PR TITLE
Indicate survey must be selected via monitoring tab and inspect-tab(connect #2455)

### DIFF
--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3332,7 +3332,6 @@ div.chooseSurveyData {
     position: relative;
     display: block;
     margin: 0px 0 10px 0;
-    width: 100%;
     overflow: auto;
     > select {
         max-width: 20%;
@@ -3342,18 +3341,9 @@ div.chooseSurveyData {
 }
 
 div.redBorder {
-    position: relative;
-    display: inline-block;
-    margin: 0px 0 10px 0;
-    width: 33%;
     border: 2px solid red;
     border-radius: 8px;
     padding: 5px 3px 0 5px;
-    > select {
-        max-width: 20%;
-        float: left;
-        display: inline;
-    }
 }
 
 .filterData {

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3348,6 +3348,7 @@ div.redBorder {
     width: 33%;
     border: 2px solid red;
     border-radius: 8px;
+    padding: 5px 3px 0 5px;
     > select {
         max-width: 20%;
         float: left;

--- a/Dashboard/app/css/main.scss
+++ b/Dashboard/app/css/main.scss
@@ -3341,6 +3341,20 @@ div.chooseSurveyData {
     }
 }
 
+div.redBorder {
+    position: relative;
+    display: inline-block;
+    margin: 0px 0 10px 0;
+    width: 33%;
+    border: 2px solid red;
+    border-radius: 8px;
+    > select {
+        max-width: 20%;
+        float: left;
+        display: inline;
+    }
+}
+
 .filterData {
     border-top: 1px solid white;
     .dataDeviceId {

--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -15,7 +15,8 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   selectedSurveyInstanceId: null,
   selectedSurveyInstanceNum: null,
   siString: null,
-
+  missingSurvey:false,
+  
   form: function() {
     if (FLOW.selectedControl.get('selectedSurvey')) {
       return FLOW.selectedControl.get('selectedSurvey');
@@ -36,10 +37,23 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   
   // do a new query
   doFindSurveyInstances: function () {
+    //check first that survey is selected before performing find action
+    if (this.incompleteSurveySelection()) {
+      return;
+    }
+    this.set('missingSurvey', false)
     FLOW.surveyInstanceControl.get('sinceArray').clear();
     FLOW.surveyInstanceControl.set('pageNumber', -1);
     FLOW.metaControl.set('since', null);
     this.doNextPage();
+  },
+  
+  incompleteSurveySelection: function () {
+    if (FLOW.selectedControl.get('selectedSurvey') === null) {
+        this.set('missingSurvey', true);
+        return true;
+     }
+    return false;
   },
 
   doInstanceQuery: function () {

--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -38,23 +38,22 @@ FLOW.inspectDataTableView = FLOW.View.extend({
   // do a new query
   doFindSurveyInstances: function () {
     //check first that survey is selected before performing find action
-    if (this.incompleteSurveySelection()) {
+    if (FLOW.selectedControl.get('selectedSurvey') === null) {
+      this.set('missingSurvey', true)
       return;
     }
-    this.set('missingSurvey', false)
+    
     FLOW.surveyInstanceControl.get('sinceArray').clear();
     FLOW.surveyInstanceControl.set('pageNumber', -1);
     FLOW.metaControl.set('since', null);
     this.doNextPage();
   },
-  
-  incompleteSurveySelection: function () {
-    if (FLOW.selectedControl.get('selectedSurvey') === null) {
-        this.set('missingSurvey', true);
-        return true;
-     }
-    return false;
-  },
+    
+  watchSurveySelection: function(){
+      if (FLOW.selectedControl.get('selectedSurvey')!== null) {
+         this.set('missingSurvey', false)  
+      }  
+  }.observes('FLOW.selectedControl.selectedSurvey'),
 
   doInstanceQuery: function () {
     this.set('beginDate', Date.parse(FLOW.dateControl.get('fromDate')));

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -27,14 +27,12 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
     $('.si_details').hide();
     $('tr[data-flow-id="si_details_' + evt.context.get('keyId') + '"]').show();
   },
-  
-  incompleteSurveySelection: function (){
-     if (FLOW.selectedControl.get('selectedSurveyGroup') === null) {
-       this.set('missingSurvey',true);
-       return true;
+    
+  watchSurveySelection: function(){
+     if (FLOW.selectedControl.get('selectedSurveyGroup') !== null) {
+        this.set('missingSurvey', false)
      }
-     return false;
-  },
+  }.observes('FLOW.selectedControl.selectedSurveyGroup'),
 
   findSurveyedLocale: function (evt) {
 	  var ident = this.get('identifier'),
@@ -43,10 +41,10 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
 	      cursorType = FLOW.metaControl.get('cursorType'),
         criteria = {};
     //check if the survey is not selected, then highlight the dropdown
-    if (this.incompleteSurveySelection()) {
-        return;  
-    }
-    this.set('missingSurvey', false)
+     if (FLOW.selectedControl.get('selectedSurveyGroup') === null) {
+       this.set('missingSurvey', true)
+       return;
+     }
     
 	  if (ident) {
 		  criteria.identifier = ident;

--- a/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
+++ b/Dashboard/app/js/lib/views/data/monitoring-data-table-view.js
@@ -1,6 +1,7 @@
 FLOW.MonitoringDataTableView = FLOW.View.extend({
   showingDetailsDialog: false,
   cursorStart: null,
+  missingSurvey:false,
 
   pageNumber: function(){
 	return FLOW.router.surveyedLocaleController.get('pageNumber');
@@ -26,6 +27,14 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
     $('.si_details').hide();
     $('tr[data-flow-id="si_details_' + evt.context.get('keyId') + '"]').show();
   },
+  
+  incompleteSurveySelection: function (){
+     if (FLOW.selectedControl.get('selectedSurveyGroup') === null) {
+       this.set('missingSurvey',true);
+       return true;
+     }
+     return false;
+  },
 
   findSurveyedLocale: function (evt) {
 	  var ident = this.get('identifier'),
@@ -33,7 +42,12 @@ FLOW.MonitoringDataTableView = FLOW.View.extend({
 	      sgId = FLOW.selectedControl.get('selectedSurveyGroup'),
 	      cursorType = FLOW.metaControl.get('cursorType'),
         criteria = {};
-
+    //check if the survey is not selected, then highlight the dropdown
+    if (this.incompleteSurveySelection()) {
+        return;  
+    }
+    this.set('missingSurvey', false)
+    
 	  if (ident) {
 		  criteria.identifier = ident;
 	  }

--- a/Dashboard/app/js/templates/navData/inspect-data.handlebars
+++ b/Dashboard/app/js/templates/navData/inspect-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.inspectDataTableView}}
 <section class="" id="inspectData">
     <div class="floats-in filterData" id="dataFilter">
-        <div class="chooseSurveyData">
+        <div {{bindAttr class="view.missingSurvey:redBorder:chooseSurveyData"}}>
           {{#unless FLOW.projectControl.isLoading}}
             {{view FLOW.SurveySelectionView showDataReadSurveysOnly=true}}
           {{/unless}}

--- a/Dashboard/app/js/templates/navData/inspect-data.handlebars
+++ b/Dashboard/app/js/templates/navData/inspect-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.inspectDataTableView}}
 <section class="" id="inspectData">
     <div class="floats-in filterData" id="dataFilter">
-        <div {{bindAttr class="view.missingSurvey:redBorder:chooseSurveyData"}}>
+        <div {{bindAttr class="view.missingSurvey:redBorder :chooseSurveyData"}}>
           {{#unless FLOW.projectControl.isLoading}}
             {{view FLOW.SurveySelectionView showDataReadSurveysOnly=true}}
           {{/unless}}

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.MonitoringDataTableView}}
 <section class="" id="monitoringData">
     <div class="floats-in filterData" id="dataFilter">
-      <div class="chooseSurveyData">
+      <div {{bindAttr class="view.missingSurvey:redBorder:chooseSurveyData"}}>
       {{#unless FLOW.projectControl.isLoading}}
         {{view FLOW.SurveySelectionView showMonitoringSurveysOnly=true}}
       {{/unless}}

--- a/Dashboard/app/js/templates/navData/monitoring-data.handlebars
+++ b/Dashboard/app/js/templates/navData/monitoring-data.handlebars
@@ -1,7 +1,7 @@
 {{#view FLOW.MonitoringDataTableView}}
 <section class="" id="monitoringData">
     <div class="floats-in filterData" id="dataFilter">
-      <div {{bindAttr class="view.missingSurvey:redBorder:chooseSurveyData"}}>
+      <div {{bindAttr class="view.missingSurvey:redBorder :chooseSurveyData"}}>
       {{#unless FLOW.projectControl.isLoading}}
         {{view FLOW.SurveySelectionView showMonitoringSurveysOnly=true}}
       {{/unless}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
In the Monitoring  and inspect data tab,  the user must select a survey to be able to see the data points. Currently if she does not select anything and hits 'Find' we show 'No results found'. This error message should apply to when there is no data for a survey and not when a survey is not selected.

#### The solution
* highlight the dropdown when the user hits Find but did not select a survey
* ensure that No results found only shows when a survey is selected that is empty, has no data submitted to it
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
