### PR TITLE
[#3571] Add webform password validation support

### DIFF
--- a/Dashboard/app/js/lib/components/forms/form-share/index.jsx
+++ b/Dashboard/app/js/lib/components/forms/form-share/index.jsx
@@ -30,7 +30,7 @@ export default class WebFormShare extends React.Component {
   };
 
   render() {
-    const { valid, shareUrl } = this.props.data;
+    const { valid, shareUrl, sharePassword } = this.props.data;
     return (
       <>
         <li>
@@ -67,7 +67,7 @@ export default class WebFormShare extends React.Component {
                   {this.state.copyToClipboard && <span>Copied to clipboard</span>}
 
                   <div className="password">
-                    <span>Password: webform</span>
+                    <span>Password: {sharePassword}</span>
                   </div>
                 </>
               ) : (

--- a/Dashboard/app/js/lib/components/forms/form-share/style.scss
+++ b/Dashboard/app/js/lib/components/forms/form-share/style.scss
@@ -25,9 +25,10 @@
           font-size: 15px;
           margin-right: auto;
           background: #efefef;
-          padding: 7px 12px;
+          padding: 20px 12px;
           width: 80%;
           border-radius: 4px;
+          overflow-x: auto;
         }
 
         a {

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -798,6 +798,7 @@ FLOW.surveyControl = Ember.ArrayController.create(observe({
       url,
       success: (data) =>{
         this.set('webformId', data.webformId);
+        this.set('password', data.password);
       },
       error: function(xhr) {
         console.error(xhr)

--- a/Dashboard/app/js/lib/views/surveys/form-share.jsx
+++ b/Dashboard/app/js/lib/views/surveys/form-share.jsx
@@ -12,6 +12,7 @@ FLOW.WebFormShareView = FLOW.ReactComponentView.extend(
     'FLOW.questionControl.content.isLoaded': 'formValidation',
     'FLOW.questionGroupControl.content.isLoaded': 'formValidation',
     'FLOW.surveyControl.webformId': 'renderReactSide',
+    'FLOW.surveyControl.password': 'renderReactSide',
   }),
   {
     init() {
@@ -41,6 +42,7 @@ FLOW.WebFormShareView = FLOW.ReactComponentView.extend(
         strings: {},
         data: {
           valid: this.valid,
+          sharePassword: FLOW.surveyControl.password,
           shareUrl:
             FLOW.surveyControl.webformId &&
             `${window.location.origin}/webforms/${FLOW.surveyControl.webformId}`,

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -59,13 +59,15 @@ public class WebForm {
 	public static String encryptId(Long surveyId, String seed, String pw) {
 		return OneTimePadCypher.encrypt(seed, surveyId.toString()+"$"+pw);
 	}
-	public static String decryptId(String webFormId, String seed, String pw) {
+	public static String decryptId(String webFormId, String seed) {
+        return OneTimePadCypher.decrypt(seed, webFormId);
+    }
+    public static String authId(String webFormId, String seed, String pw) {
         String decrypted = OneTimePadCypher.decrypt(seed, webFormId);
         String[] res = decrypted.split("\\$");
         if (res.length == 2 && res[1].equals(pw)) {
             return res[0];
         }
-		return null;
-	}
-
+        return null;
+    }
 }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.akvo.flow.util.OneTimePadCypher;
+
 public class WebForm {
 
     public static Set<String> unsupportedQuestionTypes() {
@@ -53,5 +55,17 @@ public class WebForm {
         List<Question> validQuestions = questions.stream().filter(i -> !unsupportedQuestionTypes().contains(i.getType().toString())).collect(Collectors.toList());
         return validQuestions.size() == questions.size();
     }
+
+	public static String encryptId(Long surveyId, String seed, String pw) {
+		return OneTimePadCypher.encrypt(seed, surveyId.toString()+"$"+pw);
+	}
+	public static String decryptId(String webFormId, String seed, String pw) {
+        String decrypted = OneTimePadCypher.decrypt(seed, webFormId);
+        String[] res = decrypted.split("\\$");
+        if (res.length == 2 && res[1].equals(pw)) {
+            return res[0];
+        }
+		return null;
+	}
 
 }

--- a/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebForm.java
@@ -56,16 +56,16 @@ public class WebForm {
         return validQuestions.size() == questions.size();
     }
 
-	public static String encryptId(Long surveyId, String seed, String pw) {
-		return OneTimePadCypher.encrypt(seed, surveyId.toString()+"$"+pw);
+	public static String encryptId(Long surveyId, String seed, String pw, Double version) {
+		return OneTimePadCypher.encrypt(seed, surveyId.toString()+"$$$"+pw+"$$$"+version);
 	}
 	public static String decryptId(String webFormId, String seed) {
         return OneTimePadCypher.decrypt(seed, webFormId);
     }
     public static String authId(String webFormId, String seed, String pw) {
         String decrypted = OneTimePadCypher.decrypt(seed, webFormId);
-        String[] res = decrypted.split("\\$");
-        if (res.length == 2 && res[1].equals(pw)) {
+        String[] res = decrypted.split("\\$\\$\\$");
+        if (res.length == 3 && res[1].equals(pw)) {
             return res[0];
         }
         return null;

--- a/GAE/src/com/gallatinsystems/survey/domain/WebFormAuthPayload.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/WebFormAuthPayload.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package com.gallatinsystems.survey.domain;
+
+import java.io.Serializable;
+
+public class WebFormAuthPayload implements Serializable {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 7303464504301045462L;
+    
+    String password;
+    String webFormId;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getWebFormId() {
+        return webFormId;
+    }
+
+    public void setWebFormId(String webFormId) {
+        this.webFormId = webFormId;
+    }
+
+}

--- a/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
+++ b/GAE/src/com/gallatinsystems/surveyal/domain/SurveyedLocale.java
@@ -231,9 +231,7 @@ public class SurveyedLocale extends BaseDomain {
     }
 
     /**
-     * Creates a base32 version of a UUID. In the output, it replaces the following letters: l, o, i
-     * are replace by w, x, y, to avoid confusion with 1 and 0 we don't use the z as it can easily
-     * be confused with 2, especially in handwriting. If we can't form the base32 version, we return
+     * Creates a stripped version of base32 version of a UUID. If we can't form the base32 version, we return
      * an empty string. The same code is used in the FLOW Mobile app:
      * https://github.com/akvo/akvo-flow-mobile/blob/feature/pointupdates/survey/
      * src/com/gallatinsystems/survey/device/util/Base32.java The resulting identifier is a string
@@ -244,21 +242,35 @@ public class SurveyedLocale extends BaseDomain {
     public static String generateBase32Uuid() {
         final String uuid = UUID.randomUUID().toString();
         String strippedUUID = (uuid.substring(0, 13) + uuid.substring(24, 27)).replace("-", "");
-        String result = null;
         try {
             Long id = Long.parseLong(strippedUUID, 16);
-            result = Long.toString(id, 32).replace("l", "w").replace("o", "x").replace("i", "y");
-            while (result.length() < 12) { //un-suppress leading zeroes; we must have 12 characters
-                result = "0" + result;
-            }
+            return readableUuid(id);
+
         } catch (NumberFormatException e) {
             // if we can't create the base32 UUID string, return the original uuid.
-            result = uuid;
+            return uuid;
+        }
+    }
+
+    /**
+     * In the output, it replaces the following letters: l, o, i
+     * are replace by w, x, y, to avoid confusion with 1 and 0 we don't use the z as it can easily
+     * be confused with 2, especially in handwriting
+     *
+     * @param uuid
+     * @return
+     */
+    public static String readableUuid(Long uuid) {
+        String result = null;
+        result = Long.toString(uuid, 32).replace("l", "w").replace("o", "x").replace("i", "y");
+        while (result.length() < 12) { //un-suppress leading zeroes; we must have 12 characters
+            result = "0" + result;
         }
 
         // insert dashes for readability
         return String.format("%s-%s-%s", result.substring(0, 4), result.substring(4, 8),
                 result.substring(8));
+
     }
 
     /**

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.akvo.flow.util.OneTimePadCypher;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,6 +49,7 @@ import com.gallatinsystems.survey.dao.SurveyUtils;
 import com.gallatinsystems.survey.domain.Question;
 import com.gallatinsystems.survey.domain.Survey;
 import com.gallatinsystems.survey.domain.WebForm;
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 
@@ -160,13 +160,13 @@ public class SurveyRestService {
         if(validWebForm){
             survey.setWebForm(validWebForm);
             surveyDao.save(survey);
-            response.put("webformId", OneTimePadCypher.encrypt(PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP),
-                    id.toString()));
+            String pw = SurveyedLocale.generateBase32Uuid();
+            response.put("webformId", WebForm.encryptId(id, PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP), pw));
+            response.put("password", pw);
         } else {
             throw new SurveyNotValidAsWebformException(
                 "Webforms don't support monitoring surveys, or repeatable question groups or the following question types: geoshape, signature or caddisfly");
         }
-
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -49,6 +49,7 @@ import com.gallatinsystems.survey.dao.SurveyUtils;
 import com.gallatinsystems.survey.domain.Question;
 import com.gallatinsystems.survey.domain.Survey;
 import com.gallatinsystems.survey.domain.WebForm;
+import com.gallatinsystems.survey.domain.WebFormAuthPayload;
 import com.gallatinsystems.surveyal.domain.SurveyedLocale;
 import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
@@ -167,6 +168,23 @@ public class SurveyRestService {
             throw new SurveyNotValidAsWebformException(
                 "Webforms don't support monitoring surveys, or repeatable question groups or the following question types: geoshape, signature or caddisfly");
         }
+        return response;
+    }
+
+    @RequestMapping(method = RequestMethod.POST, value = "/webform/auth")
+    @ResponseBody
+    public Map<String, Object> authWebFormId(@RequestBody WebFormAuthPayload payLoad) {
+        final String password = payLoad.getPassword();
+        final String webFormId = payLoad.getWebFormId();
+        final Map<String, Object> response = new HashMap<String, Object>();
+
+        // if the POST data contains a pw and id continue. Otherwise,
+        // server will respond with 400 Bad Request
+        if (password == null || webFormId == null) {
+            return getErrorResponse();
+        }
+
+        response.put("valid", WebForm.authId(webFormId, PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP), password));
         return response;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -161,8 +161,8 @@ public class SurveyRestService {
         if(validWebForm){
             survey.setWebForm(validWebForm);
             surveyDao.save(survey);
-            String pw = SurveyedLocale.generateBase32Uuid();
-            response.put("webformId", WebForm.encryptId(id, PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP), pw));
+            String pw = SurveyedLocale.readableUuid(survey.getCreatedDateTime().getTime());
+            response.put("webformId", WebForm.encryptId(id, PropertyUtil.getProperty(RestAuthFilter.REST_PRIVATE_KEY_PROP), pw, survey.getVersion()));
             response.put("password", pw);
         } else {
             throw new SurveyNotValidAsWebformException(

--- a/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
+++ b/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
@@ -18,13 +18,17 @@ package com.gallatinsystems.survey.domain;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Date;
+
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
+
 public class WebFormTest {
     
     final String secretKey = "very-secret-key";
     final String valueToEncrypt = "text";
     final Long surveyId = new Long(12345);
-    final String pw = "9pyf-9a0k-htxq";
-    final String webFormId = "R1dBTRhXXBMLA1kUClUSWw0GAVw";
+    final String pw = SurveyedLocale.readableUuid(new Date(1590477935471L).getTime());
+    final String webFormId = "R1dBTRhXVVNCVFlIUlINWxAZC0s";
     @Test
     void encryptSurveyId() {
         assertEquals(webFormId, WebForm.encryptId(surveyId, secretKey, pw)); 

--- a/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
+++ b/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
@@ -28,15 +28,16 @@ public class WebFormTest {
     final String valueToEncrypt = "text";
     final Long surveyId = new Long(12345);
     final String pw = SurveyedLocale.readableUuid(new Date(1590477935471L).getTime());
-    final String webFormId = "R1dBTRhXVVNCVFlIUlINWxAZC0s";
+    final String webFormId = "R1dBTRhXQUdCVUQcRgBAQRFfDEYBA0dWQUUDWw";
+    final Double version = new Double(1);
     @Test
     void encryptSurveyId() {
-        assertEquals(webFormId, WebForm.encryptId(surveyId, secretKey, pw)); 
+        assertEquals(webFormId, WebForm.encryptId(surveyId, secretKey, pw, version));
     }
     
     @Test
     void decryptSurveyId() {
-       assertEquals(surveyId+"$"+pw, WebForm.decryptId(webFormId, secretKey));
+       assertEquals(surveyId+"$$$"+pw+"$$$"+version, WebForm.decryptId(webFormId, secretKey));
     }
 
     @Test

--- a/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
+++ b/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package com.gallatinsystems.survey.domain;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.gallatinsystems.surveyal.domain.SurveyedLocale;
+import com.google.apphosting.utils.config.ApplicationXml.Modules.Web;
+
+public class WebFormTest {
+    
+    final String secretKey = "very-secret-key";
+    final String valueToEncrypt = "text";
+    final Long surveyId = new Long(12345);
+    final String pw = "9pyf-9a0k-htxq";
+    final String webFormId = "R1dBTRhXXBMLA1kUClUSWw0GAVw";
+    @Test
+    void encryptSurveyId() {
+        assertEquals(webFormId, WebForm.encryptId(surveyId, secretKey, pw)); 
+    }
+    
+    @Test
+    void decryptSurveyId() {
+       assertEquals("12345", WebForm.decryptId(webFormId, secretKey, pw)); 
+    }
+}

--- a/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
+++ b/GAE/test/com/gallatinsystems/survey/domain/WebFormTest.java
@@ -18,9 +18,6 @@ package com.gallatinsystems.survey.domain;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.gallatinsystems.surveyal.domain.SurveyedLocale;
-import com.google.apphosting.utils.config.ApplicationXml.Modules.Web;
-
 public class WebFormTest {
     
     final String secretKey = "very-secret-key";
@@ -35,6 +32,12 @@ public class WebFormTest {
     
     @Test
     void decryptSurveyId() {
-       assertEquals("12345", WebForm.decryptId(webFormId, secretKey, pw)); 
+       assertEquals(surveyId+"$"+pw, WebForm.decryptId(webFormId, secretKey));
     }
+
+    @Test
+    void authId() {
+       assertEquals("12345", WebForm.authId(webFormId, secretKey, pw));
+    }
+
 }


### PR DESCRIPTION
#### Changes
Relates #3562 

- Add webform password as part of webformId (encrypted) value
- Uses SurveyedLocale.generateBase32uuid logic as webform password
- Set new entrypoint `rest/surveys/webform/auth` to validate webFormId having a `webFormId` and a `password`
#### The solution

#### Screenshots (if appropriate)
<img width="764" alt="Screenshot 2020-05-25 at 16 26 59" src="https://user-images.githubusercontent.com/731829/82821557-a0ee0500-9ea4-11ea-8ade-be05ad41f385.png">

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
