### PR TITLE
[#3416] - remove module splitting from webpack

### DIFF
--- a/Dashboard/webpack.config.prod.js
+++ b/Dashboard/webpack.config.prod.js
@@ -57,18 +57,7 @@ export default {
   ],
 
   optimization: {
-    moduleIds: 'hashed',
     minimize: true,
-    runtimeChunk: 'single',
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors',
-          chunks: 'all',
-        },
-      },
-    },
   },
 
   module: {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Unnecessary module splitting config was added to webpack config which was breaking the build

#### The solution
Remove module splitting 

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
