### PR TITLE
[#2906]Remove always logging an error(Connect #2906)

### DIFF
--- a/GAE/src/org/akvo/flow/events/EventLogger.java
+++ b/GAE/src/org/akvo/flow/events/EventLogger.java
@@ -68,7 +68,6 @@ public class EventLogger {
             String urlPath = PropertyUtil.getProperty(Prop.EVENT_NOTIFICATION);
 
             if (urlPath == null || urlPath.trim().length() == 0) {
-                logger.log(Level.SEVERE, "Event notification URL not present in appengine-web.xml");
                 return;
             }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Errors were logged for each failed notification, *or* each notification that was not possible because of missing or empty config parameter, cluttering the logs.
#### The solution
Remove logging of error if no config.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
