### PR TITLE
[#3408]Do not use "since" parameter in identifier search.

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyedLocaleRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyedLocaleRestService.java
@@ -82,7 +82,7 @@ public class SurveyedLocaleRestService {
         if (searchIdentifiers) {
             //JDO implementation cannot handle both OR and a prefix in a filter expression,
             //so we have to search again and concatenate
-            List<SurveyedLocale> sls2 = surveyedLocaleDao.listSurveyedLocales(since, null, search, null, null);
+            List<SurveyedLocale> sls2 = surveyedLocaleDao.listSurveyedLocales(null, null, search, null, null);
             copyToDtoList(sls2, locales);
         }
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The since string was used for two different lookups.
#### The solution
Use it only for the same lookup it was obtained from.
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
