### PR TITLE
[#3506] - make close button smaller

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -312,7 +312,7 @@
             border-bottom: 1px solid #e6e6e6;
 
             .icon {
-              font-size: 2em;
+              font-size: 1.3em;
             }
 
             .device-details p {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Section close button in assignments was big and in your face

#### The solution
Make it smaller and less in your face

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30107382/79205983-94eb3e00-7e36-11ea-945f-1bbf9f2032ec.png)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
