### PR TITLE
[#3502] - make folder selector stretch to fit screen

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/FormSection.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/FormSection.jsx
@@ -46,7 +46,7 @@ export default class FormSection extends React.Component {
             </span>
           </p>
 
-          <div className="form-selector">
+          <div>
             <br />
 
             <div className="folder-selector">

--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/styles.scss
@@ -185,11 +185,12 @@
 
         .settings {
           padding: 15px 25px;
-          width: 45%;
+          width: 90%;
 
           .assignment-date {
             margin-top: 15px;
             margin-bottom: 2em;
+            width: 50%;
 
             .date-picker {
               display: flex;
@@ -222,14 +223,16 @@
             }
           }
 
-          .assignment-survery-folder {
-            margin-bottom: 1.5em;
-          }
-
           .assignment-form-selector {
             margin-top: 2.3em;
 
+            .heading {
+              width: 45%;
+            }
+
             .folder-selector {
+              width: 90%;
+              
               select {
                 width: 150px;
                 height: 38px;
@@ -251,6 +254,8 @@
             }
 
             .form-selector {
+              width: 50%;
+
               .form {
                 width: 100%;
                 display: flex;

--- a/Dashboard/app/js/lib/components/selectors/FormSelector/index.jsx
+++ b/Dashboard/app/js/lib/components/selectors/FormSelector/index.jsx
@@ -8,7 +8,7 @@ export default class FormSelector extends React.Component {
     const { forms, onCheck } = this.props;
 
     return (
-      <div>
+      <div className="form-selector">
         {Object.keys(forms).map(formId => (
           <div className="form" key={formId}>
             <label htmlFor={formId}>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Folder selector width was limited to 45% of the container

#### The solution
Make `folder-selector` width full-width

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
