### PR TITLE
[#1502] Add missing variable to generate version package

### DIFF
--- a/ci/mvn-deploy.sh
+++ b/ci/mvn-deploy.sh
@@ -36,6 +36,7 @@ java -cp /google-cloud-sdk/platform/google_appengine/google/appengine/tools/java
      --application="${PROJECT_ID}" \
      update ./target/appengine-staging
 
+version=$(git describe)
 archive_name="${version}.zip"
 (
     cd target


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* The version (zip) package used for deployment was not being generated, which means deployments would not work because the set of files for that version would not be found on the remove bucket.

#### The solution
* Correctly generate version package with the git tag.


#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
