### PR TITLE
[#3524] Use `equals` instead of `==` for String comparison

### DIFF
--- a/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
+++ b/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
@@ -292,7 +292,7 @@ public class SurveyedLocaleDao extends BaseDAO<SurveyedLocale> {
         query.setFilter(filterString.toString());
         query.declareParameters(paramString.toString());
 
-        if (cursor != null && cursor != "")
+        if (cursor != null && !"".equals(cursor))
             prepareCursor(cursor, query);
 
         return (List<SurveyedLocale>) query.executeWithMap(paramMap);


### PR DESCRIPTION
A common pitfall when trying to compare strings is to use `==`
operator, but this one is for checking if to objects are the same
"reference".  Most of the cases we want to use `.equals()` function.

In this particular issue the check `!= ""` was evaluating that the
passed string parameter `since` was the same refence, so the code
prepared a cursor of only 20 entities.

Fixing this problem now leads to a different UX problem that the user
needs to click one by one a pontential large list of checkboxes. This
problem will be fixed in a different changeset.

More info: https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/513839#513839