### PR TITLE
[#2919]Answer to name used in local dev config file. (connect #2919)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     command: tail -f /dev/null
     links:
      - s3:akvoflowsandbox.s3.amazonaws.com
+     - fake-flow-services:services.akvoflow.local
     ports:
      - 8888:8888
      - 5005:5005
   fake-flow-services:
     image: solsson/http-echo
-    network_mode: service:mainnetwork
     environment:
       - PORT=3000
   s3:


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Fake flow services were not responding to the DNS name in the local instance config file.
Admittedly, the difference between responding 200 to everything and then doing nothing, and not being reachable at all, is minor. Still, it results in an error in flow.
#### The solution
Add that.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
