### PR TITLE
[#3608] Download datapoints with cursor

### DIFF
--- a/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
+++ b/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
@@ -157,8 +157,14 @@ public class RestAuthFilter implements Filter {
     }
 
     @Override
-    public void init(FilterConfig arg) throws ServletException {
-        String enabledFlag = PropertyUtil.getProperty(ENABLED_PROP);
+    public void init(FilterConfig filterConfig) throws ServletException {
+        String enabledFlag = null;
+        if (filterConfig.getInitParameter(ENABLED_PROP) != null) {
+            enabledFlag = filterConfig.getInitParameter(ENABLED_PROP);
+        } else {
+            enabledFlag = PropertyUtil.getProperty(ENABLED_PROP);
+        }
+
         if (enabledFlag != null) {
             try {
                 isEnabled = Boolean.parseBoolean(enabledFlag.trim());
@@ -168,7 +174,12 @@ public class RestAuthFilter implements Filter {
                 isEnabled = false;
             }
         }
-        privateKey = PropertyUtil.getProperty(REST_PRIVATE_KEY_PROP);
+
+        if (filterConfig.getInitParameter(REST_PRIVATE_KEY_PROP) != null) {
+            privateKey = filterConfig.getInitParameter(REST_PRIVATE_KEY_PROP);
+        } else {
+            privateKey = PropertyUtil.getProperty(REST_PRIVATE_KEY_PROP);
+        }
     }
 
     @Override

--- a/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
+++ b/GAE/src/com/gallatinsystems/framework/servlet/RestAuthFilter.java
@@ -17,14 +17,15 @@
 package com.gallatinsystems.framework.servlet;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TimeZone;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 import javax.servlet.Filter;
@@ -85,74 +86,66 @@ public class RestAuthFilter implements Filter {
             "unchecked", "rawtypes"
     })
     private boolean isAuthorized(ServletRequest req) throws Exception {
-
-        Map paramMap = req.getParameterMap();
-        String incomingHash = null;
-        long incomingTimestamp = 0;
-        List<String> names = new ArrayList<String>();
-        if (paramMap != null) {
-            names.addAll(paramMap.keySet());
-            Collections.sort(names);
-            StringBuilder builder = new StringBuilder();
-            for (String name : names) {
-                if (!RestRequest.HASH_PARAM.equals(name)) {
-                    if (builder.length() > 0) {
-                        builder.append("&");
-                    }
-
-                    if (RestRequest.TIMESTAMP_PARAM.equals(name)) {
-                        String timestamp = ((String[]) paramMap.get(name))[0];
-                        try {
-                            DateFormat df = new SimpleDateFormat(
-                                    "yyyy/MM/dd HH:mm:ss");
-                            df.setTimeZone(TimeZone.getTimeZone("GMT"));
-                            incomingTimestamp = df.parse(timestamp).getTime();
-                        } catch (Exception e) {
-                            log.warning("Recived rest api request with invalid timestamp");
-                            return false;
-                        }
-                    }
-                    String[] vals = ((String[]) paramMap.get(name));
-                    int count = 0;
-                    for (String v : vals) {
-                        if (count > 0) {
-                            builder.append("&");
-                        }
-                        builder.append(name).append("=").append(URLEncoder.encode(v, "UTF-8"));
-                        count++;
-                    }
-                } else {
-                    incomingHash = ((String[]) paramMap.get(name))[0];
-                    incomingHash = incomingHash.replaceAll(" ", "+");
-                }
-            }
-
-            if (incomingHash != null) {
-                String ourHash = MD5Util.generateHMAC(builder.toString(),
-                        privateKey);
-                if (ourHash == null) {
-                    // Do something but for now return false;
-                    return false;
-                }
-
-                if (ourHash.equals(incomingHash)) {
-                    return isTimestampValid(incomingTimestamp);
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        return false;
+        return validateHashParam(req) && validateTimeStamp(req);
     }
 
-    private boolean isTimestampValid(long theirTime) {
-        long time = System.currentTimeMillis();
-        if (Math.abs(time - theirTime) > MAX_TIME) {
+    public boolean validateHashParam(ServletRequest req) throws UnsupportedEncodingException {
+        if (req.getParameterMap() == null || req.getParameter(RestRequest.HASH_PARAM) == null) {
             return false;
-        } else {
-            return true;
+        }
+
+        SortedMap<Object, String[]> sortedParamMap = new TreeMap<>();
+        sortedParamMap.putAll(req.getParameterMap());
+
+        StringBuilder builder = new StringBuilder();
+        for (Object key : sortedParamMap.keySet()) {
+            String paramKey = (String) key;
+            if (RestRequest.HASH_PARAM.equals(paramKey)) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+
+            String[] vals = ((String[]) sortedParamMap.get(paramKey));
+            int count = 0;
+            for (String v : vals) {
+                if (count > 0) {
+                    builder.append("&");
+                }
+                builder.append(paramKey).append("=").append(URLEncoder.encode(v, "UTF-8"));
+                count++;
+            }
+        }
+
+        String incomingHash = ((String[]) sortedParamMap.get(RestRequest.HASH_PARAM))[0];
+        incomingHash = incomingHash.replaceAll(" ", "+");
+
+        String ourHash = MD5Util.generateHMAC(builder.toString(), privateKey);
+        if (ourHash == null) {
+            // Do something but for now return false;
+            return false;
+        }
+
+        return ourHash.equals(incomingHash);
+    }
+
+    public boolean validateTimeStamp(ServletRequest req) {
+        Map<Object, String[]> paramMap = req.getParameterMap();
+
+        if(paramMap.isEmpty() || !paramMap.containsKey(RestRequest.TIMESTAMP_PARAM)) {
+            return false;
+        }
+
+        String timestamp = ((String[]) paramMap.get(RestRequest.TIMESTAMP_PARAM))[0];
+        try {
+            DateFormat df = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+            df.setTimeZone(TimeZone.getTimeZone("GMT"));
+            long incomingTimeStamp = df.parse(timestamp).getTime();
+            return (Math.abs(System.currentTimeMillis() - incomingTimeStamp) < MAX_TIME);
+        } catch (ParseException e) {
+            log.warning("Recived rest api request with invalid timestamp");
+            return false;
         }
     }
 

--- a/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
+++ b/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
@@ -121,4 +121,16 @@ public class RestAuthFilterTests {
 
         assertTrue(restAuthFilter.validateTimeStamp(mockHttpRequest));
     }
+
+    @Test
+    void testHashGenerationWithCursor() throws ServletException, IOException {
+        mockFilterConfig.addInitParameter("enableRestSecurity", "true");
+
+        mockHttpRequest.addParameter("cursor", "ClEKHwoSbGFzdFVwZGF0ZURhdGVUaW1lEgkI-PSu5tTU6gISKmoPYWt2b2Zsb3dzYW5kYm94chcLEg5TdXJ2ZXllZExvY2FsZRiDoK1GDBgAIAA");
+        mockHttpRequest.setParameter("h", "v9ft3ERJ+qHI+9Str1HTwCvLRXs=");
+        RestAuthFilter restAuthFilter = new RestAuthFilter();
+        restAuthFilter.init(mockFilterConfig);
+
+        assertTrue(restAuthFilter.validateHashParam(mockHttpRequest));
+    }
 }

--- a/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
+++ b/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package com.gallatinsystems.framework.servlet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RestAuthFilterTests {
+    private MockHttpServletRequest mockHttpRequest;
+
+    private MockHttpServletResponse mockHttpResponse;
+
+    private MockFilterConfig mockFilterConfig;
+
+    private String testPrivateKey = "very private";
+
+    @BeforeEach
+    public void setUp() {
+        this.mockHttpRequest = new MockHttpServletRequest();
+        mockHttpRequest.setRequestURI("/datapoints");
+        mockHttpRequest.setMethod("GET");
+        mockHttpRequest.addParameter("action", "saveSurveyInstance");
+        mockHttpRequest.addParameter("collectionDate", "30-03-2017+10%3A05%3A57+CEST");
+        mockHttpRequest.addParameter("duration", "41");
+        mockHttpRequest.addParameter("questionId", "149382277%7C0%3D44.3845%257C7.5845%257C1%7Ctype%3DGEO");
+        mockHttpRequest.addParameter("questionId", "151492308%7C0%3Dhttp%253A%252F%252Fwaterforpeople.s3.amazonaws.com%252Fimages%252Fdb0756e0-b2ec-49ed-bbdb-26d4478af5c3.jpg%7Ctype%3DIMAGE");
+        mockHttpRequest.addParameter("questionId", "152332013%7C0%3Dfiunsc%7Ctype%3DVALUE");
+        mockHttpRequest.addParameter("questionId", "149292013%7C0%3D3%7Ctype%3DVALUE");
+        mockHttpRequest.addParameter("runAsTask", "1");
+        mockHttpRequest.addParameter("submitter", "tony");
+        mockHttpRequest.addParameter("surveyId", "15316201398");
+        mockHttpRequest.addParameter("surveyInstanceId", "15337202187");
+        mockHttpRequest.addParameter("ts", "2020/03/03 15:05:14");
+        mockHttpRequest.addParameter("h", "CmuehPsWW6//5Q4i8O1P5AjS/8Y=");
+
+        mockHttpResponse = new MockHttpServletResponse();
+
+        mockFilterConfig = new MockFilterConfig();
+        mockFilterConfig.addInitParameter("restPrivateKey", "very private");
+        mockFilterConfig.addInitParameter("enableRestSecurity", "true");
+    }
+
+    @Test
+    void testAuthorizationSucess() throws ServletException, IOException {
+
+        RestAuthFilter filter = new RestAuthFilter();
+        filter.init(mockFilterConfig);
+        filter.doFilter(mockHttpRequest, mockHttpResponse, new MockFilterChain());
+
+        assertEquals(null, mockHttpResponse.getErrorMessage());
+    }
+
+}

--- a/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
+++ b/GAE/test/com/gallatinsystems/framework/servlet/RestAuthFilterTests.java
@@ -27,18 +27,19 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class RestAuthFilterTests {
+
     private MockHttpServletRequest mockHttpRequest;
 
     private MockHttpServletResponse mockHttpResponse;
 
     private MockFilterConfig mockFilterConfig;
 
-    private String testPrivateKey = "very private";
-
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws ServletException {
+
         this.mockHttpRequest = new MockHttpServletRequest();
         mockHttpRequest.setRequestURI("/datapoints");
         mockHttpRequest.setMethod("GET");
@@ -60,17 +61,31 @@ public class RestAuthFilterTests {
 
         mockFilterConfig = new MockFilterConfig();
         mockFilterConfig.addInitParameter("restPrivateKey", "very private");
-        mockFilterConfig.addInitParameter("enableRestSecurity", "true");
+    }
+
+    @Test
+    void testDisableRestSecurity() throws ServletException, IOException {
+        mockFilterConfig.addInitParameter("enableRestSecurity", "false");
+
+        // even with extra param that is not included in the hash test should pass
+        mockHttpRequest.addParameter("extraParameter", "NotInHash");
+
+        RestAuthFilter restAuthFilter = new RestAuthFilter();
+        restAuthFilter.init(mockFilterConfig);
+        restAuthFilter.doFilter(mockHttpRequest, mockHttpResponse, new MockFilterChain());
+
+        assertNull(mockHttpResponse.getErrorMessage());
     }
 
     @Test
     void testAuthorizationSucess() throws ServletException, IOException {
+        mockFilterConfig.addInitParameter("enableRestSecurity", "true");
 
-        RestAuthFilter filter = new RestAuthFilter();
-        filter.init(mockFilterConfig);
-        filter.doFilter(mockHttpRequest, mockHttpResponse, new MockFilterChain());
+        RestAuthFilter restAuthFilter = new RestAuthFilter();
+        restAuthFilter.init(mockFilterConfig);
+        restAuthFilter.doFilter(mockHttpRequest, mockHttpResponse, new MockFilterChain());
 
-        assertEquals(null, mockHttpResponse.getErrorMessage());
+        assertNull(mockHttpResponse.getErrorMessage());
     }
 
 }

--- a/GAE/test/org/akvo/flow/api/app/DataPointServletTest.java
+++ b/GAE/test/org/akvo/flow/api/app/DataPointServletTest.java
@@ -263,4 +263,21 @@ public class DataPointServletTest {
 
         assertEquals(0, finalBatchDataPoints.size(), "There should not be any more datapoints to retrieve");
     }
+
+    @Test
+    void testDataPointsRetrievalWithNoDatapointsPresent() {
+        final Long surveyId = randomId();
+        final Long assignmentId = randomId();
+        final Long deviceId = randomId();
+        final List<Long> deviceIds = Arrays.asList(deviceId);
+        final List<Long> formIds = Arrays.asList(randomId());
+
+        createAssignment(surveyId, deviceIds, formIds);
+        createDataPointAssignment(assignmentId, deviceId, ALL_DATA_POINTS, surveyId);
+
+        final DataPointServlet servlet = new DataPointServlet();
+        final List<SurveyedLocale> noDataPointsRetrieved = servlet.getDataPointList(surveyId, deviceId, null);
+        assertEquals(0, noDataPointsRetrieved.size());
+        assertNull(BaseDAO.getCursor(noDataPointsRetrieved), "There should not be any cursor");
+    }
 }


### PR DESCRIPTION
#### Before
* Attempting to download datapoints with a cursor always results in a `401 Authorization failure` error.
 
#### The solution
* Rewrite the `RestAuthFilter` logic to make it more clear and add tests cases for authentication including some using cursors.
* Add rest cases for the retrieval of datapoints in various scenarios: when there are no datapoints present in the datastore, when they are larger than the batch size, when datapoints are updated, and when there are no more datapoints to retrieve from a batch.

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
