### PR TITLE
[#3483] - remove selected survey group when default folder is selected

### DIFF
--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -574,7 +574,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         return false;
       }
 
-      if (parentId == 0) {
+      if (parseInt(parentId, 10) === 0) {
         this.set('selectedSurveyGroupId', null);
         FLOW.selectedControl.set('selectedSurveyGroup', selectedSG);
       }

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -574,6 +574,11 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         return false;
       }
 
+      if (parentId == 0) {
+        this.set('selectedSurveyGroupId', null);
+        FLOW.selectedControl.set('selectedSurveyGroup', selectedSG);
+      }
+
       // empty forms when a new folder is picked
       this.forms = {};
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Bug with FolderSurveySelector having a survey still selected after selecting the default option (`Choose a folder or survey`)

#### The solution
When default option is selected, clear the currently selected option

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
