### PR TITLE
[#3295] remove redundant state handler

### DIFF
--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -70,6 +70,9 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       this.deviceGroups = {};
       this.deviceGroupNames = {};
 
+      // selected attributes
+      this.selectedDevices = [];
+
       // using Set to avoia duplication
       this.activeDeviceGroups = new Set();
       this.initialSurveyGroup = null;
@@ -159,14 +162,11 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     saveSurveyAssignment(data) {
       let endDateParse;
       let startDateParse;
-      const devices = [];
-      const surveys = [];
 
       // set devices and surveys
-      FLOW.selectedControl.get('selectedDevices').forEach(item => {
-        devices.push(item.get('keyId'));
-      });
+      const devices = this.selectedDevices.map(item => item.get('keyId'));
 
+      const surveys = [];
       FLOW.selectedControl.get('selectedSurveys').forEach(item => {
         surveys.push(item.get('keyId'));
       });
@@ -311,7 +311,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
                 // populate pre-selected devices
                 const device = FLOW.Device.find(deviceId);
                 if (device && device.get('keyId')) {
-                  FLOW.selectedControl.selectedDevices.pushObject(device);
+                  this.selectedDevices.push(device);
                 }
               });
           }
@@ -546,7 +546,6 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     },
 
     handleDeviceCheck(deviceId, checked, deviceGroupId) {
-      console.log(deviceId);
       // if it's the select all option
       if (deviceId == 0) {
         return this.handleSelectAllDevice(deviceGroupId, checked);
@@ -554,15 +553,11 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
       const device = FLOW.Device.find(deviceId);
       if (checked) {
-        // push device to FLOW.selectedControl.selectedDevices
-        FLOW.selectedControl.selectedDevices.pushObject(
-          FLOW.Device.find(deviceId)
-        );
+        // push device to selectedDevices
+        this.selectedDevices.push(FLOW.Device.find(deviceId));
       } else {
-        // remove device to FLOW.selectedControl.selectedDevices
-        FLOW.selectedControl.selectedDevices.removeObject(
-          FLOW.Device.find(deviceId)
-        );
+        // remove device to selectedDevices
+        this.selectedDevices.pop(FLOW.Device.find(deviceId));
       }
 
       // check devices
@@ -586,9 +581,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         .map(deviceId => FLOW.Device.find(deviceId));
 
       allDevices.forEach(device => {
-        FLOW.selectedControl.selectedDevices[
-          checked ? 'pushObject' : 'removeObject'
-        ](device);
+        this.selectedDevices[checked ? 'push' : 'pop'](device);
 
         // check devices
         this.deviceGroups[device.get('deviceGroup') || '1'][

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -72,6 +72,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
       // selected attributes
       this.selectedDevices = [];
+      this.selectedSurveys = [];
 
       // using Set to avoia duplication
       this.activeDeviceGroups = new Set();
@@ -138,7 +139,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         deviceGroupNames: this.deviceGroupNames,
         activeDeviceGroups: this.activeDeviceGroups,
         initialSurveyGroup: this.initialSurveyGroup,
-        numberOfForms: FLOW.selectedControl.get('selectedSurveys').length,
+        numberOfForms: this.selectedSurveys.length,
       };
 
       return {
@@ -165,11 +166,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
       // set devices and surveys
       const devices = this.selectedDevices.map(item => item.get('keyId'));
-
-      const surveys = [];
-      FLOW.selectedControl.get('selectedSurveys').forEach(item => {
-        surveys.push(item.get('keyId'));
-      });
+      const surveys = this.selectedSurveys.map(item => item.get('keyId'));
 
       // validate data before continuing
       const isValid = this.validateAssignment({ ...data, devices, surveys });
@@ -232,8 +229,6 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
     // setups
     setupControls() {
-      FLOW.selectedControl.set('selectedDevices', []);
-      FLOW.selectedControl.set('selectedSurveys', []);
       FLOW.selectedControl.set('selectedSurveyGroup', null);
       FLOW.selectedControl.set('selectedDeviceGroup', null);
       FLOW.surveyControl.set('content', null);
@@ -266,7 +261,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         .forEach(formId => {
           const form = FLOW.Survey.find(formId);
           if (form && form.get('keyId')) {
-            FLOW.selectedControl.selectedSurveys.pushObject(form);
+            this.selectedSurveys.push(form);
 
             // load selected survey group
             this.initialSurveyGroup = form.get('surveyGroupId');
@@ -515,14 +510,10 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
       // add/remove form to/from assignment
       if (this.forms[formId].checked) {
-        // push survey to FLOW.selectedControl.selectedSurveys
-        FLOW.selectedControl.selectedSurveys.pushObject(
-          FLOW.Survey.find(formId)
-        );
+        // push survey to selectedSurveys
+        this.selectedSurveys.push(FLOW.Survey.find(formId));
       } else {
-        FLOW.selectedControl.selectedSurveys.removeObject(
-          FLOW.Survey.find(formId)
-        );
+        this.selectedSurveys.pop(FLOW.Survey.find(formId));
       }
 
       this.renderReactSide();

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -95,6 +95,8 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     },
 
     getProps() {
+      console.log(this.selectedSurveys, this.forms);
+
       const strings = {
         saveAssignment: Ember.String.loc('_save'),
         settings: Ember.String.loc('_settings'),
@@ -260,6 +262,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         .forEach(formId => {
           const form = FLOW.Survey.find(formId);
           if (form && form.get('keyId')) {
+            console.log('PUSHING AT:: SETUP');
             this.selectedSurveys.push(form);
 
             // load selected survey group
@@ -369,9 +372,9 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     },
 
     formInAssignment(formId) {
-      const formsInAssignment = FLOW.selectedControl
-        .get('selectedSurveys')
-        .map(item => item.get('id'));
+      const formsInAssignment = this.selectedSurveys.map(item =>
+        item.get('id')
+      );
 
       // convert id to string
       return formsInAssignment
@@ -465,9 +468,10 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     },
 
     deviceInAssignment(deviceId) {
-      const devicesInAssignment = FLOW.selectedControl.selectedSurveyAssignment.get(
-        'deviceIds'
+      const devicesInAssignment = this.selectedDevices.map(item =>
+        item.get('id')
       );
+
       return devicesInAssignment
         ? devicesInAssignment.indexOf(deviceId) > -1
         : false;
@@ -506,7 +510,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       // if checking a form in a new survey, remove all forms
       if (this.shouldRemoveForms()) {
         // remove all currently selected forms
-        FLOW.selectedControl.set('selectedSurveys', []);
+        this.selectedSurveys = [];
       }
 
       // check form
@@ -515,6 +519,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       // add/remove form to/from assignment
       if (this.forms[formId].checked) {
         // push survey to selectedSurveys
+        console.log('PUSHING AT:: CHECK');
         this.selectedSurveys.push(FLOW.Survey.find(formId));
       } else {
         this.selectedSurveys.pop(FLOW.Survey.find(formId));
@@ -529,6 +534,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       const selectedSG = FLOW.projectControl
         .get('content')
         .find(sg => sg.get('keyId') == parentId);
+
       if (selectedSG && selectedSG.get('projectType') !== 'PROJECT_FOLDER') {
         FLOW.selectedControl.set('selectedSurveyGroup', selectedSG);
         return false;
@@ -536,6 +542,8 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
       // empty forms when a new folder is picked
       this.forms = {};
+      this.selectedSurveys = [];
+
       this.renderReactSide();
       return true;
     },


### PR DESCRIPTION
`FLOW.selectedControl` was a redundant complexity, replaced it with normal javascript array for device and form selector.

To test:
- Assert all form functionality works as before
- Assert all device functionality works as before

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
