### PR TITLE
Issue/2961 guard against too long messages (connect #2961)

### DIFF
--- a/GAE/src/com/gallatinsystems/messaging/domain/Message.java
+++ b/GAE/src/com/gallatinsystems/messaging/domain/Message.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012, 2019 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -96,6 +96,7 @@ public class Message extends BaseDomain {
     }
 
     //Max 1500 chars
+    //TODO If the UI displayed the long msg instead if it exists, we should clear shortMessage.
     public void setShortMessage(String shortMessage) {
         if (shortMessage.length() > 1500) {
         	setMessage(shortMessage);

--- a/GAE/src/com/gallatinsystems/messaging/domain/Message.java
+++ b/GAE/src/com/gallatinsystems/messaging/domain/Message.java
@@ -95,8 +95,14 @@ public class Message extends BaseDomain {
         return shortMessage;
     }
 
+    //Max 1500 chars
     public void setShortMessage(String shortMessage) {
-        this.shortMessage = shortMessage;
+        if (shortMessage.length() > 1500) {
+        	setMessage(shortMessage);
+        	this.shortMessage = shortMessage.substring(0, 1495) + " ...";
+        } else {
+        	this.shortMessage = shortMessage;
+        }
     }
 
 }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Error messages >1500 chars would not be saved, since the shortMessage field cannot contain those. (The name is a hint!)
#### The solution
Truncate a long message, and store the full one in the message text field. Full msg will not (currently) be shown in the UI, but will at least remain in the data store for debugging.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
