### PR TITLE
Exclude node modules from docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /Config
 /Dashboard/.sass-cache
 /Dashboard/tmp
+/Dashboard/node_modules
 /.git
 /scripts
 /tests


### PR DESCRIPTION
The content of the node_modules folder is being sent to docker for the build,
but it is not used as that folder is mounted as a volume.

The folder happens to be ~500mb in size, which means that in my box a
`docker-compose up --build -d` takes ~50 secs. By ignoring this folder, the
same command takes ~6 secs.

Fixes #3244