### PR TITLE
[#3339] - Fix footer on add/edit tab

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -308,6 +308,7 @@
 
           .body {
             padding: 15px 3em;
+            padding-bottom: 3em;
 
             .assignment-device-selector {
               margin-bottom: 1.5em;


### PR DESCRIPTION
#### The solution
 Add padding to `.device-action-page .body` to remove overlap with footer

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30107382/70788927-43e91180-1d92-11ea-8fa7-940f8fd90a6b.png)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
