### PR TITLE
[#3624] - add a basic text to tell user if he/she is offline

### DIFF
--- a/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
+++ b/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default class OfflineIndicator extends React.Component {
+  state = {
+    isOffline: false,
+  };
+
+  componentDidMount() {
+    window.addEventListener('online', this.onlineStatus);
+    window.addEventListener('offline', this.onlineStatus);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('online', this.onlineStatus);
+    window.removeEventListener('offline', this.onlineStatus);
+  }
+
+  onlineStatus = () => {
+    this.setState({ isOffline: !navigator.onLine });
+  };
+
+  render() {
+    return this.state.isOffline && <p>You are offline. Changes {"won't"} be saved</p>;
+  }
+}

--- a/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
+++ b/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
@@ -6,18 +6,24 @@ export default class OfflineIndicator extends React.Component {
   };
 
   componentDidMount() {
-    window.addEventListener('online', this.onlineStatus);
-    window.addEventListener('offline', this.onlineStatus);
+    this.timer = setInterval(() => {
+      fetch('https://www.google.com/generate_204', { mode: 'no-cors' })
+        .then(res => {
+          // with no-cors, res.status is 0 because the javascript ignores all response.
+          // we don't need the response, all we need to know is if the request went through or not
+          if (res.status !== 204) {
+            this.setState({ isOffline: false });
+          }
+        })
+        .catch(() => {
+          this.setState({ isOffline: true });
+        });
+    }, 5000);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('online', this.onlineStatus);
-    window.removeEventListener('offline', this.onlineStatus);
+    clearInterval(this.timer);
   }
-
-  onlineStatus = () => {
-    this.setState({ isOffline: !navigator.onLine });
-  };
 
   render() {
     return this.state.isOffline && <p>You are offline. Changes {"won't"} be saved</p>;

--- a/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
+++ b/Dashboard/app/js/lib/components/reusable/OfflineIndicator/index.jsx
@@ -8,12 +8,8 @@ export default class OfflineIndicator extends React.Component {
   componentDidMount() {
     this.timer = setInterval(() => {
       fetch('https://www.google.com/generate_204', { mode: 'no-cors' })
-        .then(res => {
-          // with no-cors, res.status is 0 because the javascript ignores all response.
-          // we don't need the response, all we need to know is if the request went through or not
-          if (res.status !== 204) {
-            this.setState({ isOffline: false });
-          }
+        .then(() => {
+          this.setState({ isOffline: false });
         })
         .catch(() => {
           this.setState({ isOffline: true });

--- a/Dashboard/app/js/lib/views/surveys/offline-state.jsx
+++ b/Dashboard/app/js/lib/views/surveys/offline-state.jsx
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import OfflineIndicator from 'akvo-flow/components/reusable/OfflineIndicator';
+
+require('akvo-flow/views/react-component');
+
+FLOW.OfflineIndicatorView = FLOW.ReactComponentView.extend({
+  init() {
+    this._super();
+  },
+
+  didInsertElement(...args) {
+    this._super(...args);
+    this.reactRender(<OfflineIndicator />);
+  },
+});

--- a/Dashboard/app/js/lib/views/views.js
+++ b/Dashboard/app/js/lib/views/views.js
@@ -31,6 +31,7 @@ require('akvo-flow/views/devices/survey-bootstrap-view');
 require('akvo-flow/views/stats/new-stats');
 require('akvo-flow/views/stats/stats-lists');
 require('akvo-flow/views/surveys/form-share');
+require('akvo-flow/views/surveys/offline-state');
 
 FLOW.ApplicationView = Ember.View.extend(template('application/application'));
 

--- a/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/nav-surveys-main.handlebars
@@ -69,6 +69,7 @@
             {{else}}
               <li><a class="saveProject noChanges">{{t _save}}</a></li>
             {{/if}}
+            <li>{{view FLOW.OfflineIndicatorView}}</li>
           </ul>
         </nav>
       {{/if}}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Tell user is he/she is online or offline

#### The solution
This is a simple implementation of using navigator.onLine.
It wouldn't work on some older browsers, but we would handle this edge case in future modifications

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30107382/99365449-98a4de80-28b7-11eb-90da-1a9078ba53f4.png)


#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
