### PR TITLE
[#2956]Bump py-openssl version to 17.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex ; \
     openssh-client~=7 \
     python2~=2.7 \
     py-crcmod~=1.7 \
-    py-openssl~=17.2 \
+    py-openssl~=17.5 \
     maven~=3.5 \
     libc6-compat~=1.1 \
     su-exec~=0.2 \


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Travis build failed
#### The solution
Go to 17.5
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
