### PR TITLE
[#3552] - use environmental variable for site id

### DIFF
--- a/Dashboard/app/js/lib/analytics.js
+++ b/Dashboard/app/js/lib/analytics.js
@@ -10,7 +10,7 @@ export function init() {
     const u = 'https://analytics.akvo.org/';
 
     window._paq.push(['setTrackerUrl', `${u}ppms.php`]);
-    window._paq.push(['setSiteId', 'ceda081e-8077-4ea3-98bc-f608d6f87cc9']);
+    window._paq.push(['setSiteId', process.env.ANALYTICS_SITE_ID]);
 
     const d = document;
     const g = d.createElement('script');

--- a/Dashboard/webpack.config.dev.js
+++ b/Dashboard/webpack.config.dev.js
@@ -43,6 +43,7 @@ export default {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('development'), // Tells React to build in either dev or prod modes. https://facebook.github.io/react/downloads.html (See bottom)
+      'process.env.ANALYTICS_SITE_ID': JSON.stringify('2eb02fff-08a4-4973-ae92-fb4ae6157da4'),
       __DEV__: true,
       __VERSION__: JSON.stringify(execSync('git describe').toString()),
     }),

--- a/Dashboard/webpack.config.prod.js
+++ b/Dashboard/webpack.config.prod.js
@@ -32,6 +32,7 @@ export default {
     // Tells React to build in prod mode. https://facebook.github.io/react/downloads.html
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.ANALYTICS_SITE_ID': JSON.stringify('ceda081e-8077-4ea3-98bc-f608d6f87cc9'),
       __DEV__: false,
       __VERSION__: JSON.stringify(execSync('git describe').toString()),
     }),


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
We were using fixed ids for both local and prod environment

#### The solution
Use env variables for controlling analytics site-ids

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
