### PR TITLE
[#3593] Fix tooltip text

### DIFF
--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -84,6 +84,8 @@ FLOW.TooltipQuestionMark = Ember.View.extend({
 
   classNames: ['helpIcon','tooltip'],
 
+  attributeBindings: ['tooltipText:data-title'],
+
   tooltipText: null,
 
   eventManager: Ember.Object.create({
@@ -91,10 +93,9 @@ FLOW.TooltipQuestionMark = Ember.View.extend({
 
     yOffset: 20,
 
-    text: null,
-
     mouseEnter: function (e) {
-      $("body").append("<p id='tooltip'>" + this.get('text') + "</p>");
+      let tooltipText = $(e.target).attr("data-title");
+      $("body").append("<p id='tooltip'>" + tooltipText + "</p>");
       $("#tooltip")
         .css("top", (e.pageY - this.get('xOffset')) + "px")
         .css("left", (e.pageX + this.get('yOffset')) + "px")
@@ -111,10 +112,6 @@ FLOW.TooltipQuestionMark = Ember.View.extend({
         .css("left", (e.pageX + this.get('yOffset')) + "px")
     },
   }),
-
-  didInsertElement() {
-    this.eventManager.set('text', this.get('tooltipText'));
-  },
 });
 
 FLOW.TooltipText = FLOW.TooltipQuestionMark.extend({
@@ -128,10 +125,8 @@ FLOW.TooltipText = FLOW.TooltipQuestionMark.extend({
 
     // this class causes the button to be styled in unwanted way
     this.get('classNames').removeObject('helpIcon');
-  },
 
-  didInsertElement() {
-    this.eventManager.set('text', Ember.String.loc(this.get('i18nTooltipKey')));
+    this.set('tooltipText', Ember.String.loc(this.get('i18nTooltipKey')));
   },
 });
 

--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -50,7 +50,8 @@
                 <li><a class="addSurvey noChanges">{{t _create_new_survey}}</a></li>
               {{else}}
                 {{#if view.disableAddSurveyButtonInRoot}}
-                <!--  {{t _survey_only_in_folder}} -->
+                <!--  Needed in the comment in order for translation parser to identify translation key
+                      {{t _survey_only_in_folder}} -->
                   <li>{{#view FLOW.TooltipText i18nTooltipKey="_survey_only_in_folder"}}{{t _create_new_survey}}{{/view}}</li>
                 {{else}}
                   <li><a class="addSurvey" {{action "createProject" target="FLOW.projectControl"}}>{{t _create_new_survey}}</a></li>

--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -50,7 +50,7 @@
                 <li><a class="addSurvey noChanges">{{t _create_new_survey}}</a></li>
               {{else}}
                 {{#if view.disableAddSurveyButtonInRoot}}
-                {{!--  {{t _survey_only_in_folder}} --}}
+                <!--  {{t _survey_only_in_folder}} -->
                   <li>{{#view FLOW.TooltipText i18nTooltipKey="_survey_only_in_folder"}}{{t _create_new_survey}}{{/view}}</li>
                 {{else}}
                   <li><a class="addSurvey" {{action "createProject" target="FLOW.projectControl"}}>{{t _create_new_survey}}</a></li>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

* The `eventManager` is a shared instance therefore the tooltip text was being overwritten. i.e. all tooltips contained text of the last tooltip loaded on a page. 

#### The solution

* Save tooltip text in a new attribute and retrieve it on `mouseover` a tooltip element
* Replace handlebars comment with HTML comment to fix wrong rendering


#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
