### PR TITLE
 Indicate form must be selected via exports page(connect #2380)

### DIFF
--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -39,13 +39,11 @@ FLOW.ExportReportsView = Ember.View.extend({
   
   updateSurveyStatus: function(surveyStatus){
      if (surveyStatus === 'survey-selected') {
-       console.log('survey selected finally')
        this.set('missingSurvey',false)
      }else if (surveyStatus === 'not-selected') {
-       console.log('not selected survey')
        this.set('missingSurvey',true)
      }else{
-       console.log('nothing boy ....')
+       //do nothing....
      }
   }
 });
@@ -162,9 +160,6 @@ FLOW.ExportReportTypeView = Ember.View.extend({
       this.get('parentView').updateSurveyStatus('not-selected')
       return;
     }
-    if (this.incompleteSurveySelection()) {
-      return;
-    }
     FLOW.ReportLoader.load('COMPREHENSIVE', sId, opts);
   },
 
@@ -191,6 +186,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     var sId = this.get('selectedSurvey');
     if (!sId) {
       this.get('parentView').updateSurveyStatus('not-selected')
+      return;
     }
 
     FLOW.editControl.set('summaryPerGeoArea', true);

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -55,6 +55,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
   onlyRecentText: Ember.String.loc('_only_recent_submissions'),
   tagName: 'li',
   classNames: 'trigger',
+  missingSurvey: false,
 
   dateRangeDisabledObserver: function () {
     this.set('rangeActive', this.get("exportOption") === "range" ? "" : "background-color: transparent;");
@@ -97,6 +98,22 @@ FLOW.ExportReportTypeView = Ember.View.extend({
       return null;
     }
   }.property('FLOW.selectedControl.selectedQuestion'),
+  
+  incompleteSurveySelection: function(){
+     if (FLOW.selectedControl.get('selectedSurvey') == null) {
+       console.log('survey is not selected')
+        this.set('missingSurvey', true);
+        return true;
+     }
+     return false;
+  },
+  
+  watchSurveySelection: function(){
+     console.log('survey has been selected')
+     if (FLOW.selectedControl.get('selectedSurvey')!== null) {
+        this.set('missingSurvey', false)
+     }
+  }.observes('FLOW.selectedControl.selectedSurvey'),
 
   hideLastCollection: function () {
     if (!FLOW.selectedControl.selectedSurvey) {
@@ -120,8 +137,16 @@ FLOW.ExportReportTypeView = Ember.View.extend({
   showDataCleaningReport: function () {
     var opts = {startDate:this.get("reportFromDate"), endDate:this.get("reportToDate"), lastCollectionOnly: this.get('exportOption') === "recent"};
     var sId = this.get('selectedSurvey');
-    if (!sId) {
+    /*if (!sId) {
       this.showWarning();
+      return;
+    }*/
+    //console.log(sId)
+    if (!sId) {
+       console.log('hey nothing')
+       return;
+    }
+    if (this.incompleteSurveySelection()) {
       return;
     }
     FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
@@ -132,6 +157,10 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     var sId = this.get('selectedSurvey');
     if (!sId) {
       this.showWarning();
+      console.log('hey nothing')
+      return;
+    }
+    if (this.incompleteSurveySelection()) {
       return;
     }
     FLOW.ReportLoader.load('DATA_ANALYSIS', sId, opts);
@@ -141,6 +170,10 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     var opts = {}, sId = this.get('selectedSurvey');
     if (!sId) {
       this.showWarning();
+      console.log('hey nothing....')
+      return;
+    }
+    if (this.incompleteSurveySelection()) {
       return;
     }
     FLOW.ReportLoader.load('COMPREHENSIVE', sId, opts);
@@ -162,8 +195,11 @@ FLOW.ExportReportTypeView = Ember.View.extend({
 
   showSurveyForm: function () {
     var sId = this.get('selectedSurvey');
-    if (!sId) {
+    /*if (!sId) {
       this.showWarning();
+      return;
+    }*/
+    if (this.incompleteSurveySelection()) {
       return;
     }
     FLOW.ReportLoader.load('SURVEY_FORM', sId);
@@ -171,8 +207,11 @@ FLOW.ExportReportTypeView = Ember.View.extend({
 
   showComprehensiveOptions: function () {
     var sId = this.get('selectedSurvey');
-    if (!sId) {
+    /*if (!sId) {
       this.showWarning();
+      return;
+    }*/
+    if (this.incompleteSurveySelection()) {
       return;
     }
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -38,11 +38,7 @@ FLOW.ExportReportsView = Ember.View.extend({
   missingSurvey: false,
   
   updateSurveyStatus: function (surveyStatus) {
-     if (surveyStatus === 'survey-selected') {
-         this.set('missingSurvey',false)
-     } else {
-         this.set('missingSurvey',true)
-     }
+     this.set('missingSurvey', surveyStatus !== 'survey-selected')
   }
 });
 

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -34,7 +34,16 @@ FLOW.ReportLoader = Ember.Object.create({
 });
 
 FLOW.ExportReportsView = Ember.View.extend({
-  templateName: 'navReports/export-reports'
+  templateName: 'navReports/export-reports',
+  updateSurveyStatus: function(surveyStatus){
+     if (surveyStatus === 'survey-selected') {
+       console.log('survey selected finally')
+     }else if (surveyStatus === 'not-selected') {
+       console.log('not selected survey')
+     }else{
+       console.log('nothing boy ....')
+     }
+  }
 });
 
 FLOW.ExportReportTypeView = Ember.View.extend({
@@ -55,7 +64,6 @@ FLOW.ExportReportTypeView = Ember.View.extend({
   onlyRecentText: Ember.String.loc('_only_recent_submissions'),
   tagName: 'li',
   classNames: 'trigger',
-  missingSurvey: false,
 
   dateRangeDisabledObserver: function () {
     this.set('rangeActive', this.get("exportOption") === "range" ? "" : "background-color: transparent;");
@@ -99,19 +107,9 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     }
   }.property('FLOW.selectedControl.selectedQuestion'),
   
-  incompleteSurveySelection: function(){
-     if (FLOW.selectedControl.get('selectedSurvey') == null) {
-       console.log('survey is not selected')
-        this.set('missingSurvey', true);
-        return true;
-     }
-     return false;
-  },
-  
   watchSurveySelection: function(){
-     console.log('survey has been selected')
      if (FLOW.selectedControl.get('selectedSurvey')!== null) {
-        this.set('missingSurvey', false)
+        this.get('parentView').updateSurveyStatus('survey-selected')
      }
   }.observes('FLOW.selectedControl.selectedSurvey'),
 
@@ -137,17 +135,9 @@ FLOW.ExportReportTypeView = Ember.View.extend({
   showDataCleaningReport: function () {
     var opts = {startDate:this.get("reportFromDate"), endDate:this.get("reportToDate"), lastCollectionOnly: this.get('exportOption') === "recent"};
     var sId = this.get('selectedSurvey');
-    /*if (!sId) {
-      this.showWarning();
-      return;
-    }*/
-    //console.log(sId)
     if (!sId) {
-       console.log('hey nothing')
+       this.get('parentView').updateSurveyStatus('not-selected')
        return;
-    }
-    if (this.incompleteSurveySelection()) {
-      return;
     }
     FLOW.ReportLoader.load('DATA_CLEANING', sId, opts);
   },
@@ -156,11 +146,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     var opts = {startDate:this.get("reportFromDate"), endDate:this.get("reportToDate"), lastCollectionOnly: this.get('exportOption') === "recent"};
     var sId = this.get('selectedSurvey');
     if (!sId) {
-      this.showWarning();
-      console.log('hey nothing')
-      return;
-    }
-    if (this.incompleteSurveySelection()) {
+      this.get('parentView').updateSurveyStatus('not-selected')
       return;
     }
     FLOW.ReportLoader.load('DATA_ANALYSIS', sId, opts);
@@ -169,8 +155,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
   showComprehensiveReport: function () {
     var opts = {}, sId = this.get('selectedSurvey');
     if (!sId) {
-      this.showWarning();
-      console.log('hey nothing....')
+      this.get('parentView').updateSurveyStatus('not-selected')
       return;
     }
     if (this.incompleteSurveySelection()) {
@@ -183,11 +168,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     var sId = this.get('selectedSurvey');
     var qId = this.get('selectedQuestion');
     if (!sId || !qId) {
-      FLOW.ReportLoader.showDialogMessage(
-        Ember.String.loc('_export_data'),
-        Ember.String.loc('_select_survey_and_geoshape_question_warning'),
-        'ignore'
-      );
+      this.get('parentView').updateSurveyStatus('not-selected')
       return;
     }
     FLOW.ReportLoader.load('GEOSHAPE', sId, {"questionId": qId});
@@ -195,11 +176,8 @@ FLOW.ExportReportTypeView = Ember.View.extend({
 
   showSurveyForm: function () {
     var sId = this.get('selectedSurvey');
-    /*if (!sId) {
-      this.showWarning();
-      return;
-    }*/
-    if (this.incompleteSurveySelection()) {
+    if (!sId) {
+      this.get('parentView').updateSurveyStatus('not-selected')
       return;
     }
     FLOW.ReportLoader.load('SURVEY_FORM', sId);
@@ -207,12 +185,8 @@ FLOW.ExportReportTypeView = Ember.View.extend({
 
   showComprehensiveOptions: function () {
     var sId = this.get('selectedSurvey');
-    /*if (!sId) {
-      this.showWarning();
-      return;
-    }*/
-    if (this.incompleteSurveySelection()) {
-      return;
+    if (!sId) {
+      this.get('parentView').updateSurveyStatus('not-selected')
     }
 
     FLOW.editControl.set('summaryPerGeoArea', true);

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -35,11 +35,15 @@ FLOW.ReportLoader = Ember.Object.create({
 
 FLOW.ExportReportsView = Ember.View.extend({
   templateName: 'navReports/export-reports',
+  missingSurvey: false,
+  
   updateSurveyStatus: function(surveyStatus){
      if (surveyStatus === 'survey-selected') {
        console.log('survey selected finally')
+       this.set('missingSurvey',false)
      }else if (surveyStatus === 'not-selected') {
        console.log('not selected survey')
+       this.set('missingSurvey',true)
      }else{
        console.log('nothing boy ....')
      }

--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -37,13 +37,11 @@ FLOW.ExportReportsView = Ember.View.extend({
   templateName: 'navReports/export-reports',
   missingSurvey: false,
   
-  updateSurveyStatus: function(surveyStatus){
+  updateSurveyStatus: function (surveyStatus) {
      if (surveyStatus === 'survey-selected') {
-       this.set('missingSurvey',false)
-     }else if (surveyStatus === 'not-selected') {
-       this.set('missingSurvey',true)
-     }else{
-       //do nothing....
+         this.set('missingSurvey',false)
+     } else {
+         this.set('missingSurvey',true)
      }
   }
 });
@@ -109,7 +107,7 @@ FLOW.ExportReportTypeView = Ember.View.extend({
     }
   }.property('FLOW.selectedControl.selectedQuestion'),
   
-  watchSurveySelection: function(){
+  watchSurveySelection: function () {
      if (FLOW.selectedControl.get('selectedSurvey')!== null) {
         this.get('parentView').updateSurveyStatus('survey-selected')
      }

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -5,6 +5,7 @@
   </div>
     <div class="surveySelect">
       <nav class="breadCrumb floats-in">
+       <div {{bindAttr class= "view.missingSurvey:redBorder"}}>
         {{#unless FLOW.projectControl.isLoading}}
           {{view FLOW.SurveySelectionView showDataReadSurveysOnly=true}}
         {{/unless}}
@@ -17,6 +18,7 @@
               prompt=""
               promptBinding="Ember.STRINGS._select_form" id="monitorSelection"}}
         {{/if}}
+       </div>
       </nav>
     </div>
     <section class="exportContainer">


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Under the export reports tab, if one of the download options was selected without first selecting the survey:
-Data cleaning export: nothing would happen
-Data analysis export: a pop up dialog with the message error generating report would be displayed
-Comprehensive report: a pop up dialog with the message 'your report is being prepared' would be displayed
-Geoshape data: a pop up dialog with the message 'please select a form and a geoshape question' would be displayed
-Survey Form: a pop up dialog with the message 'you must select a survey to run a report' would be displayed
#### The solution
Show the highlight box around the survey dropdown when the survey is not selected yet the user is trying to generate the exports
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
