### PR TITLE
Render caddisfly response on maps tab (#1750)

### DIFF
--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -96,7 +96,7 @@ FLOW.renderCaddisflyAnswer = function(json){
         var jsonParsed = JSON.parse(json);
 
         // get out image url
-        if (!Ember.empty(jsonParsed.image)){
+        if ('image' in jsonParsed){
           imageUrl = FLOW.Env.photo_url_root + jsonParsed.image.trim();
         }
 
@@ -106,7 +106,7 @@ FLOW.renderCaddisflyAnswer = function(json){
                 return "<br><div>" + item.name + " : " + item.value + " " + item.unit + "</div>";
             }).join("\n");
         html += "<br>"
-        html += "<div class=\"signatureImage\"><img src=\"" + imageUrl +"\"}} /></div>"
+        html += "<div class=\"signatureImage\"><img src=\"" + imageUrl +"\"/></div>"
         return html;
     } catch (e) {
         return json;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Caddisfly response displaying as a json string on the details panel of maps tab
#### The solution
Changed how we check for "image" property on caddisfly response
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
