### PR TITLE
Remove dependency causing build failure connect (#3138)

### DIFF
--- a/Dashboard/package.json
+++ b/Dashboard/package.json
@@ -8,11 +8,10 @@
     "lint:quiet": "npm run lint -- --quiet"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
     "babel-register": "^6.26.0",
     "dayjs": "^1.8.12",
     "handlebars": "^4.1.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Upgrading from babel 6 to 7 requires deeper dependencies upgrade which is causing builds to sometimes fail
#### The solution
revert to v6 for now
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
