### PR TITLE
Issue/3382 handle repetition gaps

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -508,6 +509,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
         analyseData(allData);
 
         // write the data now, row by row
+        // (We cannot go back up more than the Spreadsheet writer window)
         for (InstanceData instanceData : allData) {
             MessageDigest digest = MessageDigest.getInstance("MD5");
             if (separateSheetsForRepeatableGroups) {
@@ -630,22 +632,26 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             throws NoSuchAlgorithmException {
 
         int startRow = sheet.getLastRowNum() + 1;
-        //maxIterationsCount is for entire instance. We need it for this sheet only!
-        int maxIter = 0;
+        //iterationsPresent is for entire instance. We need it for this sheet only!
+        //int maxIter = 0;
+        Set<Long> iterationsOnThisSheet = new TreeSet<>(); //Ordered
         if (!groupSheet) { //Must have one row of metadata on base sheet, even if no values
-            maxIter = 1;
+            //maxIter = 1;
+            iterationsOnThisSheet.add(0L);
         }
         for (QuestionDto qd : whichQuestions) {
             final Long questionId = qd.getKeyId();
             SortedMap<Long, String> iterationsMap = instanceData.responseMap.get(questionId);
             if (iterationsMap != null) {
-                maxIter = Math.max(maxIter, iterationsMap.size());
+                iterationsOnThisSheet.addAll(iterationsMap.keySet());
+                //maxIter = Math.max(maxIter, iterationsMap.size());
             }
         }
 
-        for (int i = 0; i < maxIter; i++) {
-            Row iterationRow = getRow(startRow + i, sheet);
-            writeMetadataRow(iterationRow, instanceData, i + 1, groupSheet);
+        int rowOffset = 0;
+        for (long i : iterationsOnThisSheet) {
+            Row iterationRow = getRow(startRow + rowOffset, sheet);
+            writeMetadataRow(iterationRow, instanceData, (int) i + 1, groupSheet); //assume <2 billion repeats
             for (QuestionDto qd : whichQuestions) {
                 final Long questionId = qd.getKeyId();
                 SortedMap<Long, String> iterationsMap = instanceData.responseMap.get(questionId);
@@ -664,6 +670,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
                     md.update(val.getBytes());
                 }
             }
+            rowOffset++;
         }
     }
 
@@ -723,9 +730,11 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             SummaryModel model) {
 
         //maxIterationsCount is actually the max iteration index; 0 for 1 iteration...
-        for (int i = 0; i <= (int) instanceData.maxIterationsCount; i++) {
-            Row iterationRow = getRow(startRow + i, sheet);
-            writeMetadataRow(iterationRow, instanceData, i + 1, true);
+        //even worse, there may be gaps in the index
+        int rowOffset = 0;
+        for (long i : instanceData.iterationsPresent) { //TODO sorted?
+            Row iterationRow = getRow(startRow + rowOffset, sheet);
+            writeMetadataRow(iterationRow, instanceData, (int)i + 1, true); //assume <2 billion repeats
             for (String q : questionIdList) {
                 final Long questionId = Long.valueOf(q);
                 final QuestionDto questionDto = questionsById.get(questionId);
@@ -733,17 +742,18 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
                 if (iterationsMap == null) {
                     continue;
                 }
-                String val = iterationsMap.get(new Long(i));
+                String val = iterationsMap.get(i);
                 if (val != null) {
                     writeAnswer(iterationRow, columnIndexMap.get(q), questionDto, val);
                 }
             }
+            rowOffset++;
         }
 
-        int maxRow = startRow + (int) instanceData.maxIterationsCount + 1;
+        int maxRow = startRow + rowOffset; //TODO: fencepost error??
 
 
-        // Rebuild old response map format for from instanceData.responseMap
+        // Rebuild old response map format for rollups from instanceData.responseMap
         // Question id -> response
         Map<String, String> responseMap = new HashMap<>();
 

--- a/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/GraphicalSurveySummaryExporter.java
@@ -633,10 +633,8 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
 
         int startRow = sheet.getLastRowNum() + 1;
         //iterationsPresent is for entire instance. We need it for this sheet only!
-        //int maxIter = 0;
         Set<Long> iterationsOnThisSheet = new TreeSet<>(); //Ordered
         if (!groupSheet) { //Must have one row of metadata on base sheet, even if no values
-            //maxIter = 1;
             iterationsOnThisSheet.add(0L);
         }
         for (QuestionDto qd : whichQuestions) {
@@ -644,7 +642,6 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             SortedMap<Long, String> iterationsMap = instanceData.responseMap.get(questionId);
             if (iterationsMap != null) {
                 iterationsOnThisSheet.addAll(iterationsMap.keySet());
-                //maxIter = Math.max(maxIter, iterationsMap.size());
             }
         }
 
@@ -729,12 +726,11 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             Map<String, String> collapseIdMap,
             SummaryModel model) {
 
-        //maxIterationsCount is actually the max iteration index; 0 for 1 iteration...
-        //even worse, there may be gaps in the index
+        //iterationsPresent is a set because there may be gaps
         int rowOffset = 0;
-        for (long i : instanceData.iterationsPresent) { //TODO sorted?
+        for (long i : instanceData.iterationsPresent) { //sorted
             Row iterationRow = getRow(startRow + rowOffset, sheet);
-            writeMetadataRow(iterationRow, instanceData, (int)i + 1, true); //assume <2 billion repeats
+            writeMetadataRow(iterationRow, instanceData, (int)i + 1, true); //assume <2 billion iterations
             for (String q : questionIdList) {
                 final Long questionId = Long.valueOf(q);
                 final QuestionDto questionDto = questionsById.get(questionId);
@@ -750,7 +746,7 @@ public class GraphicalSurveySummaryExporter extends SurveySummaryExporter {
             rowOffset++;
         }
 
-        int maxRow = startRow + rowOffset; //TODO: fencepost error??
+        int maxRow = startRow + rowOffset;
 
 
         // Rebuild old response map format for rollups from instanceData.responseMap

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -786,7 +786,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
      * @param baseSheet
      * @return A map from column index to question id.
      */
-    private static Map<Integer, Long> processHeader(Sheet sheet, int headerRowIndex) {
+    public static Map<Integer, Long> processHeader(Sheet sheet, int headerRowIndex) {
         Map<Integer, Long> columnIndexToQuestionId = new HashMap<>();
 
         Row headerRow = sheet.getRow(headerRowIndex);

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -515,17 +515,17 @@ public class RawDataSpreadsheetImporter implements DataImporter {
 
 
         int iterations = 1;
-        int repeatIterationColumnIndex = -1;
+        int siColumnIndex = -1;
 
         // Count the maximum number of iterations for this instance
         if (singleOrRepSheet) {
-            repeatIterationColumnIndex = metadataColumnHeaderIndex.get(REPEAT_COLUMN_KEY);//unsafe assignment
+            siColumnIndex = metadataColumnHeaderIndex.get(SURVEY_INSTANCE_COLUMN_KEY); //unsafe assignment
             while (true) {
                 Row row = sheet.getRow(startRow + iterations);
                 if (row == null // no row
-                        || isEmptyCell(row.getCell(repeatIterationColumnIndex))
+                        || isEmptyCell(row.getCell(siColumnIndex))
                         || ExportImportUtils.parseCellAsString(
-                                row.getCell(repeatIterationColumnIndex)).equals("1") // next q //PROBLEM
+                                row.getCell(siColumnIndex)).equals(surveyInstanceId) // next q
                 ) {
                     break;
                 }
@@ -552,9 +552,9 @@ public class RawDataSpreadsheetImporter implements DataImporter {
 
                 long iteration = 1;
                 if (singleOrRepSheet) {
-                    Cell cell = iterationRow.getCell(repeatIterationColumnIndex);
+                    Cell cell = iterationRow.getCell(siColumnIndex);
                     if (cell != null) {
-                        iteration = (long) iterationRow.getCell(repeatIterationColumnIndex)
+                        iteration = (long) iterationRow.getCell(siColumnIndex)
                                 .getNumericCellValue();
                     }
                 }
@@ -762,7 +762,8 @@ public class RawDataSpreadsheetImporter implements DataImporter {
     }
 
     private static String getMetadataCellContent(Row baseRow,
-            Map<String, Integer> metadataColumnHeaderIndex, String metadataCellColumnKey) {
+            Map<String, Integer> metadataColumnHeaderIndex,
+            String metadataCellColumnKey) {
         Cell metadataCell = baseRow.getCell(metadataColumnHeaderIndex.get(metadataCellColumnKey));
         return ExportImportUtils.parseCellAsString(metadataCell);
     }

--- a/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporter.java
@@ -525,7 +525,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
                 if (row == null // no row
                         || isEmptyCell(row.getCell(repeatIterationColumnIndex))
                         || ExportImportUtils.parseCellAsString(
-                                row.getCell(repeatIterationColumnIndex)).equals("1") // next q
+                                row.getCell(repeatIterationColumnIndex)).equals("1") // next q //PROBLEM
                 ) {
                     break;
                 }
@@ -577,7 +577,7 @@ public class RawDataSpreadsheetImporter implements DataImporter {
         surveyInstanceDto.setFormVersion(formVer);
 
         InstanceData instanceData = new InstanceData(surveyInstanceDto, responseMap); //Copies and sorts the responseMap
-        instanceData.maxIterationsCount = iterations;
+        //instanceData.maxIterationsCount = iterations;
         return instanceData;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveySummaryExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveySummaryExporter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -701,7 +701,7 @@ public class SurveySummaryExporter extends AbstractDataExporter {
             }
         }
 
-        public double getMode() {
+        public Double getMode() {
             if (!isSorted) {
                 Collections.sort(valueList);
                 isSorted = true;

--- a/GAE/test/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporterTests.java
+++ b/GAE/test/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporterTests.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RawDataSpreadsheetImporterTests {
 
-    private void createSheet(Workbook wb, String name, String topleft, boolean app, boolean rep, int questionColumns) {
+    private Sheet createSheet(Workbook wb, String name, String topleft, boolean app, boolean rep, int questionColumns) {
         Sheet sheet = wb.createSheet(name);
 
         Row row0 = sheet.createRow(0);
@@ -58,6 +58,7 @@ class RawDataSpreadsheetImporterTests {
         for (int j = 0; j < questionColumns; j++) {
             row1.createCell(i + j).setCellValue((123000 + j) + "|Question" + j);
         }
+        return sheet;
     }
 
     private File createValidTestSpreadsheet(String fileName) throws IOException {
@@ -65,6 +66,21 @@ class RawDataSpreadsheetImporterTests {
         createSheet(wb, "Raw Data", "Metadata", false, false, 0); //Right name, right index for base
         createSheet(wb, "Group 2", "Metadata", false, true, 1); //Right name for group sheet
         createSheet(wb, "Foobar", "Not metadata", false, true, 0); //Should be completely ignored
+
+        FileOutputStream fileOut = new FileOutputStream(fileName);
+        wb.setActiveSheet(0);
+        wb.write(fileOut);
+        fileOut.close();
+
+        return new File(fileName);
+    }
+
+    private File createValidTestSpreadsheetWithData(String fileName, xyzzy questions) throws IOException {
+        Workbook wb = new SXSSFWorkbook(10); //Only need a tiny window
+        Sheet baseSheet = createSheet(wb, "Raw Data", "Metadata", false, false, 1); //Right name, right index for base
+        Row row = baseSheet.createRow(2);
+
+        Sheet groupSheet = createSheet(wb, "Group 2", "Metadata", false, true, 1); //Right name for group sheet
 
         FileOutputStream fileOut = new FileOutputStream(fileName);
         wb.setActiveSheet(0);
@@ -91,7 +107,18 @@ class RawDataSpreadsheetImporterTests {
     public void testValidSheets() throws IOException {
         DataImporter dimp = new RawDataSpreadsheetImporter();
 
-        //Check that a canonical file passes
+        //Check that a canonical file passes validation
+        File file1 = createValidTestSpreadsheet("/tmp/valid1.xlsx");
+        Map<Integer,String> errors = dimp.validate(file1);
+        assertEquals(0, errors.size());
+
+    }
+
+    @Test
+    public void testValidSheetsWithData() throws IOException {
+        DataImporter dimp = new RawDataSpreadsheetImporter();
+
+        //Check that a canonical file passes validation
         File file1 = createValidTestSpreadsheet("/tmp/valid1.xlsx");
         Map<Integer,String> errors = dimp.validate(file1);
         assertEquals(0, errors.size());

--- a/GAE/test/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporterTests.java
+++ b/GAE/test/org/waterforpeople/mapping/dataexport/RawDataSpreadsheetImporterTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2019-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -17,23 +17,38 @@
 package org.waterforpeople.mapping.dataexport;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto;
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionOptionDto;
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionDto.QuestionType;
 
 import com.gallatinsystems.framework.dataexport.applet.DataImporter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class RawDataSpreadsheetImporterTests {
+
+    private static final long QID_START = 123000;
+    private static final long IID_START = 4711;
 
     private Sheet createSheet(Workbook wb, String name, String topleft, boolean app, boolean rep, int questionColumns) {
         Sheet sheet = wb.createSheet(name);
@@ -56,9 +71,28 @@ class RawDataSpreadsheetImporterTests {
         sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, i - 1));
 
         for (int j = 0; j < questionColumns; j++) {
-            row1.createCell(i + j).setCellValue((123000 + j) + "|Question" + j);
+            row1.createCell(i + j).setCellValue((QID_START + j) + "|Question" + j);
         }
         return sheet;
+    }
+
+    private void createDataRow(Sheet sheet, int rowIndex, int repIndex, boolean app, boolean rep, List<String> answers) {
+        Row row2 = sheet.createRow(rowIndex);
+        int i = 0;
+        row2.createCell(i++).setCellValue("aaaa-bbbb-cccc");
+        if (app) {row2.createCell(i++).setCellValue("Data approval status");}
+        row2.createCell(i++).setCellValue("ADisplayName");
+        if (rep) {row2.createCell(i++).setCellValue(repIndex);}
+        row2.createCell(i++).setCellValue("ADeviceIdentifier");
+        row2.createCell(i++).setCellValue(Long.toString(IID_START));
+        row2.createCell(i++).setCellValue("27-01-2020 11:32:22 CET");
+        row2.createCell(i++).setCellValue("Someone");
+        row2.createCell(i++).setCellValue("00:11:22");
+        row2.createCell(i++).setCellValue(17.0);
+
+        for (String answer: answers) {
+            row2.createCell(i++).setCellValue(answer);
+        }
     }
 
     private File createValidTestSpreadsheet(String fileName) throws IOException {
@@ -75,12 +109,28 @@ class RawDataSpreadsheetImporterTests {
         return new File(fileName);
     }
 
-    private File createValidTestSpreadsheetWithData(String fileName, xyzzy questions) throws IOException {
+    private File createValidTestSpreadsheetWithNonRepData(String fileName, List<String> answers) throws IOException {
         Workbook wb = new SXSSFWorkbook(10); //Only need a tiny window
         Sheet baseSheet = createSheet(wb, "Raw Data", "Metadata", false, false, 1); //Right name, right index for base
-        Row row = baseSheet.createRow(2);
+        createDataRow(baseSheet, 2, 0, false, false, answers);
 
-        Sheet groupSheet = createSheet(wb, "Group 2", "Metadata", false, true, 1); //Right name for group sheet
+        FileOutputStream fileOut = new FileOutputStream(fileName);
+        wb.setActiveSheet(0);
+        wb.write(fileOut);
+        fileOut.close();
+
+        return new File(fileName);
+    }
+
+    private File createValidTestSpreadsheetWithRepData(String fileName, List<String> answers) throws IOException {
+        Workbook wb = new SXSSFWorkbook(10); //Only need a tiny window
+        Sheet baseSheet = createSheet(wb, "Raw Data", "Metadata", false, false, 0); //Right name, right index for base
+        createDataRow(baseSheet, 2, 0, false, false, new ArrayList<String>()); //no data on the base sheet
+
+        Sheet groupSheet = createSheet(wb, "Group 1", "Metadata", false, true, 1); //Right name for a RQG sheet
+        createDataRow(groupSheet, 2, 1, false, true, answers);
+        //Make a gap in the repeat index
+        createDataRow(groupSheet, 3, 3, false, true, answers);
 
         FileOutputStream fileOut = new FileOutputStream(fileName);
         wb.setActiveSheet(0);
@@ -115,14 +165,110 @@ class RawDataSpreadsheetImporterTests {
     }
 
     @Test
-    public void testValidSheetsWithData() throws IOException {
-        DataImporter dimp = new RawDataSpreadsheetImporter();
+    public void testValidBaseSheetWithData() throws Exception {
+        RawDataSpreadsheetImporter dimp = new RawDataSpreadsheetImporter();
 
-        //Check that a canonical file passes validation
-        File file1 = createValidTestSpreadsheet("/tmp/valid1.xlsx");
-        Map<Integer,String> errors = dimp.validate(file1);
-        assertEquals(0, errors.size());
+        List<String> dataList = new ArrayList<>();
+        dataList.add("testData");
+        File file1 = createValidTestSpreadsheetWithNonRepData("/tmp/valid2.xlsx", dataList);
 
+        //Import it to check that data is found
+        InputStream stream = new PushbackInputStream(new FileInputStream(file1));
+        Workbook wb = WorkbookFactory.create(stream);
+        assertEquals(wb.getNumberOfSheets(), 1);
+
+        final int headerRowIndex = 1; //Only test modern (split) sheets
+
+        Sheet sheet = wb.getSheetAt(0);
+        Map<Integer, Long> headerMap = RawDataSpreadsheetImporter.processHeader(sheet, headerRowIndex);
+        assertEquals(1, headerMap.size()); //one data
+
+        Map<Sheet, Map<Integer, Long>> sheetMap = new HashMap<>();
+        sheetMap.put(sheet, headerMap);
+
+        //Mock up a DTO
+        QuestionDto dto = new QuestionDto();
+        dto.setType(QuestionType.FREE_TEXT);
+        dto.setText("Question0");
+        dto.setKeyId(QID_START);
+
+        //Put it in a map
+        Map<Long, QuestionDto> questionIdToQuestionDto = new HashMap<>();
+        questionIdToQuestionDto.put(QID_START, dto);
+        //Make an empty map for options
+        Map<Long, List<QuestionOptionDto>> optionNodes = new HashMap<>();
+
+        List<InstanceData> instanceDataList = dimp.parseSplitSheets(sheet,
+                sheetMap,
+                questionIdToQuestionDto,
+                optionNodes,
+                headerRowIndex);
+        assertNotNull(instanceDataList);
+        assertEquals(1, instanceDataList.size());
+        assertNotNull(instanceDataList.get(0));
+        assertNotNull(instanceDataList.get(0).responseMap);
+        assertNotNull(instanceDataList.get(0).responseMap.get(QID_START));
+        assertNotNull(instanceDataList.get(0).responseMap.get(QID_START).get(0L));
+        assertEquals("testData", instanceDataList.get(0).responseMap.get(QID_START).get(0L));
+    }
+
+
+    @Test
+    public void testValidSheetsWithRepeatData() throws Exception {
+        RawDataSpreadsheetImporter dimp = new RawDataSpreadsheetImporter();
+
+        List<String> dataList = new ArrayList<>();
+        dataList.add("testDataSplit");
+        File file1 = createValidTestSpreadsheetWithRepData("/tmp/valid3.xlsx", dataList);
+
+        //Import it to check that data is found
+        InputStream stream = new PushbackInputStream(new FileInputStream(file1));
+        Workbook wb = WorkbookFactory.create(stream);
+        assertEquals(2, wb.getNumberOfSheets());
+
+        final int headerRowIndex = 1; //Only test modern (split) sheets
+
+        Map<Sheet, Map<Integer, Long>> sheetMap = new HashMap<>();
+
+        Sheet baseSheet = wb.getSheetAt(0);
+        assertNotNull(baseSheet);
+        Map<Integer, Long> headerMap = RawDataSpreadsheetImporter.processHeader(baseSheet, headerRowIndex);
+        assertEquals(0, headerMap.size()); //no data here
+        sheetMap.put(baseSheet, headerMap);
+
+        Sheet groupSheet = wb.getSheetAt(1);
+        assertNotNull(groupSheet);
+        headerMap = RawDataSpreadsheetImporter.processHeader(groupSheet, headerRowIndex);
+        assertEquals(1, headerMap.size()); //one data column
+        sheetMap.put(groupSheet, headerMap);
+
+        //Mock up a DTO
+        QuestionDto dto = new QuestionDto();
+        dto.setType(QuestionType.FREE_TEXT);
+        dto.setText("Question0");
+        dto.setKeyId(QID_START);
+
+        //Put it in a map
+        Map<Long, QuestionDto> questionIdToQuestionDto = new HashMap<>();
+        questionIdToQuestionDto.put(QID_START, dto);
+        //Make an empty map for options
+        Map<Long, List<QuestionOptionDto>> optionNodes = new HashMap<>();
+
+        List<InstanceData> instanceDataList = dimp.parseSplitSheets(baseSheet,
+                sheetMap,
+                questionIdToQuestionDto,
+                optionNodes,
+                headerRowIndex);
+        assertNotNull(instanceDataList);
+        assertEquals(1, instanceDataList.size());
+        assertNotNull(instanceDataList.get(0));
+        assertNotNull(instanceDataList.get(0).responseMap);
+        assertNotNull(instanceDataList.get(0).responseMap.get(QID_START));
+        assertNotNull(instanceDataList.get(0).responseMap.get(QID_START).get(0L));
+        assertEquals("testDataSplit", instanceDataList.get(0).responseMap.get(QID_START).get(0L));
+        assertEquals("testDataSplit", instanceDataList.get(0).responseMap.get(QID_START).get(2L));
+        assertNull(instanceDataList.get(0).responseMap.get(QID_START).get(1L));
+        assertNull(instanceDataList.get(0).responseMap.get(QID_START).get(3L));
     }
 
     @Test
@@ -141,6 +287,8 @@ class RawDataSpreadsheetImporterTests {
     @AfterAll
     public static void removeTestFiles() {
         new File("/tmp/valid1.xlsx").delete();
+        new File("/tmp/valid2.xlsx").delete();
+        new File("/tmp/valid3.xlsx").delete();
         new File("/tmp/invalid1.xlsx").delete();
 
     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Gaps in repeat indexes were filled in with empty cells in exports/empty data in imports.
#### The solution
Handle gaps properly; add nothing.
Add unit tests for import.
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
