### PR TITLE
[#3629] - add pagination for datapoints

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
@@ -35,7 +35,7 @@ export default class AssignDatapoints extends React.Component {
     if (datapointAssignment) {
       datapointsData = datapointAssignment.datapoints;
       allDPAssigned = datapointAssignment.allDataPointsAssigned;
-      hasMore = datapointAssignment.hasMoreRawIds;
+      hasMore = datapointAssignment.datapoints.length < datapointAssignment.datapointIds.length;
     }
 
     return {

--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
@@ -30,16 +30,19 @@ export default class AssignDatapoints extends React.Component {
 
     let datapointsData = [];
     let allDPAssigned = false;
+    let hasMore = false;
 
     if (datapointAssignment) {
       datapointsData = datapointAssignment.datapoints;
       allDPAssigned = datapointAssignment.allDataPointsAssigned;
+      hasMore = datapointAssignment.hasMoreRawIds;
     }
 
     return {
       deviceData,
       datapointsData,
       allDPAssigned,
+      hasMore,
     };
   };
 
@@ -99,7 +102,8 @@ export default class AssignDatapoints extends React.Component {
   };
 
   render() {
-    const { deviceData, datapointsData, allDPAssigned } = this.getAssignmentData();
+    const { loadMoreDatapoints } = this.context.actions;
+    const { deviceData, datapointsData, allDPAssigned, hasMore } = this.getAssignmentData();
 
     const assignedDataPointIds = datapointsData.reduce((acc, current) => {
       acc[current.id] = true;
@@ -116,6 +120,16 @@ export default class AssignDatapoints extends React.Component {
               <AllDatapoints deviceId={deviceData.id} />
             ) : (
               <DatapointList datapointsData={datapointsData} />
+            )}
+
+            {!allDPAssigned && hasMore && (
+              <button
+                onClick={() => loadMoreDatapoints(deviceData.id)}
+                className="btnOutline"
+                type="button"
+              >
+                Load more
+              </button>
             )}
           </div>
         </div>

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -44,6 +44,8 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
       // datapoints methods
       this.saveDatapoints = this.saveDatapoints.bind(this);
       this.getDeviceDatapoints = this.getDeviceDatapoints.bind(this);
+      this.getDatapointsDetails = this.getDatapointsDetails.bind(this);
+      this.loadMoreDatapoints = this.loadMoreDatapoints.bind(this);
       this.detectDatapointsLoaded = this.detectDatapointsLoaded.bind(this);
       this.findDatapoints = this.findDatapoints.bind(this);
       this.detectSearchedDatapointLoaded = this.detectSearchedDatapointLoaded.bind(this);
@@ -155,6 +157,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
 
         // datapoints actions
         findDatapoints: this.findDatapoints,
+        loadMoreDatapoints: this.loadMoreDatapoints,
         clearSearchedDatapoints: this.clearSearchedDatapoints,
         getDeviceDatapoints: this.getDeviceDatapoints,
         removeDatapointsFromAssignments: this.removeDatapointsFromAssignments,
@@ -591,7 +594,12 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         const datapointAssignment = this.map(item => ({
           id: item.get('keyId'),
           deviceId: item.get('deviceId'),
-          datapoints: item.get('dataPointIds'),
+          datapointIds: item.get('dataPointIds'),
+          datapoints: [],
+
+          // pagination details
+          hasMoreRawIds: false,
+          currentDatapointsIdsChunk: 0,
         }))[0];
 
         if (!datapointAssignment) {
@@ -599,7 +607,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         }
 
         // check if all datapoints has been assigned
-        if (datapointAssignment.datapoints[0] === 0) {
+        if (datapointAssignment.datapointIds[0] === 0) {
           // return early and check that all datapoints is set
           const completeDatapointAssignment = {
             ...datapointAssignment,
@@ -613,22 +621,66 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
           return;
         }
 
-        // get all datapoints for this assignment
-        FLOW.SurveyedLocale.find({ ids: datapointAssignment.datapoints }).on('didLoad', function() {
+        // get first chunk of datapoints details for this assignment
+        that.getDatapointsDetails(datapointAssignment, (datapoints, hasMoreRawIds) => {
           // combine data and add to datapoint assignments
           const completeDatapointAssignment = {
             ...datapointAssignment,
-            datapoints: this.map(dp => ({
-              name: dp.get('displayName'),
-              identifier: dp.get('identifier'),
-              id: dp.get('keyId'),
-            })),
+            hasMoreRawIds,
+            currentDatapointsIdsChunk: datapointAssignment.currentDatapointsIdsChunk + 1,
+            datapoints,
           };
 
           // add to assignment
           that.datapointAssignments.push(completeDatapointAssignment);
           that.renderReactSide();
         });
+      });
+    },
+
+    getDatapointsDetails(datapointAssignment, cb) {
+      const steps = 30;
+      const currentDatapointAssignmentsIds = datapointAssignment.datapointIds.slice(
+        datapointAssignment.currentDatapointsIdsChunk,
+        (datapointAssignment.currentDatapointsIdsChunk + 1) * steps
+      );
+
+      const hasMore =
+        (datapointAssignment.currentDatapointsIdsChunk + 1) * steps <
+        datapointAssignment.datapointIds.length;
+
+      // get this chunk datapoints
+      FLOW.SurveyedLocale.find({ ids: currentDatapointAssignmentsIds }).on('didLoad', function() {
+        cb(
+          this.map(dp => ({
+            name: dp.get('displayName'),
+            identifier: dp.get('identifier'),
+            id: dp.get('keyId'),
+          })),
+          hasMore
+        );
+      });
+    },
+
+    loadMoreDatapoints(deviceId) {
+      const datapointAssignment = this.datapointAssignments.find(sDp => sDp.deviceId === deviceId);
+      const datapointAssignmentIdx = this.datapointAssignments.findIndex(
+        sDp => sDp.deviceId === deviceId
+      );
+      if (!datapointAssignment) return null;
+
+      return this.getDatapointsDetails(datapointAssignment, (datapoints, hasMoreRawIds) => {
+        // combine data and add to datapoint assignments
+        const completeDatapointAssignment = {
+          ...datapointAssignment,
+          hasMoreRawIds,
+          currentDatapointsIdsChunk: datapointAssignment.currentDatapointsIdsChunk + 1,
+          datapoints: datapointAssignment.datapoints.concat(datapoints),
+        };
+
+        // update assignment
+        this.datapointAssignments[datapointAssignmentIdx] = completeDatapointAssignment;
+        this.renderReactSide();
       });
     },
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When loading datapoints more than 710 data points, there's a 413 error (request query too large)

#### The solution
Add pagination, so the user only fetch 30 at a time

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
