### PR TITLE
Data scripts to update Unilog

### DIFF
--- a/GAE/src/org/akvo/flow/events/EventLogger.java
+++ b/GAE/src/org/akvo/flow/events/EventLogger.java
@@ -16,14 +16,6 @@
 
 package org.akvo.flow.events;
 
-import static com.gallatinsystems.common.util.MemCacheUtils.initCache;
-import static org.akvo.flow.events.EventUtils.getEventAndActionType;
-import static org.akvo.flow.events.EventUtils.newContext;
-import static org.akvo.flow.events.EventUtils.newEntity;
-import static org.akvo.flow.events.EventUtils.newEvent;
-import static org.akvo.flow.events.EventUtils.newSource;
-import static org.akvo.flow.events.EventUtils.populateEntityProperties;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -36,10 +28,7 @@ import java.util.logging.Logger;
 
 import net.sf.jsr107cache.Cache;
 
-import org.akvo.flow.events.EventUtils.Action;
-import org.akvo.flow.events.EventUtils.EventTypes;
-import org.akvo.flow.events.EventUtils.Key;
-import org.akvo.flow.events.EventUtils.Prop;
+import org.akvo.flow.events.EventUtils.*;
 import org.akvo.flow.util.FlowJsonObjectWriter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -54,15 +43,20 @@ import com.google.appengine.api.datastore.PostPut;
 import com.google.appengine.api.datastore.PutContext;
 import com.google.appengine.api.utils.SystemProperty;
 
