### PR TITLE
[#3394] handle null names in FolderSelector comparator

### DIFF
--- a/Dashboard/app/js/lib/components/selectors/FolderSurveySelector/index.jsx
+++ b/Dashboard/app/js/lib/components/selectors/FolderSurveySelector/index.jsx
@@ -11,9 +11,7 @@ export default class FolderSurveySelector extends React.Component {
 
     if (initialSurveyGroup) {
       // if initial form is available, generate levels and mark it as selected
-      const { parentId } = surveyGroups.find(
-        sg => sg.keyId == initialSurveyGroup
-      );
+      const { parentId } = surveyGroups.find(sg => sg.keyId == initialSurveyGroup);
 
       this.setState({ levels: this.getLevels(parentId) }, () => {
         this.props.onSelectSurvey(initialSurveyGroup);
@@ -25,9 +23,7 @@ export default class FolderSurveySelector extends React.Component {
 
   getLevels = (parentId = 0) => {
     const { surveyGroups, strings, initialSurveyGroup } = this.props;
-    const initialSurvey = surveyGroups.find(
-      sg => sg.keyId == initialSurveyGroup
-    );
+    const initialSurvey = surveyGroups.find(sg => sg.keyId == initialSurveyGroup);
     const levels = [];
 
     // eslint-disable-next-line eqeqeq
@@ -42,9 +38,7 @@ export default class FolderSurveySelector extends React.Component {
             if (sgs.parentId == parent.ancestorIds[i]) {
               return total.concat({
                 ...sgs,
-                selected:
-                  initialSurvey &&
-                  initialSurvey.ancestorIds.includes(sgs.keyId),
+                selected: initialSurvey && initialSurvey.ancestorIds.includes(sgs.keyId),
               });
             }
 
@@ -94,8 +88,9 @@ export default class FolderSurveySelector extends React.Component {
   };
 
   comparator = (a, b) => {
-    const nameA = a.name.toUpperCase(); // ignore upper and lowercase
-    const nameB = b.name.toUpperCase(); // ignore upper and lowercase
+    const nameA = (a.name || '').toUpperCase(); // ignore upper and lowercase
+    const nameB = (b.name || '').toUpperCase(); // ignore upper and lowercase
+
     if (nameA < nameB) {
       return -1;
     }
@@ -126,9 +121,7 @@ export default class FolderSurveySelector extends React.Component {
   };
 
   renderForm = (folderSurveyList, id) => {
-    const defaultSurveyGroup = folderSurveyList.find(
-      sgs => sgs.selected === true
-    );
+    const defaultSurveyGroup = folderSurveyList.find(sgs => sgs.selected === true);
 
     return (
       <select


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
survey names that were null would break when you run `name.toUpperCase`.

#### The solution
Check if survey name is null before comparing strings

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
