### PR TITLE
[#3446] - make assignment name border more visible

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -65,11 +65,11 @@
             font-weight: 500;
             border: none;
             padding: 4px 5px;
-            border: 1px solid transparent;
+            border: 1px solid #b8b8bc;
 
             &:hover,
             &:focus {
-              border: 1px solid #b8b8bc;
+              border: 1px solid #4d4d4d;
             }
           }
         }


### PR DESCRIPTION
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30107382/75453955-f46bb800-5974-11ea-9811-79177a324dac.png)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
