### PR TITLE
[#3098] Use specific version of Jackson library

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -42,7 +42,7 @@
     <spring.version>4.3.23.RELEASE</spring.version>
     <spring.security.version>4.2.12.RELEASE</spring.security.version>
     <appengine.sdk.version>1.9.63</appengine.sdk.version>
-    <jackson.version>[2.9.9]</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <junit.jupiter.version>5.4.0</junit.jupiter.version>
   </properties>
 


### PR DESCRIPTION
#### WARNING on range version when building `akvo-flow-services`
```
WARNING!!! version ranges found for:
[org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [log4j commons-logging commons-codec commons-io]] -> [com.fasterxml.jackson.core/jackson-core "[2.9.9,2.9.9]"]
Consider using [org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [commons-logging log4j commons-io commons-codec com.fasterxml.jackson.core/jackson-core]].
[org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [log4j commons-logging commons-codec commons-io]] -> [com.fasterxml.jackson.core/jackson-databind "[2.9.9,2.9.9]"]
Consider using [org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [commons-logging log4j commons-io commons-codec com.fasterxml.jackson.core/jackson-databind]].
[org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [log4j commons-logging commons-codec commons-io]] -> [com.fasterxml.jackson.core/jackson-annotations "[2.9.9,2.9.9]"]
Consider using [org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [com.fasterxml.jackson.core/jackson-annotations commons-logging log4j commons-io commons-codec]].
[org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [log4j commons-logging commons-codec commons-io]] -> [com.fasterxml.jackson.dataformat/jackson-dataformat-xml "[2.9.9,2.9.9]"]
Consider using [org.akvo.flow/akvo-flow "v1.9.49-211-g94e20820" :classifier "classes" :exclusions [commons-logging log4j commons-io commons-codec com.fasterxml.jackson.dataformat/jackson-dataformat-xml]].
```
#### The solution
Use an specific version 2.9.9


## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
