### PR TITLE
Hotfix for indicate the form must be selected in the export tab(connect #2380)

### DIFF
--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -39,6 +39,7 @@ FLOW.ExportReportsView = Ember.View.extend({
   
   updateSurveyStatus: function (surveyStatus) {
      this.set('missingSurvey', surveyStatus !== 'survey-selected')
+     Ember.$('body, html ,#navExportSelect').scrollTop(0);
   }
 });
 

--- a/Dashboard/app/js/templates/navReports/export-reports.handlebars
+++ b/Dashboard/app/js/templates/navReports/export-reports.handlebars
@@ -4,7 +4,7 @@
     <a {{action "doReportsList"}} class="button exportNewBtn">{{t _back_to_reports}}</a>
   </div>
     <div class="surveySelect">
-      <nav class="breadCrumb floats-in">
+      <nav class="breadCrumb floats-in" id = "navExportSelect">
        <div {{bindAttr class= "view.missingSurvey:redBorder"}}>
         {{#unless FLOW.projectControl.isLoading}}
           {{view FLOW.SurveySelectionView showDataReadSurveysOnly=true}}


### PR DESCRIPTION
…filter

#### Before the PR (what is the issue or what needed to be done)
Challenge is that when the user clicks the generate button in the exports tab without first selecting the survey forms, the survey selection filters get highlighted but the user cannot currently see it unless she scrolls up.
#### The solution
Scroll back to the top to show the highlighted survey filters so that user can be ware that he has not yet selected the survey.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
