### PR TITLE
[#3528] Filter form instances by assigned forms

### DIFF
--- a/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
@@ -90,7 +90,7 @@ public class DataPointServlet extends AbstractRestApiServlet {
                     res.setMessage("No assignment was found");
                     return res;
                 }
-                res = convertToResponse(dpList, dpReq.getSurveyId());
+                res = convertToResponse(dpList, dpReq.getSurveyId(), device);
                 return res;
             }
             res.setCode(String.valueOf(HttpServletResponse.SC_NOT_FOUND));
@@ -139,7 +139,7 @@ public class DataPointServlet extends AbstractRestApiServlet {
     /**
      * converts the domain objects to dtos and then installs them in a DataPointResponse object
      */
-    private DataPointResponse convertToResponse(List<SurveyedLocale> slList, Long surveyId) {
+    private DataPointResponse convertToResponse(List<SurveyedLocale> slList, Long surveyId, Device device) {
         DataPointResponse resp = new DataPointResponse();
         if (slList == null) {
             resp.setCode(String.valueOf(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
@@ -151,7 +151,7 @@ public class DataPointServlet extends AbstractRestApiServlet {
         resp.setResultCount(slList.size());
 
         DataPointUtil dpu = new DataPointUtil();
-        List<SurveyedLocaleDto> dtoList = dpu.getSurveyedLocaleDtosList(slList, surveyId);
+        List<SurveyedLocaleDto> dtoList = dpu.getSurveyedLocaleDtosList(slList, surveyId, device);
 
         resp.setDataPointData(dtoList);
         return resp;

--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -125,7 +125,7 @@ public class DataPointUtil {
      * Fetches SurveyInstances using the surveyedLocalesIds and puts them in a map:
      * key: SurveyedLocalesId, value: list of SurveyInstances
      */
-    public Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds, Long surveyId, Device device) {
+    private Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds, Long surveyId, Device device) {
         SurveyInstanceDAO surveyInstanceDAO = new SurveyInstanceDAO();
 
         boolean shouldFilter = device != null;

--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -16,14 +16,13 @@
 
 package org.akvo.flow.api.app;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.gallatinsystems.device.domain.Device;
+import com.gallatinsystems.survey.dao.QuestionDao;
+import com.gallatinsystems.survey.domain.Question;
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
+import org.akvo.flow.dao.SurveyAssignmentDao;
 import org.akvo.flow.domain.DataUtils;
+import org.akvo.flow.domain.persistent.SurveyAssignment;
 import org.waterforpeople.mapping.app.web.dto.SurveyInstanceDto;
 import org.waterforpeople.mapping.app.web.dto.SurveyedLocaleDto;
 import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
@@ -32,20 +31,20 @@ import org.waterforpeople.mapping.domain.QuestionAnswerStore;
 import org.waterforpeople.mapping.domain.SurveyInstance;
 import org.waterforpeople.mapping.serialization.response.MediaResponse;
 
-import com.gallatinsystems.survey.dao.QuestionDao;
-import com.gallatinsystems.survey.domain.Question;
-import com.gallatinsystems.surveyal.domain.SurveyedLocale;
-import com.google.api.server.spi.config.Nullable;
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
 
 public class DataPointUtil {
 
-    public List<SurveyedLocaleDto> getSurveyedLocaleDtosList(List<SurveyedLocale> slList, Long surveyId) {
+    public List<SurveyedLocaleDto> getSurveyedLocaleDtosList(List<SurveyedLocale> slList, Long surveyId, Device device) {
         List<SurveyedLocaleDto> dtoList = new ArrayList<>();
         HashMap<Long, String> questionTypeMap = new HashMap<>();
         QuestionDao questionDao = new QuestionDao();
 
         List<Long> surveyedLocalesIds = getSurveyedLocalesIds(slList);
-        Map<Long, List<SurveyInstance>> surveyInstancesMap = getSurveyInstances(surveyedLocalesIds);
+        Map<Long, List<SurveyInstance>> surveyInstancesMap = getSurveyInstances(surveyedLocalesIds, surveyId, device);
         Map<Long, List<QuestionAnswerStore>> questionAnswerStore = getQuestionAnswerStoreMap(
                 surveyInstancesMap);
 
@@ -60,9 +59,9 @@ public class DataPointUtil {
     }
 
     private SurveyedLocaleDto createSurveyedLocaleDto(Long surveyGroupId, QuestionDao questionDao,
-            HashMap<Long, String> questionTypeMap, SurveyedLocale surveyedLocale,
-            Map<Long, List<QuestionAnswerStore>> questionAnswerStoreMap,
-            @Nullable List<SurveyInstance> surveyInstances) {
+                                                      HashMap<Long, String> questionTypeMap, SurveyedLocale surveyedLocale,
+                                                      Map<Long, List<QuestionAnswerStore>> questionAnswerStoreMap,
+                                                      @Nullable List<SurveyInstance> surveyInstances) {
         SurveyedLocaleDto dto = new SurveyedLocaleDto();
         dto.setId(surveyedLocale.getIdentifier());
         dto.setSurveyGroupId(surveyGroupId);
@@ -115,7 +114,7 @@ public class DataPointUtil {
         List<Long> surveyInstancesIds = new ArrayList<>();
         Collection<List<SurveyInstance>> values = surveyInstanceMap.values();
         for (List<SurveyInstance> surveyInstances : values) {
-            for (SurveyInstance surveyInstance: surveyInstances) {
+            for (SurveyInstance surveyInstance : surveyInstances) {
                 surveyInstancesIds.add(surveyInstance.getObjectId());
             }
         }
@@ -126,20 +125,37 @@ public class DataPointUtil {
      * Fetches SurveyInstances using the surveyedLocalesIds and puts them in a map:
      * key: SurveyedLocalesId, value: list of SurveyInstances
      */
-    private Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds) {
+    public Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds, Long surveyId, Device device) {
         SurveyInstanceDAO surveyInstanceDAO = new SurveyInstanceDAO();
+
+        boolean shouldFilter = device != null;
+        Set<Long> allowedFormIds = new HashSet<>();
+
+        if (shouldFilter) {
+            SurveyAssignmentDao assignmentDao = new SurveyAssignmentDao();
+            List<SurveyAssignment> assignments = assignmentDao
+                    .listAllContainingDevice(device.getKey().getId())
+                    .stream()
+                    .filter(surveyAssignment -> surveyAssignment.getSurveyId().equals(surveyId))
+                    .collect(Collectors.toList());
+            for (SurveyAssignment assignment : assignments) {
+                allowedFormIds.addAll(assignment.getFormIds());
+            }
+        }
+
         List<SurveyInstance> values = surveyInstanceDAO.fetchItemsByIdBatches(surveyedLocalesIds,
                 "surveyedLocaleId");
         Map<Long, List<SurveyInstance>> surveyInstancesMap = new HashMap<>();
+
         for (SurveyInstance surveyInstance : values) {
             Long surveyedLocaleId = surveyInstance.getSurveyedLocaleId();
-            if (surveyInstancesMap.containsKey(surveyedLocaleId)) {
-                surveyInstancesMap.get(surveyedLocaleId).add(surveyInstance);
-            } else {
-                List<SurveyInstance> instances = new ArrayList<>();
-                instances.add(surveyInstance);
-                surveyInstancesMap.put(surveyedLocaleId, instances);
+            if (!surveyInstancesMap.containsKey(surveyedLocaleId)) {
+                surveyInstancesMap.put(surveyedLocaleId, new ArrayList<>());
             }
+            if (shouldFilter && !allowedFormIds.contains(surveyInstance.getSurveyId())) {
+                continue;
+            }
+            surveyInstancesMap.get(surveyedLocaleId).add(surveyInstance);
         }
         return surveyInstancesMap;
     }
@@ -156,9 +172,9 @@ public class DataPointUtil {
     }
 
     private SurveyInstanceDto createSurveyInstanceDto(QuestionDao qDao,
-            HashMap<Long, String> questionTypeMap,
-            @Nullable List<QuestionAnswerStore> questionAnswerStores,
-            @Nullable SurveyInstance surveyInstance) {
+                                                      HashMap<Long, String> questionTypeMap,
+                                                      @Nullable List<QuestionAnswerStore> questionAnswerStores,
+                                                      @Nullable SurveyInstance surveyInstance) {
         SurveyInstanceDto surveyInstanceDto = new SurveyInstanceDto();
         if (surveyInstance != null) {
             surveyInstanceDto.setUuid(surveyInstance.getUuid());
@@ -202,7 +218,7 @@ public class DataPointUtil {
     }
 
     private String getQuestionType(QuestionDao questionDao, HashMap<Long, String> questionTypeMap,
-            QuestionAnswerStore questionAnswerStore) {
+                                   QuestionAnswerStore questionAnswerStore) {
         String type = questionAnswerStore.getType();
         if (type == null || "".equals(type)) {
             type = "VALUE";

--- a/GAE/src/org/akvo/flow/api/app/SurveyedLocaleServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/SurveyedLocaleServlet.java
@@ -105,7 +105,7 @@ public class SurveyedLocaleServlet extends AbstractRestApiServlet {
         resp.setResultCount(slList.size());
 
         DataPointUtil dpu = new DataPointUtil();
-        List<SurveyedLocaleDto> dtoList = dpu.getSurveyedLocaleDtosList(slList, surveyId);
+        List<SurveyedLocaleDto> dtoList = dpu.getSurveyedLocaleDtosList(slList, surveyId, null);
 
         resp.setSurveyedLocaleData(dtoList);
         return resp;

--- a/GAE/test/org/akvo/flow/api/app/DataPointUtilTest.java
+++ b/GAE/test/org/akvo/flow/api/app/DataPointUtilTest.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.akvo.flow.api.app;
+
+import com.gallatinsystems.device.dao.DeviceDAO;
+import com.gallatinsystems.device.domain.Device;
+import com.gallatinsystems.framework.domain.BaseDomain;
+import com.gallatinsystems.survey.dao.SurveyDAO;
+import com.gallatinsystems.survey.domain.Survey;
+import com.gallatinsystems.surveyal.dao.SurveyedLocaleDao;
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.akvo.flow.dao.SurveyAssignmentDao;
+import org.akvo.flow.domain.persistent.SurveyAssignment;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.waterforpeople.mapping.dao.SurveyInstanceDAO;
+import org.waterforpeople.mapping.domain.SurveyInstance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataPointUtilTest {
+    private final static LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+    @BeforeAll
+    public static void setUp() {
+        helper.setUp();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        helper.tearDown();
+    }
+
+    private long randomId() {
+        return ThreadLocalRandom.current().nextLong(0, 1000000);
+    }
+
+    private int randomInt() {
+        return ThreadLocalRandom.current().nextInt(1, 200);
+    }
+
+    private Survey createForm() {
+        long id = randomId();
+        Survey form = new Survey();
+        form.setKey(KeyFactory.createKey("Survey", id));
+        form.setName("Form" + id);
+        form.setVersion(1.0d);
+        SurveyDAO dao = new SurveyDAO();
+        return dao.save(form);
+    }
+
+    private List<SurveyInstance> createFormInstances(Survey form, SurveyedLocale survey, int howMany) {
+        List<SurveyInstance> newInstances = new ArrayList<>();
+        for (int i = 0; i < howMany; i++) {
+            SurveyInstance si = new SurveyInstance();
+            si.setSurveyId(form.getKey().getId());
+            si.setSurveyedLocaleId(survey.getKey().getId());
+            si.setCollectionDate(new Date());
+            si.setUuid(UUID.randomUUID().toString());
+            si.setFormVersion(form.getVersion());
+            newInstances.add(si);
+        }
+        SurveyInstanceDAO dao = new SurveyInstanceDAO();
+        return (List<SurveyInstance>) dao.save(newInstances);
+    }
+
+    private List<SurveyInstance> createFormInstances(SurveyedLocale dataPoint, int howMany, Survey... forms) {
+        List<SurveyInstance> allFormInstances = new ArrayList<>();
+        for (Survey form : forms) {
+            allFormInstances.addAll(createFormInstances(form, dataPoint, randomInt()));
+        }
+        return allFormInstances;
+    }
+
+    private SurveyedLocale createDataPoint() {
+        long id = randomId();
+        SurveyedLocale dp = new SurveyedLocale();
+        dp.setKey(KeyFactory.createKey("SurveyedLocale", id));
+        dp.setSurveyGroupId(randomId());
+
+        SurveyedLocaleDao dao = new SurveyedLocaleDao();
+        return dao.save(dp);
+    }
+
+    private Device createDevice() {
+        long id = randomId();
+        Device device = new Device();
+        device.setKey(KeyFactory.createKey("Device", id));
+        device.setEsn(String.valueOf(id));
+        device.setDeviceType(Device.DeviceType.CELL_PHONE_ANDROID);
+        device.setDeviceIdentifier(String.valueOf(id));
+
+        DeviceDAO dao = new DeviceDAO();
+        return dao.save(device);
+    }
+
+    private SurveyAssignment createAssignment(Long surveyId, List<Long> deviceIds, List<Long> formIds) {
+        SurveyAssignment assignment = new SurveyAssignment();
+        assignment.setKey(KeyFactory.createKey("SurveyAssignment", randomId()));
+        assignment.setDeviceIds(deviceIds);
+        assignment.setFormIds(formIds);
+        assignment.setSurveyId(surveyId);
+
+        SurveyAssignmentDao dao = new SurveyAssignmentDao();
+        return dao.save(assignment);
+    }
+
+    private Set<Long> getIds(List<? extends BaseDomain> entities) {
+        return entities.stream()
+                .map(surveyInstance -> surveyInstance.getKey().getId())
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void getSurveyInstancesReturnsFilteredData() {
+
+        Survey form1 = createForm();
+        Survey form2 = createForm();
+
+        Device device = createDevice();
+
+        SurveyedLocale dataPoint = createDataPoint();
+        List<Long> dataPointIds = Arrays.asList(dataPoint.getKey().getId());
+        List<SurveyInstance> allFormInstances = createFormInstances(dataPoint, randomInt(), form1, form2);
+
+        List<SurveyInstance> form1Instances = allFormInstances.stream()
+                .filter(surveyInstance -> surveyInstance.getSurveyId().equals(form1.getKey().getId()))
+                .collect(Collectors.toList());
+
+        // Assignment only contains Id for form1
+        SurveyAssignment assignment = createAssignment(dataPoint.getSurveyGroupId(),
+                Arrays.asList(device.getKey().getId()), Arrays.asList(form1.getKey().getId()));
+
+        DataPointUtil dpu = new DataPointUtil();
+        Map<Long, List<SurveyInstance>> foundInstances = dpu.getSurveyInstances(dataPointIds, dataPoint.getSurveyGroupId(), device);
+
+        Set<Long> expectedIds = getIds(form1Instances);
+
+        Set<Long> resultIds = getIds(foundInstances.get(dataPoint.getKey().getId()));
+
+        assertEquals(expectedIds, resultIds);
+    }
+
+    @Test
+    public void getSurveyInstancesReturnsAllWhenDeviceIsNull() {
+        Survey form1 = createForm();
+        Survey form2 = createForm();
+
+        SurveyedLocale dataPoint = createDataPoint();
+        List<Long> dataPointIds = Arrays.asList(dataPoint.getKey().getId());
+        List<SurveyInstance> allFormInstances = createFormInstances(dataPoint, randomInt(), form1, form2);
+
+        DataPointUtil dpu = new DataPointUtil();
+        Map<Long, List<SurveyInstance>> foundInstances = dpu.getSurveyInstances(dataPointIds, dataPoint.getSurveyGroupId(), null);
+
+        Set<Long> expectedIds = getIds(allFormInstances);
+
+        Set<Long> resultIds = getIds(foundInstances.get(dataPoint.getKey().getId()));
+
+        assertEquals(expectedIds, resultIds);
+    }
+}


### PR DESCRIPTION
The `/datapoints` endpoint will filter form instances by the
assigned forms instead of returning all. The exception is the
old `/surveyedlocale` used by old apps that will keep returning
all the data.