### PR TITLE
Use random url for webforms

### DIFF
--- a/GAE/src/com/gallatinsystems/common/util/MD5Util.java
+++ b/GAE/src/com/gallatinsystems/common/util/MD5Util.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2018 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2018,2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/com/gallatinsystems/common/util/MD5Util.java
+++ b/GAE/src/com/gallatinsystems/common/util/MD5Util.java
@@ -21,7 +21,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -75,8 +75,7 @@ public class MD5Util {
                     mac.getAlgorithm());
             mac.init(secret);
             byte[] digest = mac.doFinal(content.getBytes());
-            // TODO: Change to Base64 API when moved to Java 8
-            return DatatypeConverter.printBase64Binary(digest);
+            return new Base64().encodeAsString(digest);
         } catch (NoSuchAlgorithmException e) {
             log.log(Level.SEVERE, e.getMessage(), e);
         } catch (InvalidKeyException e) {

--- a/GAE/src/com/gallatinsystems/common/util/MD5Util.java
+++ b/GAE/src/com/gallatinsystems/common/util/MD5Util.java
@@ -19,9 +19,9 @@ package com.gallatinsystems.common.util;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.codec.binary.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -75,7 +75,7 @@ public class MD5Util {
                     mac.getAlgorithm());
             mac.init(secret);
             byte[] digest = mac.doFinal(content.getBytes());
-            return new Base64().encodeAsString(digest);
+            return Base64.getEncoder().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
             log.log(Level.SEVERE, e.getMessage(), e);
         } catch (InvalidKeyException e) {

--- a/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
+++ b/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
@@ -51,7 +51,7 @@ public class RestAuthFilter implements Filter {
     private static final Logger log = Logger.getLogger(RestAuthFilter.class
             .getName());
     private static final String ENABLED_PROP = "enableRestSecurity";
-    private static final String REST_PRIVATE_KEY_PROP = "restPrivateKey";
+    public static final String REST_PRIVATE_KEY_PROP = "restPrivateKey";
     private String privateKey;
     private boolean isEnabled = false;
 

--- a/GAE/src/com/gallatinsystems/survey/domain/Survey.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Survey.java
@@ -37,7 +37,8 @@ import com.gallatinsystems.survey.dao.SurveyGroupDAO;
 @PersistenceCapable
 public class Survey extends BaseDomain implements SecuredObject {
 
-    private static final long serialVersionUID = -8638039212962768687L;
+    private static final long serialVersionUID = -6188180121727332787L;
+
     @NotPersistent
     private HashMap<String, Translation> translationMap;
     private String code = null;
@@ -52,6 +53,7 @@ public class Survey extends BaseDomain implements SecuredObject {
     private Long surveyGroupId;
     private String defaultLanguageCode;
     private Boolean requireApproval;
+    private Boolean webForm;
 
     public enum Status {
         PUBLISHED, NOT_PUBLISHED, IMPORTED, VERIFIED, COPYING
@@ -64,6 +66,7 @@ public class Survey extends BaseDomain implements SecuredObject {
     public Survey() {
         questionGroupMap = new TreeMap<Integer, QuestionGroup>();
         requireApproval = false;
+        webForm = false;
     }
 
     public void incrementVersion() {
@@ -193,6 +196,15 @@ public class Survey extends BaseDomain implements SecuredObject {
     public Boolean getRequireApproval() {
         return requireApproval;
     }
+
+    public void setWebForm(Boolean webForm) {
+        this.webForm = webForm;
+    }
+
+    public Boolean getWebForm() {
+        return webForm;
+    }
+
 
     @Override
     public SecuredObject getParentObject() {

--- a/GAE/src/com/gallatinsystems/survey/domain/Survey.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/Survey.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015,2018 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2015,2018,2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -22,15 +22,19 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WebForm {
-   
+
+    public static Set<String> unsupportedQuestionTypes(){
+        Set<String> unsupportedTypes = new HashSet<String>();
+        unsupportedTypes.add(Question.Type.CASCADE.toString());
+        unsupportedTypes.add(Question.Type.GEOSHAPE.toString());
+        unsupportedTypes.add(Question.Type.SIGNATURE.toString());
+        unsupportedTypes.add(Question.Type.CADDISFLY.toString());
+        return unsupportedTypes;
+    }
+
     public static boolean validWebForm(final List<Question> questions){
-        Set<Question.Type> set = new HashSet<Question.Type>();
-        set.add(Question.Type.CASCADE);
-        set.add(Question.Type.GEOSHAPE);
-        set.add(Question.Type.SIGNATURE);
-        set.add(Question.Type.CADDISFLY);        
         
-        List<Question> validQuestions = questions.stream().filter(i -> !set.contains(i.getType())).collect(Collectors.toList());
+        List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
 
         return validQuestions.size() == questions.size();
     }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018-2020 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2018-2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package com.gallatinsystems.survey.domain;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class WebForm {
+   
+    public static boolean validWebForm(final List<Question> questions){
+        Set<Question.Type> set = new HashSet<Question.Type>();
+        set.add(Question.Type.CASCADE);
+        set.add(Question.Type.GEOSHAPE);
+        set.add(Question.Type.SIGNATURE);
+        set.add(Question.Type.CADDISFLY);        
+        
+        List<Question> validQuestions = questions.stream().filter(i -> !set.contains(i.getType())).collect(Collectors.toList());
+
+        return validQuestions.size() == questions.size();
+    }
+
+}

--- a/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
+++ b/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package org.akvo.flow.util;
+
+import org.springframework.security.crypto.codec.Base64;
+
+public class OneTimePadCypher {
+
+    public static String encrypt(final String secretKey, final String text) {
+      return new String(Base64.encode(xor(secretKey, text.getBytes())));
+    }
+
+    public static String decrypt(final String secretKey, final String hash) {
+      try {
+        return new String(xor(secretKey, Base64.decode(hash.getBytes())), "UTF-8");
+      } catch (java.io.UnsupportedEncodingException ex) {
+        throw new IllegalStateException(ex);
+      }
+    }
+    private static byte[] xor(final String secretKey, final byte[] input) {
+      final byte[] output = new byte[input.length];
+      final byte[] secret = secretKey.getBytes();
+      int spos = 0;
+      for (int pos = 0; pos < input.length; ++pos) {
+        output[pos] = (byte) (input[pos] ^ secret[spos]);
+        spos += 1;
+        if (spos >= secret.length) {
+          spos = 0;
+        }
+      }
+      return output;
+    }
+  
+}

--- a/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
+++ b/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
@@ -20,7 +20,7 @@ import java.util.Base64;
 public class OneTimePadCypher {
 
     public static String encrypt(final String secretKey, final String text) {
-      return new String(Base64.getEncoder().encode(xor(secretKey, text.getBytes())));
+      return new String(Base64.getUrlEncoder().withoutPadding().encodeToString(xor(secretKey, text.getBytes())));
     }
 
     public static String decrypt(final String secretKey, final String hash) {

--- a/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
+++ b/GAE/src/org/akvo/flow/util/OneTimePadCypher.java
@@ -15,17 +15,17 @@
  */
 package org.akvo.flow.util;
 
-import org.springframework.security.crypto.codec.Base64;
+import java.util.Base64;
 
 public class OneTimePadCypher {
 
     public static String encrypt(final String secretKey, final String text) {
-      return new String(Base64.encode(xor(secretKey, text.getBytes())));
+      return new String(Base64.getEncoder().encode(xor(secretKey, text.getBytes())));
     }
 
     public static String decrypt(final String secretKey, final String hash) {
       try {
-        return new String(xor(secretKey, Base64.decode(hash.getBytes())), "UTF-8");
+        return new String(xor(secretKey, Base64.getDecoder().decode(hash.getBytes())), "UTF-8");
       } catch (java.io.UnsupportedEncodingException ex) {
         throw new IllegalStateException(ex);
       }

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2012-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -25,6 +25,7 @@ import com.gallatinsystems.survey.domain.Question;
 import com.gallatinsystems.survey.domain.QuestionOption;
 import com.gallatinsystems.survey.domain.Survey;
 import com.gallatinsystems.survey.domain.SurveyGroup;
+import com.gallatinsystems.survey.domain.WebForm;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 
@@ -225,6 +226,15 @@ public class QuestionRestService {
         return response;
     }
 
+    // take care that question changes doens't break Survey.webform if any
+    protected void ensureWebFormSurvey(QuestionDto q){
+        Survey s = surveyDao.getById(q.getSurveyId());
+        if (s.getWebForm() && WebForm.unsupportedQuestionTypes().contains(q.getType().toString())){
+            s.setWebForm(false);
+            surveyDao.save(s);
+        }
+    }
+
     // update existing question
     // questionOptions are saved and updated on their own
     @RequestMapping(method = RequestMethod.PUT, value = "/{id}")
@@ -255,11 +265,13 @@ public class QuestionRestService {
                     BeanUtils.copyProperties(questionDto, q, new String[] {
                             "createdDateTime", "type", "optionList"
                     });
-                    if (questionDto.getType() != null)
-                        q.setType(Question.Type.valueOf(questionDto.getType()
-                                .toString()));
-
+                    if (questionDto.getType() != null) {
+                        q.setType(Question.Type.valueOf(questionDto.getType().toString()));
+                        ensureWebFormSurvey(questionDto);
+                    }
+                    
                     q = questionDao.save(q);
+
 
                     dto = QuestionDtoMapper.transform(q);
                     statusDto.setStatus("ok");
@@ -292,6 +304,7 @@ public class QuestionRestService {
                 if (questionDto != null) {
                     Long keyId = questionDto.getKeyId();
                     Question q;
+                    ensureWebFormSurvey(questionDto);
 
                     // if the questionDto has a key, try to get the question.
                     if (keyId != null) {
@@ -353,6 +366,8 @@ public class QuestionRestService {
             } else {
                 q = copyQuestion(questionDto);
             }
+            ensureWebFormSurvey(questionDto);
+
             dto = QuestionDtoMapper.transform(q);
             statusDto.setStatus("ok");
             statusDto.setMessage("");

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyNotValidAsWebformException.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyNotValidAsWebformException.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2014,2019 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.app.web.rest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.annotation.Resource;
+@ResponseStatus(value = HttpStatus.PRECONDITION_FAILED)
+public class SurveyNotValidAsWebformException extends RuntimeException {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6821983258134989926L;
+
+    public SurveyNotValidAsWebformException(String message) {
+        super(message);
+	}
+}

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyNotValidAsWebformException.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyNotValidAsWebformException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2014,2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -19,7 +19,6 @@ package org.waterforpeople.mapping.app.web.rest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import javax.annotation.Resource;
 @ResponseStatus(value = HttpStatus.PRECONDITION_FAILED)
 public class SurveyNotValidAsWebformException extends RuntimeException {
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2015,2017-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2012-2015,2017-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -156,7 +156,7 @@ public class SurveyRestService {
             dto.setDescription(s.getDesc());
         }
  */
-        response.put("url", OneTimePadCypher.encrypt("secretKey", id.toString()));
+        response.put("webformId", OneTimePadCypher.encrypt("secretKey", id.toString()));
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.akvo.flow.util.OneTimePadCypher;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -135,6 +136,27 @@ public class SurveyRestService {
         }
 
         response.put("surveys", results);
+        return response;
+    }
+  
+    // 
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/webform_url")
+    @ResponseBody
+    public Map<String, String> webformUrl(@PathVariable("id") Long id) {
+        final Map<String, String> response = new HashMap<String, String>();
+/*        
+        Survey s = surveyDao.getByKey(id);
+        SurveyDto dto = null;
+
+        if (s != null) {
+            dto = new SurveyDto();
+            DtoMarshaller.copyToDto(s, dto);
+            // needed because of different names for description in survey and
+            // surveyDto
+            dto.setDescription(s.getDesc());
+        }
+ */
+        response.put("url", OneTimePadCypher.encrypt("secretKey", id.toString()));
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -142,16 +142,18 @@ public class SurveyRestService {
     }
   
     // 
-    @RequestMapping(method = RequestMethod.GET, value = "/{id}/webform_url")
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/webform_id")
     @ResponseBody
     public Map<String, String> webformUrl(@PathVariable("id") Long id) {
         final Map<String, String> response = new HashMap<String, String>();
         /*
          * Survey s = surveyDao.getByKey(id); SurveyDto dto = null;
          * 
-         * if (s != null) { dto = new SurveyDto(); DtoMarshaller.copyToDto(s, dto); //
+         * if (s != null) { 
+         * dto = new SurveyDto(); DtoMarshaller.copyToDto(s, dto); //
          * needed because of different names for description in survey and // surveyDto
-         * dto.setDescription(s.getDesc()); }
+         * dto.setDescription(s.getDesc()); 
+         * }
          */
         String webformId;
         try {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -41,6 +41,8 @@ import org.waterforpeople.mapping.app.web.rest.dto.RestStatusDto;
 import org.waterforpeople.mapping.app.web.rest.dto.SurveyPayload;
 import org.waterforpeople.mapping.dao.QuestionAnswerStoreDao;
 
+import com.gallatinsystems.common.util.PropertyUtil;
+import com.gallatinsystems.framework.servlet.RestAuthFilter;
 import com.gallatinsystems.survey.dao.QuestionDao;
 import com.gallatinsystems.survey.dao.SurveyDAO;
 import com.gallatinsystems.survey.dao.SurveyUtils;
@@ -157,7 +159,8 @@ public class SurveyRestService {
             Survey s = surveyDao.getById(id);
             s.setWebForm(webform);
             surveyDao.save(s);
-            response.put("webformId", OneTimePadCypher.encrypt("secretKey", id.toString()));
+            response.put("webformId", OneTimePadCypher.encrypt(PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP),
+                    id.toString()));
         } else {
             throw new SurveyNotValidAsWebformException(
                 "Webforms don't support the following question types: cascade, geoshape, signature or caddisfly.");

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -18,7 +18,6 @@ package org.waterforpeople.mapping.app.web.rest;
 
 import static com.gallatinsystems.common.Constants.ANCESTOR_IDS_FIELD;
 
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -19,7 +19,6 @@ package org.waterforpeople.mapping.app.web.rest;
 import static com.gallatinsystems.common.Constants.ANCESTOR_IDS_FIELD;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -159,13 +158,7 @@ public class SurveyRestService {
             Survey s = surveyDao.getById(id);
             s.setWebForm(webform);
             surveyDao.save(s);
-            try {
-                String webformId = URLEncoder.encode(OneTimePadCypher.encrypt("secretKey", id.toString()), "UTF-8");
-                response.put("webformId", webformId);
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
-                throw new RuntimeException(e);
-            }
+            response.put("webformId", OneTimePadCypher.encrypt("secretKey", id.toString()));
         } else {
             throw new SurveyNotValidAsWebformException(
                 "Webforms don't support the following question types: cascade, geoshape, signature or caddisfly.");

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -18,6 +18,8 @@ package org.waterforpeople.mapping.app.web.rest;
 
 import static com.gallatinsystems.common.Constants.ANCESTOR_IDS_FIELD;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -144,19 +146,20 @@ public class SurveyRestService {
     @ResponseBody
     public Map<String, String> webformUrl(@PathVariable("id") Long id) {
         final Map<String, String> response = new HashMap<String, String>();
-/*        
-        Survey s = surveyDao.getByKey(id);
-        SurveyDto dto = null;
-
-        if (s != null) {
-            dto = new SurveyDto();
-            DtoMarshaller.copyToDto(s, dto);
-            // needed because of different names for description in survey and
-            // surveyDto
-            dto.setDescription(s.getDesc());
+        /*
+         * Survey s = surveyDao.getByKey(id); SurveyDto dto = null;
+         * 
+         * if (s != null) { dto = new SurveyDto(); DtoMarshaller.copyToDto(s, dto); //
+         * needed because of different names for description in survey and // surveyDto
+         * dto.setDescription(s.getDesc()); }
+         */
+        String webformId;
+        try {
+            webformId = URLEncoder.encode(OneTimePadCypher.encrypt("secretKey", id.toString()), "UTF-8");
+            response.put("webformId", webformId);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
         }
- */
-        response.put("webformId", OneTimePadCypher.encrypt("secretKey", id.toString()));
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -168,6 +168,9 @@ public class SurveyRestService {
         boolean validWebform = validQuestions.size() == questions.size();
 
         if(validWebform){
+            Survey s = surveyDao.getById(id);
+            s.setWebForm(true);
+            surveyDao.save(s);
             try {
                 String webformId = URLEncoder.encode(OneTimePadCypher.encrypt("secretKey", id.toString()), "UTF-8");
                 response.put("webformId", webformId);

--- a/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
+++ b/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
@@ -1,0 +1,21 @@
+package org.akvo.flow.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OneTimePadCypherTest {
+    
+    final String secretKey = "very-secret-key";
+    final String encriptedValue = "AgAKDQ=="; 
+    final String valueToEncrypt = "text";
+
+    @Test
+    void encrypt() {
+        assertEquals(OneTimePadCypher.encrypt(secretKey, valueToEncrypt), encriptedValue);
+    }
+
+    @Test
+    void decrypt() {
+        assertEquals(OneTimePadCypher.decrypt(secretKey, encriptedValue), valueToEncrypt);
+    }
+}

--- a/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
+++ b/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
 package org.akvo.flow.util;
 
 import org.junit.jupiter.api.Test;

--- a/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
+++ b/GAE/test/org/akvo/flow/util/OneTimePadCypherTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class OneTimePadCypherTest {
     
     final String secretKey = "very-secret-key";
-    final String encriptedValue = "AgAKDQ=="; 
+    final String encriptedValue = "AgAKDQ";
     final String valueToEncrypt = "text";
 
     @Test


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Relates #3562 

Besides setting up a new endpoint  in `SurveyRestService`  `GET, value = "/{id}/webform_id"` and the logic to ofuscate the SurveyId value using an OneTimePad encrypted url encoded algorithm, there are changes to take care of the new Survey db boolean column `webform` that depends on survey column types support (currently don't supported `CASCADE, GEOSHAPE, SIGNATURE, CADDISFLY`)




#### The solution

#### Screenshots (if appropriate)
Changes once integrated with UI branch
<img width="807" alt="Screenshot 2020-05-21 at 08 40 42" src="https://user-images.githubusercontent.com/731829/82532065-d4e1c700-9b40-11ea-8e4c-5e29442bbbfb.png">

New boolean column `webform` in Survey Table

<img width="551" alt="Screenshot 2020-05-21 at 08 56 03" src="https://user-images.githubusercontent.com/731829/82532143-fd69c100-9b40-11ea-90fc-f18f60c9f081.png">


#### Reviewer Checklist
* [x] Added an explanation about the work done
* [x] Connected the PR and the issue on Zenhub
* [x] Added a test plan to the issue
* [x] Updated the copyright header (when relevant)
* [x] Formatted the code
* [x] Added a documentation (if relevant)
* [x] Added some unit tests (if relevant)
