### PR TITLE
[#3451] Enable redirecting a servlet request to run as a task

### DIFF
--- a/GAE/src/com/gallatinsystems/framework/rest/RestRequest.java
+++ b/GAE/src/com/gallatinsystems/framework/rest/RestRequest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012,2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -46,6 +46,7 @@ public abstract class RestRequest implements Serializable {
     public static final String API_KEY_PARAM = "k";
     public static final String HASH_PARAM = "h";
     public static final String TIMESTAMP_PARAM = "ts";
+    public static final String RUN_AS_TASK_PARAM = "runAsTask";
 
     private List<RestError> validationErrorList;
 


### PR DESCRIPTION
### Before the PR (what is the issue or what needed to be done)
Some requests time out due to hitting the one minute deadline on GAE

#### The solution
We add the possibility to create a task by simply adding a parameter to the request.  This works for servlets that are extended from com.gallatinsystems.framework.rest.AbstractRestApiServlet.  Also right now we support only the ones that are secured.

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
