### PR TITLE
[#3629] - fix regression with load more functionality in datapoints

### DIFF
--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/AssignDatapoints/index.jsx
@@ -35,7 +35,7 @@ export default class AssignDatapoints extends React.Component {
     if (datapointAssignment) {
       datapointsData = datapointAssignment.datapoints;
       allDPAssigned = datapointAssignment.allDataPointsAssigned;
-      hasMore = datapointAssignment.datapoints.length < datapointAssignment.datapointIds.length;
+      hasMore = datapointsData.filter(dp => !!dp.id).length < datapointAssignment.datapoints.length;
     }
 
     return {
@@ -103,7 +103,12 @@ export default class AssignDatapoints extends React.Component {
 
   render() {
     const { loadMoreDatapoints } = this.context.actions;
-    const { deviceData, datapointsData, allDPAssigned, hasMore } = this.getAssignmentData();
+    const { deviceData, datapointsData, allDPAssigned } = this.getAssignmentData();
+    const dataPointsWithDetails = datapointsData.filter(dp => !!dp.id);
+    const showLoadMore =
+      !allDPAssigned &&
+      dataPointsWithDetails.length &&
+      dataPointsWithDetails.length < datapointsData.length;
 
     const assignedDataPointIds = datapointsData.reduce((acc, current) => {
       acc[current.id] = true;
@@ -119,10 +124,10 @@ export default class AssignDatapoints extends React.Component {
             {allDPAssigned ? (
               <AllDatapoints deviceId={deviceData.id} />
             ) : (
-              <DatapointList datapointsData={datapointsData} />
+              <DatapointList datapointsData={dataPointsWithDetails} />
             )}
 
-            {!allDPAssigned && hasMore && (
+            {!!showLoadMore && (
               <button
                 onClick={() => loadMoreDatapoints(deviceData.id)}
                 className="btnOutline"

--- a/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/EditDatapoints.jsx
+++ b/Dashboard/app/js/lib/components/devices/AssignmentsEditView/screens/EditDatapoints.jsx
@@ -33,7 +33,7 @@ export default class EditDatapoints extends React.Component {
     let datapointsData = [];
 
     if (selectedDatapointAssignment) {
-      datapointsData = selectedDatapointAssignment.datapoints;
+      datapointsData = selectedDatapointAssignment.datapoints.filter(dp => !!dp.id);
     }
 
     return {

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -594,8 +594,8 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         const datapointAssignment = this.map(item => ({
           id: item.get('keyId'),
           deviceId: item.get('deviceId'),
-          datapointIds: item.get('dataPointIds'),
-          datapoints: [],
+          // datapointIds: item.get('dataPointIds'),
+          datapoints: item.get('dataPointIds'),
         }))[0];
 
         if (!datapointAssignment) {
@@ -603,7 +603,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         }
 
         // check if all datapoints has been assigned
-        if (datapointAssignment.datapointIds[0] === 0) {
+        if (datapointAssignment.datapoints[0] === 0) {
           // return early and check that all datapoints is set
           const completeDatapointAssignment = {
             ...datapointAssignment,
@@ -635,20 +635,28 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
     getDatapointsDetails(datapointAssignment, callback) {
       const steps = 30;
 
-      const currentDatapointAssignmentsIds = datapointAssignment.datapointIds.slice(
-        datapointAssignment.datapoints.length,
-        datapointAssignment.datapoints.length + steps
+      const currentLoadedDatapoints = datapointAssignment.datapoints.filter(dp => !!dp.id);
+
+      const currentDatapointAssignmentsIds = datapointAssignment.datapoints.slice(
+        currentLoadedDatapoints.length,
+        currentLoadedDatapoints.length + steps
       );
 
       // get this chunk datapoints
       FLOW.SurveyedLocale.find({ ids: currentDatapointAssignmentsIds }).on('didLoad', function() {
-        callback(
-          this.map(dp => ({
-            name: dp.get('displayName'),
-            identifier: dp.get('identifier'),
-            id: dp.get('keyId'),
-          }))
-        );
+        // reassign datapoints array to be mutated
+        const datapoints = [...datapointAssignment.datapoints];
+
+        const newDatapoints = this.map(dp => ({
+          name: dp.get('displayName'),
+          identifier: dp.get('identifier'),
+          id: dp.get('keyId'),
+        }));
+
+        // replace loaded datapoints with new details
+        datapoints.splice(currentLoadedDatapoints.length, newDatapoints.length, ...newDatapoints);
+
+        callback(datapoints);
       });
     },
 
@@ -664,9 +672,7 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
           // combine data and add to datapoint assignments
           const completeDatapointAssignment = {
             ...this.datapointAssignments[datapointAssignmentIdx],
-            datapoints: this.datapointAssignments[datapointAssignmentIdx].datapoints.concat(
-              datapoints
-            ),
+            datapoints,
           };
 
           // update assignment

--- a/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
+++ b/Dashboard/app/js/lib/views/devices/assignment-edit-views.jsx
@@ -594,7 +594,6 @@ FLOW.AssignmentEditView = FLOW.ReactComponentView.extend(
         const datapointAssignment = this.map(item => ({
           id: item.get('keyId'),
           deviceId: item.get('deviceId'),
-          // datapointIds: item.get('dataPointIds'),
           datapoints: item.get('dataPointIds'),
         }))[0];
 


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Due to the new load more feature, we had 2 arrays controlling datapoints which led to a bug from assigning and editing datapoints

#### The solution
Use only one array with a load-and-replace method to load more

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
