### PR TITLE
Issue 3413/make device action button stick to bottom

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -81,12 +81,13 @@
 
     .assignment-body {
       display: flex;
+      height: 100%;
 
       .assignment-sidebar {
         flex: 1;
         background: #e8e8e8;
         padding: 5px 0px;
-        min-height: 450px;
+        height: 470px;
 
         li {
           display: flex;
@@ -159,6 +160,7 @@
       .assignment-main {
         flex: 4;
         color: #444;
+        height: 470px;
 
         .settings {
           padding: 15px 25px;
@@ -295,9 +297,12 @@
         .devices-action-page {
           position: relative;
           height: 100%;
+          display: flex;
+          flex-direction: column;
 
           .header {
             display: flex;
+            flex: 1;
             justify-content: space-between;
             padding: 15px 3em;
             align-items: center;
@@ -316,6 +321,9 @@
           .body {
             padding: 15px 3em;
             padding-bottom: 3em;
+            flex: 1 1 auto;
+            overflow: auto;
+            height: 100%;
 
             .assignment-device-selector {
               margin-bottom: 1.5em;
@@ -370,9 +378,8 @@
           }
 
           .footer {
-            position: absolute;
-            bottom: 0;
             width: 100%;
+            flex: 1;
 
             .footer-inner {
               display: flex;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Scrolling down to find the Action button is bad UX

#### The solution

#### Screenshots (if appropriate)
Making the action button fixed to the bottom of the screen and always visible to the user

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
