### PR TITLE
Fix webform validation conditions and refactor logic application contexts

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -31,11 +31,19 @@ public class WebForm {
         return unsupportedTypes;
     }
 
+    public static boolean validQuestionGroups(final Survey survey){
+        return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable().booleanValue()).collect(Collectors.toList()).size() == 0;
+    }
+
+    public static boolean validSurveyGroup(final SurveyGroup surveyGroup){
+        return !surveyGroup.getMonitoringGroup().booleanValue();
+    }
+
     public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions){
-        boolean hasRepeatableGroups = survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable().booleanValue()).collect(Collectors.toList()).size() > 0;
-        if (hasRepeatableGroups) return false;
-        boolean monitoring = surveyGroup.getMonitoringGroup().booleanValue();
-        if (monitoring) return false;
+        boolean validQuestionGroups = validQuestionGroups(survey);
+        if (!validQuestionGroups) return false;
+        boolean validSurveyGroup = validSurveyGroup(surveyGroup);
+        if (!validSurveyGroup) return false;
         List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
         return validQuestions.size() == questions.size();
     }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 public class WebForm {
 
-    public static Set<String> unsupportedQuestionTypes(){
+    public static Set<String> unsupportedQuestionTypes() {
         Set<String> unsupportedTypes = new HashSet<String>();
         unsupportedTypes.add(Question.Type.GEOSHAPE.toString());
         unsupportedTypes.add(Question.Type.SIGNATURE.toString());
@@ -31,19 +31,23 @@ public class WebForm {
         return unsupportedTypes;
     }
 
-    public static boolean validQuestionGroups(final Survey survey){
+    public static boolean validQuestionGroups(final Survey survey) {
         return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable()).collect(Collectors.toList()).size() == 0;
     }
 
-    public static boolean validSurveyGroup(final Survey survey, final SurveyGroup surveyGroup){
+    public static boolean validSurveyGroup(final Survey survey, final SurveyGroup surveyGroup) {
         return surveyGroup.getNewLocaleSurveyId() != null && surveyGroup.getNewLocaleSurveyId().equals(survey.getKey().getId());
     }
 
-    public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions){
+    public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions) {
         boolean validQuestionGroups = validQuestionGroups(survey);
-        if (!validQuestionGroups) { return false; }
+        if (!validQuestionGroups) {
+            return false;
+        }
         boolean validSurveyGroup = validSurveyGroup(survey, surveyGroup);
-        if (!validSurveyGroup) { return false; }
+        if (!validSurveyGroup) {
+            return false;
+        }
         List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
         return validQuestions.size() == questions.size();
     }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -35,7 +35,7 @@ public class WebForm {
         return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable()).collect(Collectors.toList()).size() == 0;
     }
 
-    public static boolean validSurveyGroup(final Survey survey, final SurveyGroup surveyGroup) {
+    public static boolean validForm(final Survey survey, final SurveyGroup surveyGroup) {
         return surveyGroup.getNewLocaleSurveyId() != null && surveyGroup.getNewLocaleSurveyId().equals(survey.getKey().getId());
     }
 

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -25,17 +25,18 @@ public class WebForm {
 
     public static Set<String> unsupportedQuestionTypes(){
         Set<String> unsupportedTypes = new HashSet<String>();
-        unsupportedTypes.add(Question.Type.CASCADE.toString());
         unsupportedTypes.add(Question.Type.GEOSHAPE.toString());
         unsupportedTypes.add(Question.Type.SIGNATURE.toString());
         unsupportedTypes.add(Question.Type.CADDISFLY.toString());
         return unsupportedTypes;
     }
 
-    public static boolean validWebForm(final List<Question> questions){
-        
+    public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions){
+        boolean hasRepeatableGroups = survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable().booleanValue()).collect(Collectors.toList()).size() > 0;
+        if (hasRepeatableGroups) return false;
+        boolean monitoring = surveyGroup.getMonitoringGroup().booleanValue();
+        if (monitoring) return false;
         List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
-
         return validQuestions.size() == questions.size();
     }
 

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -44,7 +44,7 @@ public class WebForm {
         if (!validQuestionGroups) {
             return false;
         }
-        boolean validSurveyGroup = validSurveyGroup(survey, surveyGroup);
+        boolean validSurveyGroup = validForm(survey, surveyGroup);
         if (!validSurveyGroup) {
             return false;
         }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -32,11 +32,11 @@ public class WebForm {
     }
 
     public static boolean validQuestionGroups(final Survey survey){
-        return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable().booleanValue()).collect(Collectors.toList()).size() == 0;
+        return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable()).collect(Collectors.toList()).size() == 0;
     }
 
-    public static boolean validSurveyGroup(final SurveyGroup surveyGroup){
-        return !surveyGroup.getMonitoringGroup().booleanValue();
+    public static Boolean validSurveyGroup(final SurveyGroup surveyGroup){
+        return !surveyGroup.getMonitoringGroup();
     }
 
     public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions){

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -35,15 +35,15 @@ public class WebForm {
         return survey.getQuestionGroupMap().values().stream().filter(i -> i.getRepeatable()).collect(Collectors.toList()).size() == 0;
     }
 
-    public static Boolean validSurveyGroup(final SurveyGroup surveyGroup){
-        return !surveyGroup.getMonitoringGroup();
+    public static boolean validSurveyGroup(final Survey survey, final SurveyGroup surveyGroup){
+        return surveyGroup.getNewLocaleSurveyId() != null && surveyGroup.getNewLocaleSurveyId().equals(survey.getKey().getId());
     }
 
     public static boolean validWebForm(final SurveyGroup surveyGroup, final Survey survey, final List<Question> questions){
         boolean validQuestionGroups = validQuestionGroups(survey);
-        if (!validQuestionGroups) return false;
-        boolean validSurveyGroup = validSurveyGroup(surveyGroup);
-        if (!validSurveyGroup) return false;
+        if (!validQuestionGroups) { return false; }
+        boolean validSurveyGroup = validSurveyGroup(survey, surveyGroup);
+        if (!validSurveyGroup) { return false; }
         List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
         return validQuestions.size() == questions.size();
     }

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
@@ -170,6 +170,8 @@ public class SurveyAssemblyServlet extends AbstractRestApiServlet {
         Survey form = surveyDao.loadFullForm(formId);
 
         SurveyGroupDAO surveyGroupDao = new SurveyGroupDAO();
+        QuestionDao questionDao = new QuestionDao();
+
         SurveyGroup survey = surveyGroupDao.getByKey(form.getSurveyGroupId());
         Long transactionId = randomNumber.nextLong();
 
@@ -195,6 +197,8 @@ public class SurveyAssemblyServlet extends AbstractRestApiServlet {
         if (uc.getUploadedZip1() && uc.getUploadedZip2()) {
             log.debug("Finishing assembly of " + formId);
             form.setStatus(Survey.Status.PUBLISHED);
+            boolean webForm = WebForm.validWebForm(surveyGroupDao.getByKey(form.getObjectId()), form, questionDao.listQuestionsBySurvey(form.getObjectId()));
+            form.setWebForm(webForm);
             surveyDao.save(form); //remember PUBLISHED status
             String messageText = "Published.  Please check: " + uc.getUrl();
             message.setShortMessage(messageText);

--- a/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java
@@ -197,8 +197,10 @@ public class SurveyAssemblyServlet extends AbstractRestApiServlet {
         if (uc.getUploadedZip1() && uc.getUploadedZip2()) {
             log.debug("Finishing assembly of " + formId);
             form.setStatus(Survey.Status.PUBLISHED);
-            boolean webForm = WebForm.validWebForm(surveyGroupDao.getByKey(form.getObjectId()), form, questionDao.listQuestionsBySurvey(form.getObjectId()));
-            form.setWebForm(webForm);
+            if (form.getWebForm()){
+                boolean webForm = WebForm.validWebForm(surveyGroupDao.getByKey(form.getObjectId()), form, questionDao.listQuestionsBySurvey(form.getObjectId()));
+                form.setWebForm(webForm);
+            }
             surveyDao.save(form); //remember PUBLISHED status
             String messageText = "Published.  Please check: " + uc.getUrl();
             message.setShortMessage(messageText);

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -25,7 +25,6 @@ import com.gallatinsystems.survey.domain.Question;
 import com.gallatinsystems.survey.domain.QuestionOption;
 import com.gallatinsystems.survey.domain.Survey;
 import com.gallatinsystems.survey.domain.SurveyGroup;
-import com.gallatinsystems.survey.domain.WebForm;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 
@@ -226,15 +225,6 @@ public class QuestionRestService {
         return response;
     }
 
-    // take care that question changes doens't break Survey.webform if any
-    protected void ensureWebFormSurvey(QuestionDto q){
-        Survey s = surveyDao.getById(q.getSurveyId());
-        if (s.getWebForm() && WebForm.unsupportedQuestionTypes().contains(q.getType().toString())){
-            s.setWebForm(false);
-            surveyDao.save(s);
-        }
-    }
-
     // update existing question
     // questionOptions are saved and updated on their own
     @RequestMapping(method = RequestMethod.PUT, value = "/{id}")
@@ -267,7 +257,6 @@ public class QuestionRestService {
                     });
                     if (questionDto.getType() != null) {
                         q.setType(Question.Type.valueOf(questionDto.getType().toString()));
-                        ensureWebFormSurvey(questionDto);
                     }
                     
                     q = questionDao.save(q);
@@ -304,7 +293,6 @@ public class QuestionRestService {
                 if (questionDto != null) {
                     Long keyId = questionDto.getKeyId();
                     Question q;
-                    ensureWebFormSurvey(questionDto);
 
                     // if the questionDto has a key, try to get the question.
                     if (keyId != null) {
@@ -366,7 +354,6 @@ public class QuestionRestService {
             } else {
                 q = copyQuestion(questionDto);
             }
-            ensureWebFormSurvey(questionDto);
 
             dto = QuestionDtoMapper.transform(q);
             statusDto.setStatus("ok");

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -48,9 +48,7 @@ import com.gallatinsystems.survey.dao.SurveyDAO;
 import com.gallatinsystems.survey.dao.SurveyGroupDAO;
 import com.gallatinsystems.survey.dao.SurveyUtils;
 import com.gallatinsystems.survey.domain.Question;
-import com.gallatinsystems.survey.domain.QuestionGroup;
 import com.gallatinsystems.survey.domain.Survey;
-import com.gallatinsystems.survey.domain.SurveyGroup;
 import com.gallatinsystems.survey.domain.WebForm;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
@@ -282,7 +280,6 @@ public class SurveyRestService {
                     log.log(Level.WARNING, "Survey version does not match (dashboard="
                             + requestDto.getVersion() + " datastore=" + s.getVersion() + ")");
                 }
-
                 s = surveyDao.save(s);
                 responseDto = new SurveyDto();
                 DtoMarshaller.copyToDto(s, responseDto);


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

- Remove Cascade question type as not allowed
- Validate survey (and update webform boolean column db) only on `surveys/{id}/webform_id` and [publishing survey logic](https://github.com/akvo/akvo-flow/blob/issue-3562/GAE/src/org/waterforpeople/mapping/app/web/SurveyAssemblyServlet.java#L197) (thus webform python backend only uses s3 survey published definitions)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
