### PR TITLE
[#3436] - keep users in assignment page after saving

### DIFF
--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -286,11 +286,6 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       });
 
       FLOW.store.commit();
-
-      // wait half a second before transitioning back to the assignments list
-      setTimeout(() => {
-        FLOW.router.transitionTo('navDevices.assignSurveysOverview');
-      }, 500);
     },
 
     // setups


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
After a user clicks on save, It automatically takes the user to the assignments list page

#### The solution
Remove the code to keep the user in the assignment edit page

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
