### PR TITLE
[#3637] Add immutable flag to question template

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -452,14 +452,11 @@ FLOW.projectControl = Ember.ArrayController.create({
 
   endCopyProject() {
     const currentFolder = this.get('currentProject');
-    const templateIds = JSON.parse(FLOW.Env.templateIds) || [];
-    const immutable = templateIds.indexOf(this.get('copyTarget').get('keyId')) >= 0;
 
     FLOW.store.findQuery(FLOW.Action, {
       action: 'copyProject',
       targetId: this.get('copyTarget').get('keyId'),
       folderId: currentFolder ? currentFolder.get('keyId') : 0,
-      immutable: immutable,
     });
 
     FLOW.store.commit();

--- a/Dashboard/app/js/lib/views/surveys/question-view.js
+++ b/Dashboard/app/js/lib/views/surveys/question-view.js
@@ -73,7 +73,22 @@ FLOW.QuestionView = FLOW.View.extend(
     })
       .property('FLOW.selectedControl.selectedQuestion', 'content.keyId')
       .cacheable(),
+    
+    isTemplate: Ember.computed(function() {
+      const surveyId = FLOW.selectedControl.selectedSurveyGroup.get('keyId');
+      return JSON.parse(FLOW.Env.templateIds).indexOf(surveyId) >= 0;
+    })
+      .property('FLOW.selectedControl.selectedSurveyGroup')
+      .cacheable(),
 
+    editable: Ember.computed(function() {
+      const immutable = this.get('content').get('immutable');
+      const isTemplate = this.get('isTemplate');
+      return isTemplate || !immutable;
+    })
+      .property('this.isTemplate')
+      .cacheable(),
+    
     amTextType: Ember.computed(function() {
       if (this.type) {
         return this.type.get('value') == 'FREE_TEXT';
@@ -238,6 +253,7 @@ FLOW.QuestionView = FLOW.View.extend(
       this.set('dependentFlag', FLOW.selectedControl.selectedQuestion.get('dependentFlag'));
       this.set('allowPoints', FLOW.selectedControl.selectedQuestion.get('allowPoints'));
       this.set('allowLine', FLOW.selectedControl.selectedQuestion.get('allowLine'));
+      this.set('immutable', FLOW.selectedControl.selectedQuestion.get('immutable'));
       this.set('allowPolygon', FLOW.selectedControl.selectedQuestion.get('allowPolygon'));
       this.set('cascadeResourceId', FLOW.selectedControl.selectedQuestion.get('cascadeResourceId'));
       this.set(
@@ -497,6 +513,7 @@ FLOW.QuestionView = FLOW.View.extend(
       FLOW.selectedControl.selectedQuestion.set('allowPoints', this.get('allowPoints'));
       FLOW.selectedControl.selectedQuestion.set('allowLine', this.get('allowLine'));
       FLOW.selectedControl.selectedQuestion.set('allowPolygon', this.get('allowPolygon'));
+      FLOW.selectedControl.selectedQuestion.set('immutable', this.get('immutable'));
 
       const allowExternalSources =
         this.type.get('value') !== 'FREE_TEXT' ? false : this.get('allowExternalSources');

--- a/Dashboard/app/js/templates/navSurveys/question-view.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/question-view.handlebars
@@ -219,6 +219,12 @@
       {{/if}}
   {{/if}}
 </div>
+{{#if view.isTemplate}}
+  <div class="dependencyBlock">
+    <label class="labelcheckbox">{{view Ember.Checkbox checkedBinding="view.immutable"}}{{t _make_copy_immutable}}
+    </label>
+  </div>
+{{/if}}
     <!-- End question specific material -->
     <nav>
       <ul>
@@ -273,21 +279,24 @@
     <nav class="smallMenu">
       <ul>
 		{{#if view.showQuestionModifyButtons}}
-      {{#unless view.content.immutable}}
+      {{#if view.editable}}
         <li><a {{action confirm FLOW.dialogControl.delQ target="FLOW.dialogControl"}} class="deleteQuestion">{{t _delete}}</a> </li>
         <li><a {{action "doQuestionCopy" target="this"}} class="copyQuestion" id="">{{t _copy}}</a></li>
         <li><a {{action "doQuestionMove" target="this"}} class="moveQuestion" id="">{{t _move}}</a></li>
         <li><a {{action "doQuestionEdit" target="this"}} class="editQuestion" id="">{{t _edit}}</a></li>
-      {{/unless}}
+      {{/if}}
 		{{/if}}
       </ul>
     </nav>
     <h1 class="questionNbr">
-        {{#if view.showQuestionModifyButtons}}
-        <a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}} </span>{{view.content.text}}</a>
+      
+      {{#if view.showQuestionModifyButtons}}
+        {{#if view.editable}}
+          <a {{action "doQuestionEdit" target="this"}} class="textLink"><span>{{view.content.order}} </span>{{view.content.text}}</a>
         {{else}}
-        <span>{{view.content.order}} </span>{{view.content.text}}
+          <span>{{view.content.order}} </span>{{view.content.text}}
         {{/if}}
+      {{/if}}
     </h1>
 
   {{/if}}

--- a/GAE/src/locale/ui-strings.properties
+++ b/GAE/src/locale/ui-strings.properties
@@ -272,6 +272,7 @@ _locate_the_data = Locate the data
 _log_in = Log in
 _log_out = Log out
 _longitude = Longitude
+_make_copy_immutable = Make this question locked when copied
 _manage_device_groups = Manage device groups
 _manage_notifications = Manage notifications
 _manage_translations = Manage translations


### PR DESCRIPTION
React accordingly in related copied forms to editable question options

If a template is copied, questions marked as immutable are not editable

Don't send the immutable parameter in the survey copy request

Co-authored-by: Emmanuel Mulo <emmanuel@akvo.org>
Co-authored-by: Daniel Sunnerek <daniel@akvo.org>
Co-authored-by: Iván Perdomo <ivan@perdomo.me>
Co-authored-by: Valeria Rogatchevskikh <valeria@akvo.org>

#### Before the PR (what is the issue or what needed to be done)

#### The solution

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
