### PR TITLE
[#1223] Use a 'transaction' for new Assignment

### DIFF
--- a/Dashboard/app/js/lib/router/router.js
+++ b/Dashboard/app/js/lib/router/router.js
@@ -20,6 +20,7 @@ FLOW.Router = Ember.Router.extend({
     FLOW.selectedControl.set('selectedCascadeResource', null);
     FLOW.selectedControl.set('cascadeImportNumLevels', null);
     FLOW.selectedControl.set('cascadeImportIncludeCodes', null);
+    FLOW.selectedControl.set('surveyAssignmentTransaction', null);
     FLOW.surveyControl.set('content', null);
     FLOW.questionControl.set('OPTIONcontent', null);
     FLOW.metaControl.set('since', null);

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -239,7 +239,13 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       sa.set('formIds', formIds);
       sa.set('deviceIds', deviceIds);
 
-      FLOW.store.commit();
+      const transaction = FLOW.selectedControl.get('surveyAssignmentTransaction');
+      if (transaction) {
+        transaction.commit();
+        FLOW.selectedControl.set('surveyAssignmentTransaction', null);
+      } else {
+        FLOW.store.commit();
+      }
 
       return true;
     },

--- a/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignments-list-view.jsx
@@ -64,10 +64,12 @@ FLOW.AssignmentsListView = FLOW.ReactComponentView.extend(observe({
   assignmentEdit(action, assignmentId) {
     switch (action) {
       case 'new': {
-        const newAssignment = FLOW.store.createRecord(FLOW.SurveyAssignment, {
+        const transaction = FLOW.store.transaction();
+        const newAssignment = transaction.createRecord(FLOW.SurveyAssignment, {
           name: Ember.String.loc('_new_assignment_change_name'),
         });
         FLOW.selectedControl.set('selectedSurveyAssignment', newAssignment);
+        FLOW.selectedControl.set('surveyAssignmentTransaction', transaction);
         break;
       }
       default: {


### PR DESCRIPTION
The new `Assignment` behavior is different than the rest of the
application, e.g.  When creating a new `Survey`, we create and commit
the record, we get a the new `keyId` from the server and then we ask
the user to "edit" it.

In the case of `Assignment` we create a new record in the client and
we don't commit it until the user clicks the "Save" button or the user
navigates away triggering an implicit `FLOW.store.commit()`.

Since we don't want to save partially filled `Assignment` if the user
navigates away, we want to discard that record.

Ember Data has a concept of "transaction" and we use it to deal with
this exception.  When creating a new `Assignment` we do it within a
transaction and we discard if the user navigates away.

>  Because newly created records are dirty from the time they are created,
>  and because dirty records can not be added to a transaction, you must
>  use the `createRecord()` method to assign new records to a transaction.
>  For example, instead of this:
>    var transaction = store.transaction();
>    var person = App.Person.createRecord({ name: "Steve" });
>    // won't work because person is dirty
>    transaction.add(person);
>  Call `createRecord()` on the transaction directly:
>    var transaction = store.transaction();
>    transaction.createRecord(App.Person, { name: "Steve" });

https://github.com/akvo/akvo-flow/blob/20200403-170810/Dashboard/app/js/vendor/ember-data-rev10.js#L516-L555