### PR TITLE
Enable editing created folder name when creating it (connect #2875)

### DIFF
--- a/Dashboard/app/js/lib/views/surveys/survey-group-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-group-views.js
@@ -355,6 +355,7 @@ FLOW.FolderEditView = Ember.TextField.extend({
 
   insertNewline: function() {
     this.get('parentView').set('folderEdit', false);
+    this.saveFolderName();
   }
 });
 

--- a/Dashboard/app/js/lib/views/surveys/survey-group-views.js
+++ b/Dashboard/app/js/lib/views/surveys/survey-group-views.js
@@ -321,7 +321,7 @@ FLOW.ProjectItemView = FLOW.View.extend({
 
   showSurveyEditButton: function() {
     var survey = this.get('content');
-    return FLOW.permControl.canEditSurvey(survey);
+    return FLOW.permControl.canEditSurvey(survey) || FLOW.projectControl.get('newlyCreated') === survey;
   }.property(),
 
   showSurveyMoveButton: function() {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
User has to open a created folder then navigate back to parent folder to be able to edit created folder's name
Hitting enter when editing folder name doesn't save the change as should based on f767d161603099324783f93414f7baf793dc3caf
#### The solution
Enable editing folder name immediately after creating it
Enable saving folder name by hitting enter
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [x] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
