### PR TITLE
[#3317]Go via setter for truncation check. Use modern 1500-char limit.

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
+++ b/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
@@ -16,7 +16,7 @@
 
 package com.gallatinsystems.surveyal.domain;
 
-import static com.gallatinsystems.common.Constants.MAX_LENGTH;
+import static com.gallatinsystems.common.Constants.MAX_DS_STRING_LENGTH;;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -169,7 +169,7 @@ public class SurveyedLocale extends BaseDomain {
     }
 
     public void setDisplayName(String displayName) {
-        this.displayName = displayName.length() > MAX_LENGTH ? displayName.substring(0, MAX_LENGTH)
+        this.displayName = displayName.length() > MAX_DS_STRING_LENGTH ? displayName.substring(0, MAX_DS_STRING_LENGTH)
                 .trim() : displayName;
     }
 
@@ -236,7 +236,7 @@ public class SurveyedLocale extends BaseDomain {
             first = false;
         }
 
-        displayName = sb.toString();
+        setDisplayName(sb.toString());
     }
 
     /**


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Too much content for the display name made it overflow the 1500 char storage limit for String. Length check was bypassed by assembleDsiplayName() method.
#### The solution
Fix that, and bump the check from old 500-char limit.
#### Screenshots (if appropriate)

## Checklist
* [ ] Connect the issue
* [ ] Test plan
* [ ] Copyright header
* [ ] Code formatting
* [ ] Documentation
