### PR TITLE
[#3645] Remove an extra query for datapoints that have already been retrieved

### DIFF
--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -69,8 +69,7 @@ public class DataPointUtil {
         HashMap<Long, String> questionTypeMap = new HashMap<>();
         QuestionDao questionDao = new QuestionDao();
 
-        List<Long> surveyedLocalesIds = getSurveyedLocalesIds(slList);
-        Map<Long, List<SurveyInstance>> surveyInstancesMap = getSurveyInstances(surveyedLocalesIds);
+        Map<Long, List<SurveyInstance>> surveyInstancesMap = getSurveyInstances(slList);
         Map<Long, List<QuestionAnswerStore>> questionAnswerStore = getQuestionAnswerStoreMap(
                 surveyInstancesMap);
 
@@ -216,23 +215,13 @@ public class DataPointUtil {
     /**
      * Fetches SurveyInstances using the surveyedLocalesIds and puts them in a map:
      * key: SurveyedLocalesId, value: list of SurveyInstances
+     * @param dataPointList
      */
-    private Map<Long, List<SurveyInstance>> getSurveyInstances(List<Long> surveyedLocalesIds) {
+    private Map<Long, List<SurveyInstance>> getSurveyInstances(List<SurveyedLocale> dataPointList) {
         SurveyInstanceDAO surveyInstanceDAO = new SurveyInstanceDAO();
         SurveyedLocaleDao surveyedLocaleDao = new SurveyedLocaleDao();
-        List<SurveyInstance> values = surveyInstanceDAO.getMonitoringData(surveyedLocaleDao.listByKeys(surveyedLocalesIds));
+        List<SurveyInstance> values = surveyInstanceDAO.getMonitoringData(dataPointList);
         return values.stream().collect(Collectors.groupingBy(SurveyInstance::getSurveyedLocaleId));
-    }
-
-    private List<Long> getSurveyedLocalesIds(List<SurveyedLocale> slList) {
-        if (slList == null) {
-            return Collections.emptyList();
-        }
-        List<Long> surveyedLocaleIds = new ArrayList<>(slList.size());
-        for (SurveyedLocale surveyedLocale : slList) {
-            surveyedLocaleIds.add(surveyedLocale.getKey().getId());
-        }
-        return surveyedLocaleIds;
     }
 
     private SurveyInstanceDto createSurveyInstanceDto(QuestionDao qDao,


### PR DESCRIPTION
### The solution
* Ideally removing the extra query speeds up the entire time to complete the request.

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
