### PR TITLE
Disable saving nameless assignment (connect #3132)

### DIFF
--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.js
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.js
@@ -29,6 +29,7 @@ FLOW.formatDate = function (value) {
 };
 
 FLOW.AssignmentEditView = FLOW.View.extend(observe({
+  'this.assignmentName': 'validateAssignmentObserver',
   'FLOW.router.navigationController.selected': 'detectChangeTab',
   'FLOW.router.devicesSubnavController.selected': 'detectChangeTab',
 }), {
@@ -223,5 +224,16 @@ FLOW.AssignmentEditView = FLOW.View.extend(observe({
 
   removeAllDevices() {
     this.set('devicesPreview', Ember.A([]));
+  },
+
+  validateAssignmentObserver() {
+    this.set('assignmentValidationFailure', (
+      (this.assignmentName && this.assignmentName.length > 100)
+      || !this.assignmentName || this.assignmentName == ''));
+    if (this.assignmentName && this.assignmentName.length > 100) {
+      this.set('assignmentValidationFailureReason', Ember.String.loc('_assignment_name_over_100_chars'));
+    } else if (!this.assignmentName || this.assignmentName == '') {
+      this.set('assignmentValidationFailureReason', Ember.String.loc('_assignment_name_not_set'));
+    }
   },
 });

--- a/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
@@ -64,7 +64,9 @@ FLOW.AssignmentsListView = FLOW.ReactComponentView.extend(observe({
   assignmentEdit(action, assignmentId) {
     switch (action) {
       case 'new': {
-        const newAssignment = FLOW.store.createRecord(FLOW.SurveyAssignment, {});
+        const newAssignment = FLOW.store.createRecord(FLOW.SurveyAssignment, {
+          name: Ember.String.loc('_new_question_please_change_name'),
+        });
         FLOW.selectedControl.set('selectedSurveyAssignment', newAssignment);
         break;
       }

--- a/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
@@ -65,7 +65,7 @@ FLOW.AssignmentsListView = FLOW.ReactComponentView.extend(observe({
     switch (action) {
       case 'new': {
         const newAssignment = FLOW.store.createRecord(FLOW.SurveyAssignment, {
-          name: Ember.String.loc('_new_question_please_change_name'),
+          name: Ember.String.loc('_new_assignment_change_name'),
         });
         FLOW.selectedControl.set('selectedSurveyAssignment', newAssignment);
         break;

--- a/Dashboard/app/js/templates/navDevices/assignment-edit-tab/assignment-edit.handlebars
+++ b/Dashboard/app/js/templates/navDevices/assignment-edit-tab/assignment-edit.handlebars
@@ -4,7 +4,11 @@
     <form>
       <fieldset id="assignmentDetails">
         <h2>01. {{t _assignment_details}}</h2>
-        <label for="assignmentName">{{t _assignment_name}}:</label>
+        <label for="assignmentName">{{t _assignment_name}}:
+          {{#if view.assignmentValidationFailure }}
+            <span style="color:red">{{view.assignmentValidationFailureReason}}</span>
+          {{/if}}
+        </label>
           {{view Ember.TextField
             valueBinding="view.assignmentName"
             id="assignmentName"
@@ -161,7 +165,11 @@
       </div>
       <div class="menuConfirm">
         <ul>
-          <li><a {{action "saveSurveyAssignment" target="this"}} class="standardBtn">{{t _save_assignment}}</a></li>
+          {{#if view.assignmentValidationFailure}}
+            <li><a class="button noChanges" id="standardBtn">{{t _save_assignment}}</a> </li>
+          {{else}}
+            <li><a {{action "saveSurveyAssignment" target="this"}} class="standardBtn">{{t _save_assignment}}</a></li>
+          {{/if}}
           <li><a {{action "cancelEditSurveyAssignment" target="this"}} class="">{{t _cancel}}</a></li>
         </ul>
       </div>

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -293,6 +293,7 @@ Move\ up = Move up
 Moving = Moving
 Name = Name
 New\ approval\ group = New approval group
+New\ assignment\ -\ please\ change\ name = New assignment - please change name
 New\ export = New export
 New\ folder = New folder
 New\ form = New form

--- a/GAE/src/locale/en.properties
+++ b/GAE/src/locale/en.properties
@@ -61,6 +61,7 @@ Are\ you\ sure\ you\ want\ to\ delete\ this\ user? = Are you sure you want to de
 Area = Area
 Assignment\ details = Assignment details
 Assignment\ name = Assignment name
+Assignment\ name\ cannot\ be\ more\ than\ 100\ characters = Assignment name cannot be more than 100 characters
 Assignment\ name\ not\ set = Assignment name not set
 Assignments\ list = Assignments list
 Attaching\ a\ metric\ to\ a\ question\ is\ a\ way\ to\ follow\ questions\ over\ multiple\ surveys.\ In\ future,\ this\ will\ be\ used\ for\ reporting\ across\ multiple\ surveys. = Attaching a metric to a question is a way to follow questions over multiple surveys. In future, this will be used for reporting across multiple surveys.

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -316,6 +316,7 @@ _move_up = Move up
 _moving = Moving
 _name = Name
 _new_approval_group = New approval group
+_new_assignment_change_name = New assignment - please change name
 _new_export = New export
 _new_folder = New folder
 _new_form = New form

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -52,6 +52,7 @@ _assignment_details = Assignment details
 _assignment_name = Assignment name
 _assignment_name_not_set = Assignment name not set
 _assignment_name_not_set_text = Before saving an assignment, you need to set an assignment name
+_assignment_name_over_100_chars = Assignment name cannot be more than 100 characters
 _assignments_list = Assignments list
 _attr_delete_header = Are you sure you want to delete this metric?
 _attribute_group = Metric group (optional)


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Save option available even when no assignment name is set resulting in a sometimes empty assignments 
#### The solution
Add validation for assignment name
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
