### PR TITLE
[#2742]Just ouput codes for OPTION+CASCADE in analysis+comprehensive (connect #2742)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -160,7 +160,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
     private boolean variableNamesInHeaders; // Also turns on splitting of answers into separate columns (options, geo, etc.) and turns off digests
     private boolean splitIntoColumns; // Turns on splitting of answers into separate columns (options, geo, etc.) and turns off digests
     private boolean separateSheetsForRepeatableGroups;
-    private boolean justCodes; //Only output the codes fro multiple-choice answers (option and cascade)
+    private boolean justCodes; //Only output the codes from multiple-choice answers (option and cascade)
     private boolean doGroupHeaders; //First header line is group names spanned over the group columns
     private Map<Long, QuestionDto> questionsById;
     private SurveyGroupDto surveyGroupDto;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
For cascade, **code:name** was output unless all had codes, then just **code**.
For option, **code:name** if code defined, otherwise **name**.
#### The solution
For analysis+comprehensive formats, output **code** if it exists, otherwise **name**.
For data cleaning format, as before, **code:name** if code defined, otherwise **name**.
#### Screenshots (if appropriate)

## Checklist
* [x] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
