### PR TITLE
[#3142] Retrieve entities with known IDs in a single batch request

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -77,7 +77,6 @@
         <groupId>org.datanucleus</groupId>
         <artifactId>datanucleus-core</artifactId>
         <version>3.1.3</version>
-        <scope>runtime</scope>
     </dependency>
     <dependency>
         <groupId>org.datanucleus</groupId>

--- a/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
+++ b/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2018 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2019 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
+++ b/GAE/src/com/gallatinsystems/framework/dao/BaseDAO.java
@@ -17,6 +17,7 @@
 package com.gallatinsystems.framework.dao;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* Entities with known IDs retrieved one by one by repeatedly making requests to the datastore for each entity.

#### The solution

* We make a single request to the datastore with the list of IDs

#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
