### PR TITLE
[#3139] Stop unnecessary loading of all Survey entities when forms are loaded

### DIFF
--- a/Dashboard/app/js/lib/models/models.js
+++ b/Dashboard/app/js/lib/models/models.js
@@ -155,18 +155,13 @@ FLOW.Survey = FLOW.BaseModel.extend({
     defaultValue: null,
   }),
 
-  /* computer property that is used in the assignment edit page but never saved to backend.
+  /* computed property that is used in the assignment edit page but never saved to backend.
   it should ideally appear as a view property. to be refactored */
   surveyGroupName: Ember.computed(function () {
-    const ancestorIds = this.get('ancestorIds');
-    const sgId = this.get('surveyGroupId');
-    // confirm form has at least the root and the parent survey as ancestors
-    if (sgId && ancestorIds.length > 1) {
-      const sg = FLOW.store.find(FLOW.SurveyGroup, sgId);
-      if (!Ember.empty(sg)) {
-        this.set('surveyGroupName', sg.get('code'));
-      }
-    }
+    const surveyId = this.get('surveyGroupId');
+    const survey = surveyId && FLOW.store.find(FLOW.SurveyGroup, surveyId);
+    if (!Ember.empty(survey)) return survey.get('name');
+    return '';
   }).property(''),
 
   allowEdit: Ember.computed(function () {

--- a/Dashboard/app/js/lib/models/models.js
+++ b/Dashboard/app/js/lib/models/models.js
@@ -133,18 +133,6 @@ FLOW.SurveyGroup = FLOW.BaseModel.extend({
 
 
 FLOW.Survey = FLOW.BaseModel.extend({
-  didLoad() {
-    // set the survey group name
-    const ancestorIds = this.get('ancestorIds');
-    const sgId = this.get('surveyGroupId');
-    // confirm form has at least the root and the parent survey as ancestors
-    if (sgId && ancestorIds.length > 1) {
-      const sg = FLOW.store.find(FLOW.SurveyGroup, sgId);
-      if (!Ember.empty(sg)) {
-        this.set('surveyGroupName', sg.get('code'));
-      }
-    }
-  },
 
   defaultLanguageCode: DS.attr('string'),
   status: DS.attr('string'),
@@ -167,8 +155,19 @@ FLOW.Survey = FLOW.BaseModel.extend({
     defaultValue: null,
   }),
 
-  // used in the assignment edit page, not saved to backend
-  surveyGroupName: null,
+  /* computer property that is used in the assignment edit page but never saved to backend.
+  it should ideally appear as a view property. to be refactored */
+  surveyGroupName: Ember.computed(function () {
+    const ancestorIds = this.get('ancestorIds');
+    const sgId = this.get('surveyGroupId');
+    // confirm form has at least the root and the parent survey as ancestors
+    if (sgId && ancestorIds.length > 1) {
+      const sg = FLOW.store.find(FLOW.SurveyGroup, sgId);
+      if (!Ember.empty(sg)) {
+        this.set('surveyGroupName', sg.get('code'));
+      }
+    }
+  }).property(''),
 
   allowEdit: Ember.computed(function () {
     return !this.get('isNew') && this.get('status') !== 'COPYING';


### PR DESCRIPTION
## Before the PR (what is the issue or what needed to be done)
* Surveys loaded one by one making loads of unnecessary requests to the backend

#### The solution
* Create computed property that defines property for which all the surveys were previously loaded.

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
