### PR TITLE
[#3528] Send only registration form data

### DIFF
--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -220,7 +220,7 @@ public class DataPointUtil {
     private Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds) {
         SurveyInstanceDAO surveyInstanceDAO = new SurveyInstanceDAO();
         SurveyedLocaleDao surveyedLocaleDao = new SurveyedLocaleDao();
-        List<SurveyInstance> values = surveyInstanceDAO.getMonitoringData(surveyedLocaleDao.listByKeys(surveyedLocalesIds), 3);
+        List<SurveyInstance> values = surveyInstanceDAO.getMonitoringData(surveyedLocaleDao.listByKeys(surveyedLocalesIds));
         return values.stream().collect(Collectors.groupingBy(SurveyInstance::getSurveyedLocaleId));
     }
 

--- a/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
@@ -768,15 +768,13 @@ public class SurveyInstanceDAO extends BaseDAO<SurveyInstance> {
         return null;
     }
 
-    public List<SurveyInstance> getMonitoringData(@Nonnull List<SurveyedLocale> surveyedLocales, int numberOfInstances) {
+    public List<SurveyInstance> getMonitoringData(@Nonnull List<SurveyedLocale> surveyedLocales) {
         List<SurveyInstance> result = new ArrayList<>();
 
         for (SurveyedLocale s : surveyedLocales) {
             SurveyInstance registrationSurveyInstance = getRegistrationSurveyInstance(s, s.getCreationSurveyId());
             if (registrationSurveyInstance != null) {
                 result.add(registrationSurveyInstance);
-                // listInstancesByLocale orders by collectionDate DESC
-                result.addAll(listInstancesByLocale(s.getKey().getId(), null, null, numberOfInstances, null));
             }
         }
         return result;

--- a/GAE/test/com/gallatinsystems/surveyal/dao/SurveyInstanceDAOTest.java
+++ b/GAE/test/com/gallatinsystems/surveyal/dao/SurveyInstanceDAOTest.java
@@ -52,12 +52,11 @@ public class SurveyInstanceDAOTest {
 
         dataStoreTestUtil.saveFormInstances(formInstances);
 
-        int numberOfInstances = 3;
-        List<SurveyInstance> monitoringData = new SurveyInstanceDAO().getMonitoringData(dataPoints, numberOfInstances);
+        List<SurveyInstance> monitoringData = new SurveyInstanceDAO().getMonitoringData(dataPoints);
 
         assertNotNull(monitoringData);
         assertFalse(monitoringData.isEmpty());
-        assertEquals(numberOfInstances + 1, monitoringData.size());
+        assertEquals(1, monitoringData.size());
     }
 
     // https://github.com/akvo/akvo-flow/issues/3652
@@ -67,7 +66,6 @@ public class SurveyInstanceDAOTest {
         Long creationSurveyId = dataStoreTestUtil.randomId();
         int numberOfDataPoints = 5;
         int totalFormInstancesPerDataPoint = 10;
-        int numberOfInstances = 3;
 
         // We're explicitly not setting up a registration form instance
         List<SurveyedLocale> dataPoints = dataStoreTestUtil.createDataPoints(surveyId, numberOfDataPoints);
@@ -77,7 +75,7 @@ public class SurveyInstanceDAOTest {
 
 
         // Calling getMonitoringData included a null value in the list if the data point has no registration form instance
-        List<SurveyInstance> monitoringData = new SurveyInstanceDAO().getMonitoringData(dataPoints, numberOfInstances);
+        List<SurveyInstance> monitoringData = new SurveyInstanceDAO().getMonitoringData(dataPoints);
 
         assertEquals(0, monitoringData.stream().filter(surveyInstance -> surveyInstance == null).count());
         assertTrue(monitoringData.isEmpty());


### PR DESCRIPTION
In instances when lots of form instances per data point, we can't
serve the request in less than 60s. The traces show lots of datastore
requests to get the most recent N submissions.

Closes #3528 
