### PR TITLE
[#3667] Set a default value for environment setting

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/EnvServlet.java
@@ -135,6 +135,10 @@ public class EnvServlet extends HttpServlet {
             props.put("extraMapboxTileLayerLabel", "");
         }
 
+        if (props.get("templateIds") == null) {
+            props.put("templateIds", "[]");
+        }
+
         props.put("appId", SystemProperty.applicationId.get());
 
         if (!"false".equalsIgnoreCase(props.get(SHOW_MAPS_PROPERTY_KEY))) {


### PR DESCRIPTION
* When the System.property `templateIds` is not defined (null) we set a default value to `[]`

Closes #3667 

