### PR TITLE
[#3416] - add contentHash and other caching options for production build

### DIFF
--- a/Dashboard/webpack.config.dev.js
+++ b/Dashboard/webpack.config.dev.js
@@ -37,7 +37,7 @@ export default {
   target: 'web',
   output: {
     path: path.resolve(__dirname, '../GAE/target/akvo-flow/admin'), // Note: Physical files are only output by the production build task `npm run build`.
-    filename: '[name].bundle.js',
+    filename: '[name].[contenthash].bundle.js',
     publicPath: '/admin/',
   },
   plugins: [
@@ -147,9 +147,7 @@ export default {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: () => [
-                require('autoprefixer'),
-              ],
+              plugins: () => [require('autoprefixer')],
               sourceMap: true,
             },
           },

--- a/Dashboard/webpack.config.prod.js
+++ b/Dashboard/webpack.config.prod.js
@@ -57,7 +57,18 @@ export default {
   ],
 
   optimization: {
+    moduleIds: 'hashed',
     minimize: true,
+    runtimeChunk: 'single',
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+      },
+    },
   },
 
   module: {
@@ -138,15 +149,15 @@ export default {
           use: [
             {
               loader: 'css-loader',
-            }, {
+            },
+            {
               loader: 'postcss-loader',
               options: {
-                plugins: () => [
-                  require('autoprefixer'),
-                ],
+                plugins: () => [require('autoprefixer')],
                 sourceMap: true,
               },
-            }, {
+            },
+            {
               loader: 'sass-loader',
               options: {
                 includePaths: [path.resolve(__dirname, 'app', 'css')],


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
No contentHash in the admin production build bundle

#### The solution
Added contentHash to only make the server fetch for new bundle if the hash changes (aka code changes)

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
