### PR TITLE
Only split folder separate character for non-signature type responses (connect #2937)

### DIFF
--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -117,12 +117,14 @@ Ember.Handlebars.registerHelper('placemarkDetail', function () {
   var answer, markup, question, cascadeJson, optionJson, cascadeString = "",
   imageSrcAttr, signatureJson, photoJson, self=this;
 
+  responseType = Ember.get(this, 'type');
   question = Ember.get(this, 'questionText');
   answer = Ember.get(this, 'value') || '';
   answer = answer.replace(/\|/g, ' | '); // geo, option and cascade data
-  answer = answer.replace(/\//g, ' / '); // also split folder paths
+  if (responseType != 'CASCADE') {
+    answer = answer.replace(/\//g, ' / '); // also split folder paths
+  }
   answer = answer.replace(/\\/g, ''); // remove escape characters
-  responseType = Ember.get(this, 'type');
 
   if (responseType === 'CASCADE') {
 

--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -121,7 +121,7 @@ Ember.Handlebars.registerHelper('placemarkDetail', function () {
   question = Ember.get(this, 'questionText');
   answer = Ember.get(this, 'value') || '';
   answer = answer.replace(/\|/g, ' | '); // geo, option and cascade data
-  if (responseType != 'CASCADE') {
+  if (responseType != 'SIGNATURE') {
     answer = answer.replace(/\//g, ' / '); // also split folder paths
   }
   answer = answer.replace(/\\/g, ''); // remove escape characters


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Signature responses not loading on maps due to response parsing set to split folder separation character
#### The solution
Set condition to parse only non-signature responses
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
