### PR TITLE
[#3316] Add registration survey attribute to XML form

### DIFF
--- a/GAE/src/org/akvo/flow/xml/XmlForm.java
+++ b/GAE/src/org/akvo/flow/xml/XmlForm.java
@@ -48,6 +48,9 @@ public final class XmlForm {
     @JacksonXmlProperty(localName = "app", isAttribute = true)
     private String app;
 
+    @JacksonXmlProperty(localName = "registrationSurvey", isAttribute = true)
+    private String registrationSurvey;
+
     @JacksonXmlProperty(localName = "surveyGroupId", isAttribute = true)
     private Long surveyGroupId;
 
@@ -65,6 +68,9 @@ public final class XmlForm {
         surveyId = form.getKey().getId();
         surveyGroupId = form.getSurveyGroupId();
         surveyGroupName = survey.getCode();
+        if(Boolean.TRUE.equals(survey.getMonitoringGroup())) {
+            registrationSurvey = survey.getNewLocaleSurveyId().toString();
+        }
         defaultLanguageCode = form.getDefaultLanguageCode();
         if (defaultLanguageCode == null) {
             defaultLanguageCode = "en";
@@ -169,6 +175,14 @@ public final class XmlForm {
 
     public void setSurveyId(String surveyId) {
         this.surveyId = Long.parseLong(surveyId);
+    }
+
+    public String getRegistrationSurvey() {
+        return registrationSurvey;
+    }
+
+    public void setRegistrationSurvey(String registrationSurvey) {
+        this.registrationSurvey = registrationSurvey;
     }
 
     @Override public String toString() {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* Registration survey id missing form the generated XML form definition

#### The solution

* `registrationSurvey` attribute is now included in XML form

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
