### PR TITLE
[#3505] - keep device groups closed by default

### DIFF
--- a/Dashboard/app/js/lib/components/selectors/DeviceSelector/DeviceAccordion.jsx
+++ b/Dashboard/app/js/lib/components/selectors/DeviceSelector/DeviceAccordion.jsx
@@ -5,7 +5,7 @@ import Checkbox from 'akvo-flow/components/reusable/Checkbox';
 
 export default class DeviceAccordion extends React.Component {
   state = {
-    isAccordionOpen: this.props.deviceGroupIsActive || true,
+    isAccordionOpen: false,
   };
 
   onAccordionClick = () => {
@@ -98,13 +98,8 @@ export default class DeviceAccordion extends React.Component {
   }
 }
 
-DeviceAccordion.defaultProps = {
-  deviceGroupIsActive: true,
-};
-
 DeviceAccordion.propTypes = {
   id: PropTypes.number.isRequired,
-  deviceGroupIsActive: PropTypes.bool,
   name: PropTypes.string.isRequired,
   devices: PropTypes.array.isRequired,
   handleSelectDevice: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Device group according was open by default causing a lot of visual noise in the page

#### The solution
Keep device group closed by default

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
