### PR TITLE
[#3538] - make device groups on sidebar closed by default

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/__partials/SidebarDropdown.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/__partials/SidebarDropdown.jsx
@@ -5,7 +5,7 @@ import AssignmentsContext from '../assignment-context';
 
 export default class SidebarDropdown extends React.Component {
   state = {
-    isOpen: true,
+    isOpen: false,
   };
 
   toggleDropdown = () => {


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Sidebar dropdowns were opened by default

#### The solution
Make the dropdown closed by default 

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
