### PR TITLE
[#3038]Handle long option results

### DIFF
--- a/GAE/src/com/gallatinsystems/common/Constants.java
+++ b/GAE/src/com/gallatinsystems/common/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
             "createUserId"
     };
     public static final int MAX_LENGTH = 500;
+    public static final int MAX_DS_STRING_LENGTH = 1500;
     public static final int CONNECTION_TIMEOUT = 60 * 1000; // 1min
     public static final int READ_TIMEOUT = 2 * 60 * 1000; // 2min
     public static final int TASK_RETRY_INTERVAL = 2 * 10 * 1000; // 2 mins

--- a/GAE/src/org/waterforpeople/mapping/analytics/dao/SurveyQuestionSummaryDao.java
+++ b/GAE/src/org/waterforpeople/mapping/analytics/dao/SurveyQuestionSummaryDao.java
@@ -121,7 +121,10 @@ public class SurveyQuestionSummaryDao extends BaseDAO<SurveyQuestionSummary> {
      */
     @SuppressWarnings("unchecked")
     public List<SurveyQuestionSummary> listByResponse(String questionId, String questionResponse) {
-        //Reject too-long key; TODO truncate instead?
+        if (questionResponse == null) {
+            return Collections.emptyList();
+        }
+        //Truncate too-long key
         String answer = questionResponse;
         if (answer.length() > Constants.MAX_LENGTH) {
             answer = answer.substring(0, Constants.MAX_LENGTH);

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -1436,9 +1436,27 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
         if (surveyedLocaleId != null) {
             options.param(DataProcessorRequest.LOCALE_ID_PARAM, String.valueOf(surveyedLocaleId));
         }
-        com.google.appengine.api.taskqueue.Queue queue = com.google.appengine.api.taskqueue.QueueFactory
-                .getQueue("background-processing");
-        queue.add(options);
+        QueueFactory.getQueue("background-processing").add(options);
+    }
+
+    public static void queueSynchronizedSummaryUpdate(SurveyInstance si, boolean increment) {
+        TaskOptions to = TaskOptions.Builder
+                .withUrl("/app_worker/dataprocessor")
+                .param(DataProcessorRequest.ACTION_PARAM,
+                        DataProcessorRequest.UPDATE_SURVEY_INSTANCE_SUMMARIES)
+                .param(DataProcessorRequest.SURVEY_INSTANCE_PARAM, si.getKey().getId() + "")
+                .param(DataProcessorRequest.DELTA_PARAM, increment ? "1":"-1");
+        QueueFactory.getQueue("surveyResponseCount").add(to);
+    }
+
+    public static void queueAdjustSurveyResponseCount(String key, boolean increment) {
+        TaskOptions to = TaskOptions.Builder
+                .withUrl("/app_worker/dataprocessor")
+                .param(DataProcessorRequest.ACTION_PARAM,
+                        DataProcessorRequest.SURVEY_RESPONSE_COUNT)
+                .param(DataProcessorRequest.COUNTER_ID_PARAM, key)
+                .param(DataProcessorRequest.DELTA_PARAM, increment ? "1":"-1");
+        QueueFactory.getQueue("surveyResponseCount").add(to);
     }
 
 }


### PR DESCRIPTION

#### Before the PR (what is the issue or what needed to be done)
Long/JSON results are not handled when looking up summary data.
#### The solution
Take apart JSON results and handle it without a crash if it still is too long.
Also moved the task-submitting code to DataProcessorRestServelet, where the task will be handled.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
