### PR TITLE
Remove delay between loading animation and display of submissions (connect #2827)

### DIFF
--- a/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
+++ b/Dashboard/app/js/lib/views/data/inspect-data-table-views.js
@@ -75,12 +75,6 @@ FLOW.inspectDataTableView = FLOW.View.extend({
       this.set('surveyId', null);
     }
 
-    // if we have selected a survey, preload the questions as we'll need them
-    // the questions are also loaded once the surveyInstances come in.
-    if (FLOW.selectedControl.get('selectedSurvey')) {
-      FLOW.questionControl.populateAllQuestions(FLOW.selectedControl.selectedSurvey.get('keyId'));
-    }
-
     if (!Ember.none(FLOW.locationControl.get('selectedCountry'))) {
       this.set('selectedCountryCode',FLOW.locationControl.selectedCountry.get('iso'));
     } else {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
In the inspect data tab, when a user selects a form then clicks on "Find", the dashboard makes a call to the questions endpoint first then to the survey instances resulting in the loading animation disappearing before the survey instances have finished pulling
#### The solution
We already have the questions pulled when we selected the form via the filter so remove the unnecessary call
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
