### PR TITLE
Issue/3667 immutable copy

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -454,7 +454,7 @@ FLOW.projectControl = Ember.ArrayController.create({
     const currentFolder = this.get('currentProject');
     const templateIds = JSON.parse(FLOW.Env.templateIds) || [];
     const immutable = currentFolder && templateIds.indexOf(currentFolder.get('keyId')) >= 0;
-    debugger;
+
     FLOW.store.findQuery(FLOW.Action, {
       action: 'copyProject',
       targetId: this.get('copyTarget').get('keyId'),

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -453,7 +453,7 @@ FLOW.projectControl = Ember.ArrayController.create({
   endCopyProject() {
     const currentFolder = this.get('currentProject');
     const templateIds = JSON.parse(FLOW.Env.templateIds) || [];
-    const immutable = currentFolder && templateIds.indexOf(currentFolder.get('keyId')) >= 0;
+    const immutable = templateIds.indexOf(this.get('copyTarget').get('keyId')) >= 0;
 
     FLOW.store.findQuery(FLOW.Action, {
       action: 'copyProject',

--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -452,11 +452,14 @@ FLOW.projectControl = Ember.ArrayController.create({
 
   endCopyProject() {
     const currentFolder = this.get('currentProject');
-
+    const templateIds = JSON.parse(FLOW.Env.templateIds) || [];
+    const immutable = currentFolder && templateIds.indexOf(currentFolder.get('keyId')) >= 0;
+    debugger;
     FLOW.store.findQuery(FLOW.Action, {
       action: 'copyProject',
       targetId: this.get('copyTarget').get('keyId'),
       folderId: currentFolder ? currentFolder.get('keyId') : 0,
+      immutable: immutable,
     });
 
     FLOW.store.commit();

--- a/Dashboard/app/js/lib/models/models.js
+++ b/Dashboard/app/js/lib/models/models.js
@@ -176,6 +176,9 @@ FLOW.QuestionGroup = FLOW.BaseModel.extend({
   repeatable: DS.attr('boolean', {
     defaultValue: false,
   }),
+  immutable: DS.attr('boolean', {
+    defaultValue: false,
+  }),
 });
 
 FLOW.Question = FLOW.BaseModel.extend({

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -953,6 +953,10 @@ FLOW.QuestionView = FLOW.View.extend(
       });
     },
 
+    immutableGroup: Ember.computed(() => {
+      return FLOW.selectedControl.selectedQuestionGroup.get('immutable');
+    }).property('FLOW.selectedControl.selectedQuestionGroup'),
+
     showQuestionModifyButtons: Ember.computed(() => {
       const form = FLOW.selectedControl.get('selectedSurvey');
       return FLOW.permControl.canEditForm(form);

--- a/Dashboard/app/js/templates/navSurveys/edit-questions.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/edit-questions.handlebars
@@ -49,8 +49,10 @@
             {{/if}}
             </div>
             {{#if view.amVisible}}
+              {{#unless view.content.immutable}}
               <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.content.repeatable" disabledBinding="view.disableQuestionGroupEditing"}}{{t _repeatable_question_group}}</label>
               {{tooltip _repeatable_question_group_tooltip}}
+              {{/unless}}
             {{/if}}
             {{#if view.showSaveCancelButton}}
               <div class="groupSave">
@@ -66,11 +68,12 @@
                     <li><a {{action "toggleVisibility" target="this"}} class="showQuestionGroup">{{t _show_questions}} </a></li>
                   {{/if}}
                   {{#if view.showQuestionGroupModifyButtons}}
-                     <li><a {{action "doQGroupNameEdit" target="this"}} class="editQuestionGroup">{{t _edit_group_name}}</a></li>
-                     <li><a {{action "doQGroupMove" target="this"}} class="moveQuestionGroup">{{t _move}}</a></li>
-                     <li><a {{action "doQGroupCopy" target="this"}} class="copyQuestionGroup">{{t _copy}}</a></li>
-                     <li><a {{action confirm FLOW.dialogControl.delQG target="FLOW.dialogControl"}} class="deleteQuestionGroup">{{t _delete}}</a></li>
-
+                     {{#unless view.content.immutable}}
+                       <li><a {{action "doQGroupNameEdit" target="this"}} class="editQuestionGroup">{{t _edit_group_name}}</a></li>
+                       <li><a {{action "doQGroupMove" target="this"}} class="moveQuestionGroup">{{t _move}}</a></li>
+                       <li><a {{action "doQGroupCopy" target="this"}} class="copyQuestionGroup">{{t _copy}}</a></li>
+                     {{/unless}}
+                       <li><a {{action confirm FLOW.dialogControl.delQG target="FLOW.dialogControl"}} class="deleteQuestionGroup">{{t _delete}}</a></li>
                   {{/if}}
                 {{/unless}}
               </ul>
@@ -81,9 +84,9 @@
           {{#if view.amVisible}}
             <div class="questionSetContent">
               {{view FLOW.QuestionView zeroItemQuestion=true}}
-                {{#each question in FLOW.questionControl}}
-                  {{view FLOW.QuestionView contentBinding="question" zeroItemQuestion=false}}
-                {{/each}}
+              {{#each question in FLOW.questionControl}}
+                {{view FLOW.QuestionView contentBinding="question" zeroItemQuestion=false}}
+              {{/each}}
             </div>
           {{/if}}
           <!-- end question group block -->

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -310,7 +310,11 @@
 			</ul>
 		  </nav>
 		 {{else}}
-		   <a {{action "doInsertQuestion" target="this"}} class="addQuestion">{{t _add_new_question}}</a>
+        {{#if view.immutableGroup}}
+          <span class="addQuestion">&nbsp;</span>
+        {{else}}
+          <a {{action "doInsertQuestion" target="this"}} class="addQuestion">{{t _add_new_question}}</a>
+        {{/if}}
 		{{/if}}
 	  {{/if}}
 	{{/if}}

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -273,10 +273,12 @@
     <nav class="smallMenu">
       <ul>
 		{{#if view.showQuestionModifyButtons}}
+      {{#unless view.content.immutable}}
         <li><a {{action confirm FLOW.dialogControl.delQ target="FLOW.dialogControl"}} class="deleteQuestion">{{t _delete}}</a> </li>
         <li><a {{action "doQuestionCopy" target="this"}} class="copyQuestion" id="">{{t _copy}}</a></li>
         <li><a {{action "doQuestionMove" target="this"}} class="moveQuestion" id="">{{t _move}}</a></li>
         <li><a {{action "doQuestionEdit" target="this"}} class="editQuestion" id="">{{t _edit}}</a></li>
+      {{/unless}}
 		{{/if}}
       </ul>
     </nav>

--- a/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
@@ -46,6 +46,7 @@ public class QuestionGroup extends BaseDomain {
     private Integer order;
     private Boolean repeatable;
     private Status status = null;
+    private Boolean immutable = false;
 
     public enum Status {
         READY, COPYING
@@ -134,6 +135,14 @@ public class QuestionGroup extends BaseDomain {
     
     public Boolean getRepeatable() {
         return repeatable;
+    }
+
+    public void setImmutable(boolean immutable) {
+        this.immutable = immutable;
+    }
+
+    public Boolean getImmutable() {
+        return immutable;
     }
     
 }

--- a/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
@@ -137,7 +137,7 @@ public class QuestionGroup extends BaseDomain {
         return repeatable;
     }
 
-    public void setImmutable(boolean immutable) {
+    public void setImmutable(Boolean immutable) {
         this.immutable = immutable;
     }
 

--- a/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/QuestionGroupDto.java
+++ b/GAE/src/org/waterforpeople/mapping/app/gwt/client/survey/QuestionGroupDto.java
@@ -35,6 +35,7 @@ public class QuestionGroupDto extends BaseDto implements NamedObject {
     private Long sourceId;
     private Boolean repeatable;
     private String status;
+    private Boolean immutable;
 
     public Integer getOrder() {
         return order;
@@ -127,5 +128,12 @@ public class QuestionGroupDto extends BaseDto implements NamedObject {
     public Boolean getRepeatable() {
         return repeatable;
     }
-    
+
+    public Boolean getImmutable() {
+        return immutable;
+    }
+
+    public void setImmutable(Boolean immutable) {
+        this.immutable = immutable;
+    }
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -126,7 +126,7 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
             status.setValue("inProgress, target=" + dpReq.getSurveyId());
             statusDao.save(status);
 
-            copySurvey(dpReq.getSurveyId(), Long.valueOf(dpReq.getSource()));
+            copySurvey(dpReq.getSurveyId(), Long.valueOf(dpReq.getSource()), dpReq.getImmutable());
 
             // now update the status
             status.setInError(false);
@@ -147,7 +147,7 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
 
                 Long surveyId = originalQuestionGroup.getSurveyId();
                 SurveyUtils.copyQuestionGroup(originalQuestionGroup, newQuestionGroup,
-                        surveyId, null, SurveyUtils.listQuestionIdsUsedInSurveyGroup(surveyId));
+                        surveyId, null, SurveyUtils.listQuestionIdsUsedInSurveyGroup(surveyId), false);
 
                 newQuestionGroup.setStatus(QuestionGroup.Status.READY); // copied
                 qgDao.save(newQuestionGroup);
@@ -417,7 +417,7 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
     }
 
 
-    private void copySurvey(Long copiedSurveyId, Long originalSurveyId) {
+    private void copySurvey(Long copiedSurveyId, Long originalSurveyId, boolean immutable) {
 
         final QuestionGroupDao qgDao = new QuestionGroupDao();
 
@@ -437,11 +437,12 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
             // need a temp group to avoid state sharing exception
             QuestionGroup tmpGroup = new QuestionGroup();
             SurveyUtils.shallowCopy(sourceGroup, tmpGroup);
+            tmpGroup.setImmutable(immutable);
             tmpGroup.setSurveyId(copiedSurveyId);
 
             final QuestionGroup copyGroup = qgDao.save(tmpGroup);
             SurveyUtils.copyQuestionGroup(sourceGroup, copyGroup, copiedSurveyId,
-                    qDependencyResolutionMap, null); //new survey, so id re-use is OK
+                    qDependencyResolutionMap, null, immutable); //new survey, so id re-use is OK
         }
 
         final SurveyDAO sDao = new SurveyDAO();

--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -126,7 +126,7 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
             status.setValue("inProgress, target=" + dpReq.getSurveyId());
             statusDao.save(status);
 
-            copySurvey(dpReq.getSurveyId(), Long.valueOf(dpReq.getSource()), dpReq.getImmutable());
+            SurveyUtils.copySurvey(dpReq.getSurveyId(), Long.valueOf(dpReq.getSource()), dpReq.getImmutable());
 
             // now update the status
             status.setInError(false);
@@ -414,51 +414,6 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
             pm.makePersistentAll(toRemove); // some objects are in "transient" state
             dao.delete(toRemove);
         }
-    }
-
-
-    private void copySurvey(Long copiedSurveyId, Long originalSurveyId, boolean immutable) {
-
-        final QuestionGroupDao qgDao = new QuestionGroupDao();
-
-        final List<QuestionGroup> qgList = qgDao.listQuestionGroupBySurvey(originalSurveyId);
-        final Map<Long, Long> qDependencyResolutionMap = new HashMap<Long, Long>();
-
-        if (qgList == null) {
-            log.log(Level.INFO, "Nothing to copy from {surveyId: " + originalSurveyId
-                    + "} to {surveyId: " + copiedSurveyId + "}");
-            SurveyUtils.resetSurveyState(copiedSurveyId);
-            return;
-        }
-
-        log.log(Level.INFO, "Copying " + qgList.size() + " `QuestionGroup`");
-
-        for (final QuestionGroup sourceGroup : qgList) {
-            // need a temp group to avoid state sharing exception
-            QuestionGroup tmpGroup = new QuestionGroup();
-            SurveyUtils.shallowCopy(sourceGroup, tmpGroup);
-            tmpGroup.setImmutable(immutable);
-            tmpGroup.setSurveyId(copiedSurveyId);
-
-            final QuestionGroup copyGroup = qgDao.save(tmpGroup);
-            SurveyUtils.copyQuestionGroup(sourceGroup, copyGroup, copiedSurveyId,
-                    qDependencyResolutionMap, null, immutable); //new survey, so id re-use is OK
-        }
-
-        final SurveyDAO sDao = new SurveyDAO();
-        final Survey copiedSurvey = SurveyUtils.resetSurveyState(copiedSurveyId);
-        final Survey originalSurvey = sDao.getById(originalSurveyId);
-
-        MessageDao mDao = new MessageDao();
-        Message message = new Message();
-
-        message.setObjectId(copiedSurveyId);
-        message.setObjectTitle(copiedSurvey.getName());
-        message.setActionAbout("copySurvey");
-        message.setShortMessage("Copying from Survey " + originalSurveyId + " ("
-                + originalSurvey.getName() + ") completed");
-        mDao.save(message);
-
     }
 
     /**

--- a/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
@@ -74,6 +74,7 @@ public class EnvServlet extends HttpServlet {
         properties.add("extraMapboxTileLayerLabel");
         properties.add(WEBFORM_REDIRECTION_URL);
         properties.add(CADDISFLY_TESTS_FILE_URL_KEY);
+        properties.add("templateIds");
     }
 
     @Override

--- a/GAE/src/org/waterforpeople/mapping/app/web/dto/DataProcessorRequest.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/dto/DataProcessorRequest.java
@@ -73,6 +73,7 @@ public class DataProcessorRequest extends RestRequest {
     public static final String DELETE_CHILD_CASCADE_NODES = "deleteCascadeNodes";
     public static final String UPDATE_SURVEY_INSTANCE_SUMMARIES = "updateSurveyInstanceSummaries";
     public static final int MAX_TASK_RETRIES = 3;
+    public static final String IMMUTABLE_PARAM = "immutable";
 
     private String country;
     private String source;
@@ -90,6 +91,7 @@ public class DataProcessorRequest extends RestRequest {
     private Long parentNodeId = null;
     private List<Long> dependentQuestionIds;
     private int retry = 0;
+    private Boolean immutable = false;
 
     @Override
     protected void populateFields(HttpServletRequest req) throws Exception {
@@ -214,6 +216,10 @@ public class DataProcessorRequest extends RestRequest {
             } catch (NumberFormatException e) {
                 // no-op
             }
+        }
+
+        if(req.getParameter(IMMUTABLE_PARAM) != null) {
+            setImmutable(Boolean.valueOf(req.getParameter(IMMUTABLE_PARAM)));
         }
     }
 
@@ -351,6 +357,14 @@ public class DataProcessorRequest extends RestRequest {
 
     public void setSurveyGroupId(Long surveyGroupId) {
         this.surveyGroupId = surveyGroupId;
+    }
+
+    public Boolean getImmutable() {
+        return immutable;
+    }
+
+    public void setImmutable(Boolean immutable) {
+        this.immutable = immutable;
     }
 
 }

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/ActionRestService.java
@@ -81,7 +81,8 @@ public class ActionRestService {
             @RequestParam(value = "version", defaultValue = "") String version,
             @RequestParam(value = "dbInstructions", defaultValue = "") String dbInstructions,
             @RequestParam(value = "targetId", defaultValue = "") Long targetId,
-            @RequestParam(value = "folderId", defaultValue = "") Long folderId) {
+            @RequestParam(value = "folderId", defaultValue = "") Long folderId,
+            @RequestParam(value = "immutable", defaultValue = "false") Boolean immutable) {
         String status = "failed";
         String message = "";
         final Map<String, Object> response = new HashMap<String, Object>();
@@ -112,7 +113,7 @@ public class ActionRestService {
         } else if ("publishCascade".equals(action)) {
             status = SurveyUtils.publishCascade(cascadeResourceId);
         } else if ("copyProject".equals(action)) {
-            status = copyProject(targetId, folderId);
+            status = copyProject(targetId, folderId, immutable);
         }
 
         statusDto.setStatus(status);
@@ -276,7 +277,7 @@ public class ActionRestService {
         }
     }
 
-    private String copyProject(Long targetId, Long folderId) {
+    private String copyProject(Long targetId, Long folderId, boolean immutable) {
 
         SurveyGroup projectSource = surveyGroupDao.getByKey(targetId);
         SurveyGroup projectParent = null;
@@ -325,7 +326,7 @@ public class ActionRestService {
             surveyDto.setName(sourceSurvey.getName());
             surveyDto.setPath(projectCopy.getPath() + "/" + sourceSurvey.getName());
             surveyDto.setSurveyGroupId(savedProjectCopy.getKey().getId());
-            Survey surveyCopy = SurveyUtils.copySurvey(sourceSurvey, surveyDto);
+            Survey surveyCopy = SurveyUtils.copySurvey(sourceSurvey, surveyDto, immutable);
             surveyCopy.setAncestorIds(surveysAncestorIds);
             surveyCopy.setSurveyGroupId(savedProjectCopy.getKey().getId());
             long copyId = surveyDao.save(surveyCopy).getKey().getId();

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -422,7 +422,7 @@ public class QuestionRestService {
         }
         return SurveyUtils.copyQuestion(source, dto.getQuestionGroupId(), dto.getOrder(),
                 source.getSurveyId(),
-                SurveyUtils.listQuestionIdsUsedInSurveyGroup(source.getSurveyId()));
+                SurveyUtils.listQuestionIdsUsedInSurveyGroup(source.getSurveyId()), false);
     }
 
     private Question newQuestion(QuestionDto dto) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -337,7 +337,7 @@ public class SurveyRestService {
             // source survey not found, the getById already logged the problem
             return null;
         }
-        return SurveyUtils.copySurvey(source, dto, false); //FIXME
+        return SurveyUtils.copySurvey(source, dto, false);
     }
 
     private Survey marshallToDomain(SurveyDto dto) {

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/SurveyRestService.java
@@ -337,7 +337,7 @@ public class SurveyRestService {
             // source survey not found, the getById already logged the problem
             return null;
         }
-        return SurveyUtils.copySurvey(source, dto);
+        return SurveyUtils.copySurvey(source, dto, false); //FIXME
     }
 
     private Survey marshallToDomain(SurveyDto dto) {

--- a/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
+++ b/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
 package com.gallatinsystems.surveyal.dao;
 
 import com.gallatinsystems.common.Constants;

--- a/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
+++ b/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
@@ -20,7 +20,6 @@ import org.springframework.beans.BeanUtils;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveyDto;
 
 import java.util.List;
-import java.util.logging.Level;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,6 +50,10 @@ public class SurveyUtilsTest {
         List<QuestionGroup> qgs = new QuestionGroupDao().listQuestionGroupBySurvey(copiedSurvey.getKey().getId());
         assertEquals(1, qgs.size());
         assertTrue(qgs.get(0).getImmutable());
+
+        List<Question> questions = new QuestionDao().listQuestionsBySurvey(copiedSurvey.getKey().getId());
+        assertEquals(1, questions.size());
+        assertTrue(questions.get(0).getImmutable());
     }
 
     private Survey copySurvey(Survey sourceSurvey) {
@@ -83,6 +86,7 @@ public class SurveyUtilsTest {
         QuestionGroup newQg = new QuestionGroupDao().save(qg);
 
         Question q = new Question();
+        q.setType(Question.Type.FREE_TEXT);
         q.setQuestionGroupId(newQg.getKey().getId());
         q.setSurveyId(newSurvey.getKey().getId());
         new QuestionDao().save(q);

--- a/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
+++ b/GAE/test/com/gallatinsystems/surveyal/dao/SurveyUtilsTest.java
@@ -1,0 +1,92 @@
+package com.gallatinsystems.surveyal.dao;
+
+import com.gallatinsystems.common.Constants;
+import com.gallatinsystems.survey.dao.QuestionDao;
+import com.gallatinsystems.survey.dao.QuestionGroupDao;
+import com.gallatinsystems.survey.dao.SurveyDAO;
+import com.gallatinsystems.survey.dao.SurveyGroupDAO;
+import com.gallatinsystems.survey.dao.SurveyUtils;
+import com.gallatinsystems.survey.domain.Question;
+import com.gallatinsystems.survey.domain.QuestionGroup;
+import com.gallatinsystems.survey.domain.Survey;
+import com.gallatinsystems.survey.domain.SurveyGroup;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.akvo.flow.api.app.DataStoreTestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+import org.waterforpeople.mapping.app.gwt.client.survey.SurveyDto;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SurveyUtilsTest {
+    private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    private DataStoreTestUtil dataStoreTestUtil;
+
+    @BeforeEach
+    public void setUp() {
+        helper.setUp();
+        dataStoreTestUtil = new DataStoreTestUtil();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    @Test
+    public void testCopyTemplateSurvey() throws Exception {
+
+        Survey sourceSurvey = createSurvey();
+        Survey copiedSurvey = copySurvey(sourceSurvey);
+
+        SurveyUtils.copySurvey(copiedSurvey.getKey().getId(), sourceSurvey.getKey().getId(), true);
+
+        List<QuestionGroup> qgs = new QuestionGroupDao().listQuestionGroupBySurvey(copiedSurvey.getKey().getId());
+        assertEquals(1, qgs.size());
+        assertTrue(qgs.get(0).getImmutable());
+    }
+
+    private Survey copySurvey(Survey sourceSurvey) {
+        SurveyDto dto = new SurveyDto();
+        dto.setName(sourceSurvey.getName());
+        dto.setSurveyGroupId(sourceSurvey.getSurveyGroupId());
+
+        final Survey tmp = new Survey();
+        BeanUtils.copyProperties(sourceSurvey, tmp, Constants.EXCLUDED_PROPERTIES);
+
+        tmp.setName(dto.getName());
+        tmp.setSurveyGroupId(dto.getSurveyGroupId());
+
+        return new SurveyDAO().save(tmp);
+    }
+
+    private Survey createSurvey() {
+
+        SurveyGroup sg = new SurveyGroup();
+        SurveyGroup newSg = new SurveyGroupDAO().save(sg);
+
+        Survey survey = new Survey();
+        survey.setName("Simple survey");
+        survey.setSurveyGroupId(newSg.getKey().getId());
+        Survey newSurvey = new SurveyDAO().save(survey);
+
+        QuestionGroup qg = new QuestionGroup();
+        qg.setName("quesitongroup");
+        qg.setSurveyId(newSurvey.getKey().getId());
+        QuestionGroup newQg = new QuestionGroupDao().save(qg);
+
+        Question q = new Question();
+        q.setQuestionGroupId(newQg.getKey().getId());
+        q.setSurveyId(newSurvey.getKey().getId());
+        new QuestionDao().save(q);
+
+        return newSurvey;
+    }
+}

--- a/GAE/war/Env.vm
+++ b/GAE/war/Env.vm
@@ -19,7 +19,8 @@ loader.register('akvo-flow/flowenv', function(require) {
     extraMapboxTileLayerMapId: '$env.extraMapboxTileLayerMapId',
     extraMapboxTileLayerAccessToken: '$env.extraMapboxTileLayerAccessToken',
     extraMapboxTileLayerLabel: '$env.extraMapboxTileLayerLabel',
-    caddisflyTestsFileUrl: '$env.caddisflyTestsFileUrl'
+    caddisflyTestsFileUrl: '$env.caddisflyTestsFileUrl',
+    templateIds: '$env.templateIds',
   });
 
   #if( $localeStrings )


### PR DESCRIPTION
* Support for `immutable` copies: 
  * When a survey is copied from a Survey *template* (defined as system property) the resulting copies of `QuestionGroup` and `Question` have the `immutable` property set to `true`.
  * This property is used for hiding the modify/edit/add controls in at *Question Group* and *Question* level in the Dashboard
  * This does **not** prevent a *Question Group* to be deleted