### PR TITLE
Load data for non monitoring surveys (connect #2680)

### DIFF
--- a/Dashboard/app/js/lib/controllers/maps-controllers-common.js
+++ b/Dashboard/app/js/lib/controllers/maps-controllers-common.js
@@ -342,14 +342,18 @@ FLOW.placemarkDetailController = Ember.ArrayController.create({
         }
 
       var survey = FLOW.projectControl.content.filterProperty('keyId', this.dataPoint.get('surveyGroupId')).get('firstObject');
-      var registrationFormId, registrationFormInstance;
-      if (survey) {
-          registrationFormId = survey.get('newLocaleSurveyId');
-          registrationFormInstance = formInstances.filterProperty('surveyId', registrationFormId).get('firstObject');
+      if (!survey) return;
+
+      var formInstance;
+      if (survey.get('monitoringGroup')) {
+          var registrationFormId = survey.get('newLocaleSurveyId');
+          formInstance = formInstances.filterProperty('surveyId', registrationFormId).get('firstObject');
+      } else {
+          formInstance = formInstances.get('firstObject');
       }
 
-      if (registrationFormInstance) {
-          FLOW.questionAnswerControl.doQuestionAnswerQuery(registrationFormInstance);
+      if (formInstance) {
+          FLOW.questionAnswerControl.doQuestionAnswerQuery(formInstance);
       }
   }.observes('FLOW.surveyInstanceControl.content.isLoaded'),
 });


### PR DESCRIPTION
#### The problem

* When one clicked on a datapoint belonging to a non-monitoring survey, the responses were not correctly retrieved because the logic always assumed a monitoring survey.

#### The solution
* For the non-monitoring surveys, we take the first (and only) form instance for a data point to correctly retrieve its associated responses

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
