### PR TITLE
[#3521] Filter search result - Don't include already assigned

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/SearchDatapoints.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/SearchDatapoints.jsx
@@ -68,6 +68,9 @@ export default class SearchDatapoints extends React.Component {
     const emptyResult = datapointsResults.length === 0;
     const allSelected = !emptyResult && selectedDatapointsIds.length === datapointsResults.length;
 
+    const assignedIds = this.props.assignedDataPointIds;
+    const filteredResults = datapointsResults.filter(i => !assignedIds[i.id]);
+
     const selectAllButton =
       emptyResult || allSelected ? (
         <span />
@@ -113,7 +116,7 @@ export default class SearchDatapoints extends React.Component {
               {undoAllButton}
               {selectAllButton}
             </div>
-            {datapointsResults.map(dp => (
+            {filteredResults.map(dp => (
               <div key={dp.id} className="search-result">
                 <Checkbox
                   key={dp.id}
@@ -156,4 +159,5 @@ SearchDatapoints.contextType = AssignmentContext;
 SearchDatapoints.propTypes = {
   deviceId: PropTypes.number.isRequired,
   changeTab: PropTypes.func.isRequired,
+  assignedDataPointIds: PropTypes.object.isRequired,
 };

--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
@@ -101,6 +101,11 @@ export default class AssignDatapoints extends React.Component {
   render() {
     const { deviceData, datapointsData, allDPAssigned } = this.getAssignmentData();
 
+    const assignedDataPointIds = datapointsData.reduce((acc, current) => {
+      acc[current.id] = true;
+      return acc;
+    }, {});
+
     return (
       <div className="devices-action-page assign-datapoints">
         <div>
@@ -117,7 +122,11 @@ export default class AssignDatapoints extends React.Component {
 
         <div>
           {this.state.currentSubTab === 'SEARCH_DATAPOINTS' && (
-            <SearchDatapoints deviceId={this.props.selectedDeviceId} changeTab={this.changeTab} />
+            <SearchDatapoints
+              deviceId={this.props.selectedDeviceId}
+              changeTab={this.changeTab}
+              assignedDataPointIds={assignedDataPointIds}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
We "cache" the ids of the already assigned datapoints and use it as
`props` for the Component. When rendering the list of available
datapoints, we filter out those already assigned.