### PR TITLE
[#3466] - automatically take users to assigning datapoints after devices are added

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AddDevices.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AddDevices.jsx
@@ -58,6 +58,9 @@ export default class AddDevice extends React.Component {
 
     // empty selected devices
     this.setState({ selectedDevicesIds: [] });
+
+    // go to the first device in the assignment to add datapoints
+    this.props.changeTab('ASSIGN_DATAPOINTS', selectedDevicesIds[0]);
   };
 
   render() {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

#### The solution
Automatically take users to datapoint assignment page after devices have been added

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
