### PR TITLE
[#3380] Update dev image + code clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ services:
 - docker
 cache:
   directories:
-    - $HOME/.m2
+    - "$HOME/.m2"
+    - "$HOME/.npm"
 
 script:
   - "./ci/bootstrap-build.sh /app/src/ci/build.sh && ./ci/deploy.sh"

--- a/ci/bootstrap-build.sh
+++ b/ci/bootstrap-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-#  Copyright (C) 2017-2018 Stichting Akvo (Akvo Foundation)
+#  Copyright (C) 2017-2019 Stichting Akvo (Akvo Foundation)
 #
 #  This file is part of Akvo FLOW.
 #
@@ -19,9 +19,14 @@
 set -eu
 
 MAVEN_REPO="$HOME/.m2"
+NPM_CACHE="$HOME/.npm"
 
 if [[ ! -d "$MAVEN_REPO" ]]; then
     mkdir "$MAVEN_REPO"
+fi
+
+if [[ ! -d "$NPM_CACHE" ]]; then
+    mkdir "$NPM_CACHE"
 fi
 
 FLOW_GIT_VERSION=$(git describe)
@@ -34,6 +39,8 @@ docker run \
        -e TRAVIS_TAG="${TRAVIS_TAG}" \
        --volume "${MAVEN_REPO}:/root/.m2:delegated" \
        --volume "${MAVEN_REPO}:/home/akvo/.m2:delegated" \
+       --volume "${NPM_CACHE}:/root/.npm:delegated" \
+       --volume "${NPM_CACHE}:/home/akvo/.npm:delegated" \
        --volume "$(pwd):/app/src:delegated" \
        --entrypoint /app/src/ci/run-as-user.sh \
-       akvo/akvo-flow-builder:20200106.165448.593bee7 "$@"
+       akvo/akvo-flow-builder:20200115.060329.ab6da76 "$@"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -19,15 +19,10 @@
 set -e
 
 SRC_DIR="/app/src"
-BUNDLE_GEMFILE="${SRC_DIR}/Dashboard/Gemfile"
-RAKEP_MODE=production
-
-export BUNDLE_GEMFILE
-export RAKEP_MODE
 
 cd "${SRC_DIR}/Dashboard"
 
-npm install
+npm ci
 npm rebuild node-sass
 npm run lint:quiet
 npm run build:prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   s3:
     image:  technekes/fake-s3-ssl:latest
   akvo-flow:
-    image: akvo/akvo-flow-builder:20200106.165448.593bee7
+    image: akvo/akvo-flow-builder:20200115.060329.ab6da76
     entrypoint: /app/src/ci/run-as-user.sh
     network_mode: service:mainnetwork
     command: /app/src/ci/devserver.sh


### PR DESCRIPTION
- Update to the latest akvo/akvo-flow-builder image that is based
  on a published google/cloud-sdk
- Remove references to ruby build process, e.g. RAKEP_MODE BUNDLE etc
  We're now using `node` to bundle our client application
- Use `npm ci` instead of `npm install` as part of the build
  https://docs.npmjs.com/cli/ci.html
- Cache `$HOME/.npm` to speed up builds
