### PR TITLE
[#3608] Download datapoints

### DIFF
--- a/GAE/pom.xml
+++ b/GAE/pom.xml
@@ -434,6 +434,9 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.1</version>
+        <configuration>
+            <trimStackTrace>true</trimStackTrace>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
+++ b/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
@@ -317,6 +317,11 @@ public class SurveyedLocaleDao extends BaseDAO<SurveyedLocale> {
     @SuppressWarnings("unchecked")
     public List<SurveyedLocale> listLocalesBySurveyGroupAndDate(Long surveyGroupId,
             Date lastUpdateTime, Integer pageSize) {
+        return listLocalesBySurveyGroupAndDate(surveyGroupId, lastUpdateTime, null, pageSize);
+    }
+
+    public List<SurveyedLocale> listLocalesBySurveyGroupAndDate(Long surveyGroupId,
+                                                                Date lastUpdateTime, String cursor, Integer pageSize) {
         PersistenceManager pm = PersistenceFilter.getManager();
         javax.jdo.Query query = pm.newQuery(SurveyedLocale.class);
         Map<String, Object> paramMap = new HashMap<String, Object>();
@@ -332,7 +337,7 @@ public class SurveyedLocaleDao extends BaseDAO<SurveyedLocale> {
         query.setFilter(filterString.toString());
         query.declareParameters(paramString.toString());
         query.declareImports("import java.util.Date");
-        query.setRange(0, pageSize);
+        prepareCursor(cursor, pageSize, query);
 
         return (List<SurveyedLocale>) query.executeWithMap(paramMap);
     }

--- a/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
+++ b/GAE/src/com/gallatinsystems/surveyal/dao/SurveyedLocaleDao.java
@@ -315,13 +315,13 @@ public class SurveyedLocaleDao extends BaseDAO<SurveyedLocale> {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public List<SurveyedLocale> listLocalesBySurveyGroupAndDate(Long surveyGroupId,
-            Date lastUpdateTime, Integer pageSize) {
-        return listLocalesBySurveyGroupAndDate(surveyGroupId, lastUpdateTime, null, pageSize);
+    public List<SurveyedLocale> listLocalesBySurveyGroupAndUpdateDate(Long surveyGroupId,
+                                                                      Date lastUpdateTime, Integer pageSize) {
+        return listLocalesBySurveyGroupAndUpdateDate(surveyGroupId, lastUpdateTime, null, pageSize);
     }
 
-    public List<SurveyedLocale> listLocalesBySurveyGroupAndDate(Long surveyGroupId,
-                                                                Date lastUpdateTime, String cursor, Integer pageSize) {
+    public List<SurveyedLocale> listLocalesBySurveyGroupAndUpdateDate(Long surveyGroupId,
+                                                                      Date lastUpdateTime, String cursor, Integer pageSize) {
         PersistenceManager pm = PersistenceFilter.getManager();
         javax.jdo.Query query = pm.newQuery(SurveyedLocale.class);
         Map<String, Object> paramMap = new HashMap<String, Object>();

--- a/GAE/src/org/akvo/flow/api/app/DataPointRequest.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointRequest.java
@@ -30,13 +30,10 @@ public class DataPointRequest extends RestRequest {
     private static final String SURVEY_ID_PARAM = "surveyId";
     private static final String ANDROID_ID_PARAM = "androidId";
     private static final String DEVICE_ID_PARAM = "deviceId";
-    private static final String LAST_UPDATE_TIME_PARAM = "lastUpdateTime";
 
     private Long surveyId;
     private String androidId;
     private String deviceId;
-
-    private Date lastUpdateTime;
 
     @Override
     protected void populateErrors() {
@@ -52,17 +49,6 @@ public class DataPointRequest extends RestRequest {
         surveyId = Long.parseLong(req.getParameter(SURVEY_ID_PARAM));
         androidId = req.getParameter(ANDROID_ID_PARAM);
         deviceId = req.getParameter(DEVICE_ID_PARAM);
-
-        if (req.getParameter(LAST_UPDATE_TIME_PARAM) != null) {
-            try {
-                Long ts = Long.parseLong(req.getParameter(LAST_UPDATE_TIME_PARAM));
-                lastUpdateTime = new Date(ts);
-            } catch (Exception e) {
-                addError(new RestError(RestError.BAD_DATATYPE_CODE,
-                        RestError.BAD_DATATYPE_MESSAGE, LAST_UPDATE_TIME_PARAM
-                        + " not a valid timestamp"));
-            }
-        }
     }
 
     public Long getSurveyId() {
@@ -88,8 +74,4 @@ public class DataPointRequest extends RestRequest {
     public void setDeviceId(String deviceId) {
         this.deviceId = deviceId;
     }
-
-    public Date getLastUpdateTime() { return lastUpdateTime; }
-
-    public void setLastUpdateTime(Date lastUpdateTime) { this.lastUpdateTime = lastUpdateTime; }
 }

--- a/GAE/src/org/akvo/flow/api/app/DataPointRequest.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointRequest.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.gallatinsystems.framework.rest.RestError;
 import com.gallatinsystems.framework.rest.RestRequest;
+import java.util.Date;
 
 /**
  * data structure for transferring data points
@@ -29,10 +30,13 @@ public class DataPointRequest extends RestRequest {
     private static final String SURVEY_ID_PARAM = "surveyId";
     private static final String ANDROID_ID_PARAM = "androidId";
     private static final String DEVICE_ID_PARAM = "deviceId";
+    private static final String LAST_UPDATE_TIME_PARAM = "lastUpdateTime";
 
     private Long surveyId;
     private String androidId;
     private String deviceId;
+
+    private Date lastUpdateTime;
 
     @Override
     protected void populateErrors() {
@@ -48,6 +52,17 @@ public class DataPointRequest extends RestRequest {
         surveyId = Long.parseLong(req.getParameter(SURVEY_ID_PARAM));
         androidId = req.getParameter(ANDROID_ID_PARAM);
         deviceId = req.getParameter(DEVICE_ID_PARAM);
+
+        if (req.getParameter(LAST_UPDATE_TIME_PARAM) != null) {
+            try {
+                Long ts = Long.parseLong(req.getParameter(LAST_UPDATE_TIME_PARAM));
+                lastUpdateTime = new Date(ts);
+            } catch (Exception e) {
+                addError(new RestError(RestError.BAD_DATATYPE_CODE,
+                        RestError.BAD_DATATYPE_MESSAGE, LAST_UPDATE_TIME_PARAM
+                        + " not a valid timestamp"));
+            }
+        }
     }
 
     public Long getSurveyId() {
@@ -74,4 +89,7 @@ public class DataPointRequest extends RestRequest {
         this.deviceId = deviceId;
     }
 
+    public Date getLastUpdateTime() { return lastUpdateTime; }
+
+    public void setLastUpdateTime(Date lastUpdateTime) { this.lastUpdateTime = lastUpdateTime; }
 }

--- a/GAE/src/org/akvo/flow/api/app/DataPointResponse.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointResponse.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2019,2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -29,6 +29,16 @@ import com.gallatinsystems.framework.rest.RestResponse;
 public class DataPointResponse extends RestResponse {
     private static final long serialVersionUID = 1L;
     private List<SurveyedLocaleDto> dataPointData;
+
+    private String cursor;
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(String cursor) {
+        this.cursor = cursor;
+    }
 
     public List<SurveyedLocaleDto> getDataPointData() {
         return dataPointData;

--- a/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
@@ -18,6 +18,7 @@ package org.akvo.flow.api.app;
 
 import com.gallatinsystems.device.dao.DeviceDAO;
 import com.gallatinsystems.device.domain.Device;
+import com.gallatinsystems.framework.dao.BaseDAO;
 import com.gallatinsystems.framework.rest.AbstractRestApiServlet;
 import com.gallatinsystems.framework.rest.RestRequest;
 import com.gallatinsystems.framework.rest.RestResponse;
@@ -77,7 +78,7 @@ public class DataPointServlet extends AbstractRestApiServlet {
     @Override
     protected RestResponse handleRequest(RestRequest req) throws Exception {
         DataPointRequest dpReq = (DataPointRequest) req;
-        RestResponse res = new RestResponse();
+        DataPointResponse res = new DataPointResponse();
         if (dpReq.getSurveyId() == null) {
             res.setCode(String.valueOf(HttpServletResponse.SC_FORBIDDEN));
             res.setMessage("Invalid Survey");
@@ -99,10 +100,12 @@ public class DataPointServlet extends AbstractRestApiServlet {
 
         if (dpList.isEmpty()) {
             res.setCode(String.valueOf(HttpServletResponse.SC_NOT_FOUND));
-            res.setMessage("No assignment was found");
+            res.setMessage("No datapoint assignment was found");
             return res;
         }
         res = convertToResponse(dpList, dpReq.getSurveyId());
+        res.setCursor(BaseDAO.getCursor(dpList));
+
         return res;
 
     }

--- a/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
@@ -37,7 +37,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -96,7 +95,7 @@ public class DataPointServlet extends AbstractRestApiServlet {
         log.fine("Found device: " + device);
 
 
-        final List<SurveyedLocale> dpList = getDataPointList(dpReq.getSurveyId(), device.getKey().getId(), dpReq.getLastUpdateTime(), dpReq.getCursor());
+        final List<SurveyedLocale> dpList = getDataPointList(dpReq.getSurveyId(), device.getKey().getId(), dpReq.getCursor());
 
         if (dpList.isEmpty()) {
             res.setCode(String.valueOf(HttpServletResponse.SC_NOT_FOUND));
@@ -108,14 +107,14 @@ public class DataPointServlet extends AbstractRestApiServlet {
 
     }
 
-    public List<SurveyedLocale> getDataPointList(Long surveyId, Long deviceId, Date lastUpdateTime, String cursor) {
+    public List<SurveyedLocale> getDataPointList(Long surveyId, Long deviceId, String cursor) {
         List<DataPointAssignment> assList =
                 dataPointAssignmentDao.listByDeviceAndSurvey(deviceId, surveyId);
 
         if (assList.isEmpty() || allDataPointsAreAssigned(assList)) {
-            return getAllDataPoints(deviceId, surveyId, lastUpdateTime, cursor);
+            return getAllDataPoints(deviceId, surveyId, cursor);
         } else {
-            return getAssignedDataPoints(assList.get(0), lastUpdateTime);
+            return getAssignedDataPoints(assList.get(0));
         }
     }
 
@@ -128,15 +127,11 @@ public class DataPointServlet extends AbstractRestApiServlet {
         return false;
     }
 
-    public List<SurveyedLocale> getDataPointList(Long surveyId, Long deviceId, Date lastUpdateTime) {
-        return getDataPointList(surveyId, deviceId, lastUpdateTime, null);
-    }
-
     public List<SurveyedLocale> getDataPointList(Long surveyId, Long deviceId) {
         return getDataPointList(surveyId, deviceId, null);
     }
 
-    private List<SurveyedLocale> getAllDataPoints(Long deviceId, Long surveyId, Date lastUpdateTime, String cursor) {
+    private List<SurveyedLocale> getAllDataPoints(Long deviceId, Long surveyId, String cursor) {
         SurveyAssignmentDao saDao = new SurveyAssignmentDao();
 
         List<SurveyAssignment> deviceSurveyAssignments = saDao.listByDeviceAndSurvey(deviceId, surveyId);
@@ -146,13 +141,13 @@ public class DataPointServlet extends AbstractRestApiServlet {
             return Collections.emptyList();
         }
 
-        return surveyedLocaleDao.listLocalesBySurveyGroupAndDate(surveyId, lastUpdateTime, cursor, LIMIT_DATAPOINTS);
+        return surveyedLocaleDao.listLocalesBySurveyGroupAndUpdateDate(surveyId, null, cursor, LIMIT_DATAPOINTS);
     }
 
     /*
      * Return only datapoints that have been explicitly assigned to a device
      */
-    private List<SurveyedLocale> getAssignedDataPoints(DataPointAssignment assignment, Date lastUpdateTime) {
+    private List<SurveyedLocale> getAssignedDataPoints(DataPointAssignment assignment) {
         Set<Long> assignedDataPointIds = new HashSet<>();
         assignedDataPointIds.addAll(assignment.getDataPointIds());
 

--- a/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointServlet.java
@@ -111,12 +111,10 @@ public class DataPointServlet extends AbstractRestApiServlet {
             // Mimic old behavior
             SurveyAssignmentDao saDao = new SurveyAssignmentDao();
 
-            List<SurveyAssignment> allAssigmentsToDevice = saDao.listAllContainingDevice(deviceId);
-            List<SurveyAssignment> filteredAssignments = allAssigmentsToDevice.stream().filter(assignment ->
-                    assignment.getSurveyId().equals(surveyId)).collect(Collectors.toList());
+            List<SurveyAssignment> deviceSurveyAssignments = saDao.listByDeviceAndSurvey(deviceId, surveyId);
 
-            if (filteredAssignments.isEmpty()) {
-                log.log(Level.SEVERE, "No assignment found for surveyId: " + surveyId + " - deviceId: " + deviceId);
+            if (deviceSurveyAssignments.isEmpty()) {
+                log.log(Level.WARNING, "No assignment found for surveyId: " + surveyId + " - deviceId: " + deviceId);
                 return null;
             }
 

--- a/GAE/src/org/akvo/flow/api/app/SurveyedLocaleServlet.java
+++ b/GAE/src/org/akvo/flow/api/app/SurveyedLocaleServlet.java
@@ -76,7 +76,7 @@ public class SurveyedLocaleServlet extends AbstractRestApiServlet {
                 Survey s = surveyDao.getById(dsjq.getSurveyID());
                 if (s != null && s.getSurveyGroupId().longValue()
                         == slReq.getSurveyGroupId().longValue()) {
-                    slList = surveyedLocaleDao.listLocalesBySurveyGroupAndDate(
+                    slList = surveyedLocaleDao.listLocalesBySurveyGroupAndUpdateDate(
                             slReq.getSurveyGroupId(), slReq.getLastUpdateTime(), SL_PAGE_SIZE);
                     return convertToResponse(slList, slReq.getSurveyGroupId());
                 }

--- a/GAE/src/org/akvo/flow/dao/SurveyAssignmentDao.java
+++ b/GAE/src/org/akvo/flow/dao/SurveyAssignmentDao.java
@@ -16,12 +16,18 @@
 
 package org.akvo.flow.dao;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.gallatinsystems.framework.servlet.PersistenceFilter;
+import org.akvo.flow.domain.persistent.DataPointAssignment;
 import org.akvo.flow.domain.persistent.SurveyAssignment;
 
 import com.gallatinsystems.framework.dao.BaseDAO;
 import com.gallatinsystems.surveyal.domain.SurveyedLocale;
+
+import javax.jdo.PersistenceManager;
 
 public class SurveyAssignmentDao extends BaseDAO<SurveyAssignment> {
 
@@ -54,9 +60,22 @@ public class SurveyAssignmentDao extends BaseDAO<SurveyAssignment> {
         return all.size();
     }
 
-    public List<SurveyAssignment> listBySurveyGroup(Long sgId) {
-        List<SurveyAssignment> sal = listByProperty("surveyGroupId", sgId, "LongString");
-        return sal;
+    public List<SurveyAssignment> listByDeviceAndSurvey(Long deviceId, Long surveyId) {
+        PersistenceManager pm = PersistenceFilter.getManager();
+        javax.jdo.Query query = pm.newQuery(SurveyAssignment.class);
+        StringBuilder filterString = new StringBuilder();
+        StringBuilder paramString = new StringBuilder();
+        Map<String, Object> paramMap = null;
+        paramMap = new HashMap<String, Object>();
+        appendNonNullParam("deviceId", filterString, paramString, "Long", deviceId, paramMap);
+        appendNonNullParam("surveyId", filterString, paramString, "Long", surveyId, paramMap);
+
+        if (filterString.length() > 0) {
+            query.setFilter(filterString.toString());
+            query.declareParameters(paramString.toString());
+        }
+
+        return (List<SurveyAssignment>) query.executeWithMap(paramMap);
     }
 
 

--- a/GAE/src/org/akvo/flow/dao/SurveyAssignmentDao.java
+++ b/GAE/src/org/akvo/flow/dao/SurveyAssignmentDao.java
@@ -67,7 +67,7 @@ public class SurveyAssignmentDao extends BaseDAO<SurveyAssignment> {
         StringBuilder paramString = new StringBuilder();
         Map<String, Object> paramMap = null;
         paramMap = new HashMap<String, Object>();
-        appendNonNullParam("deviceId", filterString, paramString, "Long", deviceId, paramMap);
+        appendNonNullParam("deviceIds", filterString, paramString, "Long", deviceId, paramMap);
         appendNonNullParam("surveyId", filterString, paramString, "Long", surveyId, paramMap);
 
         if (filterString.length() > 0) {
@@ -75,7 +75,9 @@ public class SurveyAssignmentDao extends BaseDAO<SurveyAssignment> {
             query.declareParameters(paramString.toString());
         }
 
-        return (List<SurveyAssignment>) query.executeWithMap(paramMap);
+        List<SurveyAssignment> results = (List<SurveyAssignment>) query.executeWithMap(paramMap);
+
+        return results;
     }
 
 

--- a/GAE/test/org/akvo/flow/api/app/DataPointServletTest.java
+++ b/GAE/test/org/akvo/flow/api/app/DataPointServletTest.java
@@ -242,7 +242,7 @@ public class DataPointServletTest {
         final DataPointServlet servlet = new DataPointServlet();
         final List<SurveyedLocale> firstBatchDataPoints = servlet.getDataPointList(surveyId, deviceId, null);
         String cursor = BaseDAO.getCursor(firstBatchDataPoints);
-        final List<SurveyedLocale> secondBatchDataPoints = servlet.getDataPointList(surveyId, deviceId, null, cursor);
+        final List<SurveyedLocale> secondBatchDataPoints = servlet.getDataPointList(surveyId, deviceId, cursor);
 
         assertEquals(30, firstBatchDataPoints.size());
         assertEquals(5, secondBatchDataPoints.size());


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
* Frequent timeouts while downloading datapoints from the device
* Not all datapoints downloaded

#### The solution
* Reduce the number of datapoints downloaded in a single batch to 30
* Use the `cursor` query parameter to enable selective/incremental downloading

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
