### PR TITLE
Issue/2926 cascade codes (Connect #2926)

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -115,8 +114,8 @@ public class CascadeNodeRestService {
                 if (cr != null) {
                     // copy the properties, except the createdDateTime property,
                     // because it is set in the Dao.
-                    BeanUtils.copyProperties(cascadeNodeDto, cr, new String[] {
-                            "createdDateTime"});
+                    BeanUtils.copyProperties(cascadeNodeDto, cr,
+                    		new String[] {"createdDateTime"});
                     cr = cascadeNodeDao.save(cr);
                     dto = new CascadeNodeDto();
                     BeanUtils.copyProperties(cr, dto);
@@ -188,7 +187,7 @@ public class CascadeNodeRestService {
         }
 
         String status = stateSuccess ? "ok" : "failed";
-        if (status.equals("failed")) {
+        if (!stateSuccess) {
             statusDto.setMessage("Cannot save cascade nodes");
         }
         statusDto.setStatus(status);

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2014,2017 Stichting Akvo (Akvo Foundation)
+/*  Copyright (C) 2014,2017-2018 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/CascadeNodeRestService.java
@@ -160,9 +160,6 @@ public class CascadeNodeRestService {
     private CascadeNodeDto createCascadeNode(CascadeNodeDto cascadeNodeDto){
     	CascadeNode cn = new CascadeNode();
         BeanUtils.copyProperties(cascadeNodeDto, cn);
-        if (StringUtils.isEmpty(cascadeNodeDto.getCode())) {
-            cn.setCode(cn.getName());
-        }
     	cn = cascadeNodeDao.save(cn);
     	CascadeNodeDto cnDto = new CascadeNodeDto();
     	DtoMarshaller.copyToDto(cn,cnDto);
@@ -174,8 +171,7 @@ public class CascadeNodeRestService {
     @ResponseBody
     public Map<String, Object> saveNewCascadeNodeBulk(@RequestBody
     CascadeNodeBulkPayload payLoad) {
-    	final List<CascadeNodeDto> cascadeNodeDtoList = payLoad
-                .getCascade_nodes();
+    	final List<CascadeNodeDto> cascadeNodeDtoList = payLoad.getCascade_nodes();
         final Map<String, Object> response = new HashMap<String, Object>();
         List<CascadeNodeDto> results = new ArrayList<CascadeNodeDto>();
         CascadeNodeDto dto = null;

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -995,6 +995,25 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
                 cascadeNodes.add(m);
             }
         }
+        
+        //We used to always set code=name if not otherwise set
+        //and users did not like getting a:a, b:b, etc. everywhere 
+        boolean allCodesEqualsName = true;
+        for (Map<String, String> cascadeNode : cascadeNodes) {
+            String code = cascadeNode.get("code");
+            String name = cascadeNode.get("name");
+            if (code != null && name != null
+                    && !code.toLowerCase().equals(name.toLowerCase())) {
+                allCodesEqualsName = false;
+                break;
+            }
+        }
+        if (allCodesEqualsName) {
+            for (Map<String, String> cascadeNode : cascadeNodes) {
+                cascadeNode.put("code", null);
+            }
+        }
+
 
         if (splitIntoColumns) {
             // +------------+------------+-----
@@ -1007,7 +1026,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
                 String code = map.get("code");
                 String name = map.get("name");
                 String nodeVal;
-                if (code != null) {
+                if (code != null  && !code.isEmpty()) {
                     if (justCodes) {
                         nodeVal = code;
                     } else {
@@ -1039,7 +1058,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
                 String code = node.get("code");
                 String name = node.get("name");
                 cascadeString.append("|");
-                if (code != null) {
+                if (code != null  && !code.isEmpty()) {
                     if (justCodes) {
                         cascadeString.append(code);
                     } else {

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -1002,8 +1002,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
         for (Map<String, String> cascadeNode : cascadeNodes) {
             String code = cascadeNode.get("code");
             String name = cascadeNode.get("name");
-            if (code != null && name != null
-                    && !code.toLowerCase().equals(name.toLowerCase())) {
+            if (code != null && !code.equalsIgnoreCase(name)) {
                 allCodesEqualsName = false;
                 break;
             }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
We have always set the code from the name for cascade nodes.
With a recent change this became visible in the data cleaning report.
#### The solution
Stop setting codes like that.
For backwards compatibility, go back to hiding codes when identical to names.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