+import static com.gallatinsystems.common.util.MemCacheUtils.initCache;
+import static org.akvo.flow.events.EventUtils.*;
+
 public class EventLogger {
     private static Logger logger = Logger.getLogger(EventLogger.class.getName());
 
     private static final long MIN_TIME_DIFF = 60000; // 60 seconds
 
     private void sendNotification() {
-        try {
-            String urlPath = PropertyUtil.getProperty(Prop.EVENT_NOTIFICATION);
+        sendNotificationToUnilog(PropertyUtil.getProperty(Prop.EVENT_NOTIFICATION), SystemProperty.applicationId.get());
+    }
 
+    public static void sendNotificationToUnilog(String urlPath, String appId) {
+        try {
             if (urlPath == null || urlPath.trim().length() == 0) {
                 return;
             }
@@ -74,7 +68,6 @@ public class EventLogger {
             connection.setRequestProperty("Content-Type", "application/json");
 
             Map<String, String> messageMap = new HashMap<String, String>();
-            String appId = SystemProperty.applicationId.get();
             messageMap.put(Key.APP_ID, appId);
             messageMap.put(Key.URL, appId + ".appspot.com");
 

--- a/GAE/src/org/akvo/flow/events/EventUtils.java
+++ b/GAE/src/org/akvo/flow/events/EventUtils.java
@@ -26,10 +26,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.gallatinsystems.common.Constants;
-import org.akvo.flow.util.FlowJsonObjectWriter;
 import org.akvo.flow.rest.security.user.GaeUser;
+import org.akvo.flow.util.FlowJsonObjectWriter;
 
+import com.gallatinsystems.common.Constants;
 import com.gallatinsystems.survey.domain.SurveyGroup;
 import com.gallatinsystems.survey.domain.SurveyGroup.PrivacyLevel;
 import com.google.appengine.api.datastore.Entity;
@@ -64,7 +64,7 @@ public class EventUtils {
     }
 
     // How we name the actions
-    static class Action {
+    public static class Action {
         public static final String SURVEY_GROUP = "surveyGroup";
         public static final String FORM = "form";
         public static final String QUESTION_GROUP = "questionGroup";

--- a/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
@@ -118,7 +118,9 @@ public class DataStoreWithUnilog implements DatastoreService {
         final EventTypes eventTypes = EventUtils
                 .getEventAndActionType(kind);
 
-        if (eventTypes != null) {
+        if (eventTypes == null) {
+            return null;
+        } else {
             Map<String, Object> event = updateOrCreateEvent(entity, eventTypes);
             try {
                 return EventUtils.createEventLogEntity(event, new Date());
@@ -126,7 +128,6 @@ public class DataStoreWithUnilog implements DatastoreService {
                 throw new RuntimeException(e);
             }
         }
-        return entity;
     }
 
     private Map<String, Object> updateOrCreateEvent(Entity entity,

--- a/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
@@ -31,6 +31,7 @@ public class DataStoreWithUnilog implements DatastoreService {
     private static final Date MANUAL_FIX_START_TIME = new Date();
     private DatastoreService delegate;
     private String orgId;
+    private boolean newEventsPushedToEventQueue;
 
     DataStoreWithUnilog(DatastoreService delegate, String orgId) {
         this.delegate = delegate;
@@ -103,6 +104,7 @@ public class DataStoreWithUnilog implements DatastoreService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         if (!events.isEmpty()) {
+            newEventsPushedToEventQueue = true;
             delegate.put(events);
         }
     }
@@ -255,5 +257,9 @@ public class DataStoreWithUnilog implements DatastoreService {
     @Override
     public Collection<Transaction> getActiveTransactions() {
         return delegate.getActiveTransactions();
+    }
+
+    boolean hasToNotifyUnilog() {
+        return newEventsPushedToEventQueue;
     }
 }

--- a/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
@@ -1,0 +1,259 @@
+package org.akvo.gae.remoteapi;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.akvo.flow.events.EventUtils;
+
+import com.google.appengine.api.datastore.DatastoreAttributes;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Index;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyRange;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+
+import static org.akvo.flow.events.EventUtils.*;
+
+public class DataStoreWithUnilog implements DatastoreService {
+    private static final Date MANUAL_FIX_START_TIME = new Date();
+    private DatastoreService delegate;
+    private String orgId;
+
+    DataStoreWithUnilog(DatastoreService delegate, String orgId) {
+        this.delegate = delegate;
+        this.orgId = orgId;
+    }
+
+    @Override
+    public Key put(Entity entity) {
+        Key put = delegate.put(entity);
+        storeEntityUpdate(Stream.of(entity));
+        return put;
+    }
+
+    @Override
+    public Key put(Transaction transaction, Entity entity) {
+        Key put = delegate.put(transaction, entity);
+        storeEntityUpdate(Stream.of(entity));
+        return put;
+    }
+
+    @Override
+    public List<Key> put(Iterable<Entity> iterable) {
+        List<Key> put = delegate.put(iterable);
+        Stream<Entity> entities = asStream(iterable);
+        storeEntityUpdate(entities);
+        return put;
+    }
+
+    @Override
+    public List<Key> put(Transaction transaction, Iterable<Entity> iterable) {
+        List<Key> put = delegate.put(transaction, iterable);
+        storeEntityUpdate(asStream(iterable));
+        return put;
+    }
+
+    @Override
+    public void delete(Key... keys) {
+        delegate.delete(keys);
+        storeDeleteEvents(Arrays.stream(keys));
+    }
+
+    @Override
+    public void delete(Transaction transaction, Key... keys) {
+        delegate.delete(transaction, keys);
+        storeDeleteEvents(Arrays.stream(keys));
+    }
+
+    @Override
+    public void delete(Iterable<Key> iterable) {
+        delegate.delete(iterable);
+        storeDeleteEvents(asStream(iterable));
+    }
+
+    @Override
+    public void delete(Transaction transaction, Iterable<Key> iterable) {
+        delegate.delete(transaction, iterable);
+        storeDeleteEvents(asStream(iterable));
+    }
+
+    private <T> Stream<T> asStream(Iterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private void storeEntityUpdate(Stream<Entity> entities) {
+        storeInEventQueue(entities.map(this::event));
+    }
+
+    private void storeInEventQueue(Stream<Entity> entityStream) {
+        List<Entity> events = entityStream
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (!events.isEmpty()) {
+            delegate.put(events);
+        }
+    }
+
+    private Map<String, Object> manualFixEventSource() {
+        return EventUtils.newSource("manualDataFix");
+    }
+
+    private Entity event(Entity entity) {
+        String kind = entity.getKey().getKind();
+        final EventTypes eventTypes = EventUtils
+                .getEventAndActionType(kind);
+
+        if (eventTypes != null) {
+            Map<String, Object> event = updateOrCreateEvent(entity, eventTypes);
+            try {
+                return EventUtils.createEventLogEntity(event, new Date());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return entity;
+    }
+
+    private Map<String, Object> updateOrCreateEvent(Entity entity,
+                                                    EventUtils.EventTypes eventTypes) {
+        String actionType = eventActionType(entity);
+        Map<String, Object> context = manualFixContext();
+        Map<String, Object> entityMap = EventUtils.newEntity(eventTypes.type,
+                entity.getKey().getId());
+        EventUtils.populateEntityProperties(eventTypes.type, entity, entityMap);
+        return EventUtils.newEvent(orgId,
+                eventTypes.action + actionType, entityMap, context);
+    }
+
+    private Map<String, Object> manualFixContext() {
+        return EventUtils
+                .newContext(MANUAL_FIX_START_TIME, manualFixEventSource());
+    }
+
+    private String eventActionType(Entity entity) {
+        Date lastUpdateDatetime = (Date) entity.getProperty(EventUtils.Prop.LAST_UPDATE_DATE_TIME);
+        Date createdDateTime = (Date) entity.getProperty(EventUtils.Prop.CREATED_DATE_TIME);
+        return createdDateTime.equals(lastUpdateDatetime) ? EventUtils.Action.CREATED
+                : EventUtils.Action.UPDATED;
+    }
+
+    private void storeDeleteEvents(Stream<Key> stream) {
+        storeInEventQueue(stream.map(this::deleteEvent));
+    }
+
+    private Entity deleteEvent(Key key) {
+        EventTypes types = getEventAndActionType(key.getKind());
+        if (types == null) {
+            return null;
+        }
+
+        Map<String, Object> eventContext = newContext(MANUAL_FIX_START_TIME, manualFixEventSource());
+
+        Map<String, Object> eventEntity = newEntity(types.type, key.getId());
+
+        Map<String, Object> event = newEvent(orgId,
+                types.action + Action.DELETED, eventEntity, eventContext);
+
+        try {
+            return EventUtils.createEventLogEntity(event, new Date());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //** No other method modified **//
+
+    @Override
+    public Entity get(Key key) throws EntityNotFoundException {
+        return delegate.get(key);
+    }
+
+    @Override
+    public Entity get(Transaction transaction, Key key) throws EntityNotFoundException {
+        return delegate.get(transaction, key);
+    }
+
+    @Override
+    public Map<Key, Entity> get(Iterable<Key> iterable) {
+        return delegate.get(iterable);
+    }
+
+    @Override
+    public Map<Key, Entity> get(Transaction transaction, Iterable<Key> iterable) {
+        return delegate.get(transaction, iterable);
+    }
+
+
+    @Override
+    public Transaction beginTransaction() {
+        return delegate.beginTransaction();
+    }
+
+    @Override
+    public Transaction beginTransaction(TransactionOptions transactionOptions) {
+        return delegate.beginTransaction(transactionOptions);
+    }
+
+    @Override
+    public KeyRange allocateIds(String s, long l) {
+        return delegate.allocateIds(s, l);
+    }
+
+    @Override
+    public KeyRange allocateIds(Key key, String s, long l) {
+        return delegate.allocateIds(key, s, l);
+    }
+
+    @Override
+    public KeyRangeState allocateIdRange(KeyRange keyRange) {
+        return delegate.allocateIdRange(keyRange);
+    }
+
+    @Override
+    public DatastoreAttributes getDatastoreAttributes() {
+        return delegate.getDatastoreAttributes();
+    }
+
+    @Override
+    public Map<Index, Index.IndexState> getIndexes() {
+        return delegate.getIndexes();
+    }
+
+    @Override
+    public PreparedQuery prepare(Query query) {
+        return delegate.prepare(query);
+    }
+
+    @Override
+    public PreparedQuery prepare(Transaction transaction, Query query) {
+        return delegate.prepare(transaction, query);
+    }
+
+    @Override
+    public Transaction getCurrentTransaction() {
+        return delegate.getCurrentTransaction();
+    }
+
+    @Override
+    public Transaction getCurrentTransaction(Transaction transaction) {
+        return delegate.getCurrentTransaction(transaction);
+    }
+
+    @Override
+    public Collection<Transaction> getActiveTransactions() {
+        return delegate.getActiveTransactions();
+    }
+}

--- a/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/DataStoreWithUnilog.java
@@ -40,31 +40,31 @@ public class DataStoreWithUnilog implements DatastoreService {
 
     @Override
     public Key put(Entity entity) {
-        Key put = delegate.put(entity);
+        Key result = delegate.put(entity);
         storeEntityUpdate(Stream.of(entity));
-        return put;
+        return result;
     }
 
     @Override
     public Key put(Transaction transaction, Entity entity) {
-        Key put = delegate.put(transaction, entity);
+        Key result = delegate.put(transaction, entity);
         storeEntityUpdate(Stream.of(entity));
-        return put;
+        return result;
     }
 
     @Override
     public List<Key> put(Iterable<Entity> iterable) {
-        List<Key> put = delegate.put(iterable);
+        List<Key> result = delegate.put(iterable);
         Stream<Entity> entities = asStream(iterable);
         storeEntityUpdate(entities);
-        return put;
+        return result;
     }
 
     @Override
     public List<Key> put(Transaction transaction, Iterable<Entity> iterable) {
-        List<Key> put = delegate.put(transaction, iterable);
+        List<Key> result = delegate.put(transaction, iterable);
         storeEntityUpdate(asStream(iterable));
-        return put;
+        return result;
     }
 
     @Override

--- a/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
@@ -65,11 +65,12 @@ public class RemoteAPI {
             String clz = className.indexOf(".") != -1 ? className : "org.akvo.gae.remoteapi."
                     + className;
             DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+            DatastoreService datastoreServiceWithUnilog = new DataStoreWithUnilog(ds, args[1]);
             Process p = (Process) Class.forName(clz).newInstance();
             if (isLocalDevelopmentServer) {
-                p.execute(ds, Arrays.copyOfRange(args, 2, args.length));
+                p.execute(datastoreServiceWithUnilog, Arrays.copyOfRange(args, 2, args.length));
             } else {
-                p.execute(ds, Arrays.copyOfRange(args, 4, args.length));
+                p.execute(datastoreServiceWithUnilog, Arrays.copyOfRange(args, 4, args.length));
             }
             System.out.println("Done");
         } catch (Exception e) {

--- a/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
@@ -16,7 +16,23 @@
 
 package org.akvo.gae.remoteapi;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.akvo.flow.events.EventLogger;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -60,17 +76,21 @@ public class RemoteAPI {
 
         final RemoteApiInstaller installer = new RemoteApiInstaller();
 
+        String orgId = args[1];
         try {
             installer.install(options);
             String clz = className.indexOf(".") != -1 ? className : "org.akvo.gae.remoteapi."
                     + className;
             DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
-            DatastoreService datastoreServiceWithUnilog = new DataStoreWithUnilog(ds, args[1]);
+            DataStoreWithUnilog datastoreServiceWithUnilog = new DataStoreWithUnilog(ds, orgId);
             Process p = (Process) Class.forName(clz).newInstance();
             if (isLocalDevelopmentServer) {
                 p.execute(datastoreServiceWithUnilog, Arrays.copyOfRange(args, 2, args.length));
             } else {
                 p.execute(datastoreServiceWithUnilog, Arrays.copyOfRange(args, 4, args.length));
+                if (datastoreServiceWithUnilog.hasToNotifyUnilog()) {
+                    notifyUnilog(orgId, serviceAccountPvk);
+                }
             }
             System.out.println("Done");
         } catch (Exception e) {
@@ -78,5 +98,36 @@ public class RemoteAPI {
         } finally {
             installer.uninstall();
         }
+    }
+
+    private static void notifyUnilog(String orgId, String serviceAccountPvk) {
+        try {
+            Path configFile = Paths.get(serviceAccountPvk).getParent().resolve("appengine-web.xml");
+            if (configFile.toFile().exists()) {
+                String unilogUrl = xpath(configFile, "string(//property[@name='eventNotification']/@value)");
+                if (unilogUrl != null && !unilogUrl.equals("")) {
+                    System.out.println("Notify Unilog on " + unilogUrl);
+                    EventLogger.sendNotificationToUnilog(unilogUrl, orgId);
+                }
+            }
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        } catch (SAXException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (XPathExpressionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String xpath(Path configFile, String xpathExpression) throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+        DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
+        domFactory.setNamespaceAware(false);
+        DocumentBuilder builder = domFactory.newDocumentBuilder();
+        Document doc = builder.parse(configFile.toFile());
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        XPathExpression expr = xpath.compile(xpathExpression);
+        return (String) expr.evaluate(doc, XPathConstants.STRING);
     }
 }

--- a/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/RemoteAPI.java
@@ -53,9 +53,10 @@ public class RemoteAPI {
             System.exit(1);
         }
 
-        final boolean isLocalDevelopmentServer = "localhost".equals(args[1]);
+        String orgId = args[1];
+        final boolean isLocalDevelopmentServer = "localhost".equals(orgId);
         final String className = args[0];
-        final String instanceUrl = isLocalDevelopmentServer ? "localhost" : args[1]
+        final String instanceUrl = isLocalDevelopmentServer ? "localhost" : orgId
                 + ".appspot.com";
         final int port = isLocalDevelopmentServer ? 8888 : 443;
         String serviceAccount = null;
@@ -76,7 +77,6 @@ public class RemoteAPI {
 
         final RemoteApiInstaller installer = new RemoteApiInstaller();
 
-        String orgId = args[1];
         try {
             installer.install(options);
             String clz = className.indexOf(".") != -1 ? className : "org.akvo.gae.remoteapi."


### PR DESCRIPTION
See #3176

Wrapping the default datastore into one that is Unilog aware

Requires no change in any of the current or future data scripts.

Any change in an entity will imply x2 writes, one for the entity itself and
one for the event.

Events are added after changes in the entities.

Notify Unilog of new events, using the unilog url found in the appengine-web.xml, if exists.