### PR TITLE
Store data before changing the loading flags (connect #2827)

### DIFF
--- a/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
+++ b/Dashboard/app/js/lib/models/FLOWrest-adapter-v2-common.js
@@ -166,11 +166,11 @@ DS.FLOWRESTAdapter = DS.RESTAdapter.extend({
   },
 
   didFindAll: function (store, type, json) {
+    this._super(store, type, json);
     if (type === FLOW.SurveyGroup) {
       FLOW.projectControl.set('isLoading', false);
     }
     FLOW.savingMessageControl.numLoadingChange(-1);
-    this._super(store, type, json);
   },
 
   didFindQuery: function (store, type, json, recordArray) {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Loading flag switched off before fetch result is saved to client data store causing delay between the flag disappearing and the data displaying
#### The solution
Switch the order of logic
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
