### PR TITLE
[#3376] - removed background color from assignment back button in Firefox

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -40,6 +40,7 @@
         button.go-back {
           border: none;
           padding: 2px;
+          background: transparent;
 
           i.fa {
             font-size: 21px;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
A gray background-color show on the back button on the assignments page.

#### The solution
Make the button transparent.

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
