### PR TITLE
Stop removing escape characters for signature responses (connect #2937)

### DIFF
--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -123,8 +123,8 @@ Ember.Handlebars.registerHelper('placemarkDetail', function () {
   answer = answer.replace(/\|/g, ' | '); // geo, option and cascade data
   if (responseType != 'SIGNATURE') {
     answer = answer.replace(/\//g, ' / '); // also split folder paths
+    answer = answer.replace(/\\/g, ''); // remove escape characters
   }
-  answer = answer.replace(/\\/g, ''); // remove escape characters
 
   if (responseType === 'CASCADE') {
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Escape characters being removed even for signature responses which are part of the response string
#### The solution
Stop removing escape characters for signature responses
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
