### PR TITLE
[#3447] - sort device groups

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AddDevices.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AddDevices.jsx
@@ -19,10 +19,9 @@ export default class AddDevice extends React.Component {
     const unSelectedDevices = devices.filter(device => !selectedDeviceIds.includes(device.id));
 
     // sort device groups
-    return _groupBy(
-      _sortBy(unSelectedDevices, device => device.deviceGroup.name),
-      device => device.deviceGroup.id
-    );
+    return _sortBy(_groupBy(unSelectedDevices, device => device.deviceGroup.id), [
+      item => item[0].deviceGroup.name,
+    ]);
   }
 
   onSelectDevice = (id, checked) => {

--- a/Dashboard/app/js/lib/components/selectors/DeviceSelector/DeviceAccordion.jsx
+++ b/Dashboard/app/js/lib/components/selectors/DeviceSelector/DeviceAccordion.jsx
@@ -62,8 +62,8 @@ export default class DeviceAccordion extends React.Component {
       <div className="accordion-container">
         <div className={accordionClass}>
           <Checkbox
-            id={parseInt(id, 10)}
-            name={parseInt(id, 10)}
+            id={id}
+            name={id}
             checked={this.allDevicesSelected()}
             onChange={this.selectAllDevice}
             label=""
@@ -103,7 +103,7 @@ DeviceAccordion.defaultProps = {
 };
 
 DeviceAccordion.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   deviceGroupIsActive: PropTypes.bool,
   name: PropTypes.string.isRequired,
   devices: PropTypes.array.isRequired,

--- a/Dashboard/app/js/lib/components/selectors/DeviceSelector/index.jsx
+++ b/Dashboard/app/js/lib/components/selectors/DeviceSelector/index.jsx
@@ -13,12 +13,12 @@ export default class DeviceSelector extends React.Component {
 
     return (
       <div>
-        {Object.keys(deviceGroups).map(dgId => (
+        {deviceGroups.map(devices => (
           <DeviceAccordion
-            key={dgId}
-            id={dgId}
-            name={deviceGroups[dgId][0].deviceGroup.name}
-            devices={deviceGroups[dgId]}
+            key={devices[0].deviceGroup.id}
+            id={devices[0].deviceGroup.id}
+            name={devices[0].deviceGroup.name}
+            devices={devices}
             handleSelectDevice={handleSelectDevice}
             handleSelectAllDevices={handleSelectAllDevices}
             selectedDevices={selectedDevices}
@@ -30,7 +30,7 @@ export default class DeviceSelector extends React.Component {
 }
 
 DeviceSelector.propTypes = {
-  deviceGroups: PropTypes.object.isRequired,
+  deviceGroups: PropTypes.array.isRequired,
   handleSelectDevice: PropTypes.func.isRequired,
   handleSelectAllDevices: PropTypes.func.isRequired,
   selectedDevices: PropTypes.array.isRequired,


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
devices seem to be sorted in descending order, i.e from z -> a rather than from a-> z. This was caused by javascript sorting object keys by default.

#### The solution
Sort the device group by names rather than by ID

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
