### PR TITLE
[#3697] Async delete of form instances

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/DataProcessorRestServlet.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2020 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -228,8 +228,8 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
             createNewIdentifiersLocales(dpReq.getCursor(), dpReq.getSurveyId());
         } else if (DataProcessorRequest.DELETE_SURVEY_INSTANCE_ACTION.equalsIgnoreCase(req
                 .getAction())) {
-            if (dpReq.getSurveyInstanceId() != null) {
-                deleteSurveyResponses(dpReq.getSurveyInstanceId());
+            if (dpReq.getSurveyInstanceId() != null && dpReq.getSurveyedLocaleId() != null) {
+                deleteSurveyResponses(dpReq.getSurveyInstanceId(), dpReq.getSurveyedLocaleId());
             }
         } else if (DataProcessorRequest.SURVEY_RESPONSE_COUNT.equalsIgnoreCase(req.getAction())) {
             if (dpReq.getSummaryCounterId() != null && dpReq.getDelta() != null) {
@@ -1069,12 +1069,9 @@ public class DataProcessorRestServlet extends AbstractRestApiServlet {
      *
      * @param surveyInstanceId
      */
-    private void deleteSurveyResponses(Long surveyInstanceId) {
+    private void deleteSurveyResponses(Long surveyInstanceId, Long surveyedLocaleId) {
         siDao = new SurveyInstanceDAO();
-        SurveyInstance surveyInstance = siDao.getByKey(surveyInstanceId);
-        if (surveyInstance != null) {
-            siDao.deleteSurveyInstance(surveyInstance);
-        }
+        siDao.deleteSurveyInstanceContent(surveyInstanceId, surveyedLocaleId);
     }
 
     /**

--- a/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
@@ -541,13 +541,17 @@ public class SurveyInstanceDAO extends BaseDAO<SurveyInstance> {
         summaryDao.delete(deleteList);
     }
 
-    /**
-     * Deletes a surveyInstance and all its related objects
-     *
-     * @param surveyInstance survey instance to be deleted
-     */
+
     public void deleteSurveyInstance(SurveyInstance surveyInstance) {
         final Long surveyInstanceId = surveyInstance.getKey().getId();
+        final Long surveyedLocaleId = surveyInstance.getSurveyedLocaleId();
+
+        deleteSurveyInstanceContent(surveyInstanceId, surveyedLocaleId);
+
+        super.delete(surveyInstance);
+    }
+
+    public void deleteSurveyInstanceContent(Long surveyInstanceId, Long surveyedLocaleId) {
 
         // update summary counts + delete question answers
         QuestionAnswerStoreDao qasDao = new QuestionAnswerStoreDao();
@@ -579,8 +583,7 @@ public class SurveyInstanceDAO extends BaseDAO<SurveyInstance> {
         }
 
         // task to adapt cluster data + delete surveyedlocale if not needed anymore
-        if (surveyInstance.getSurveyedLocaleId() != null) {
-            Long surveyedLocaleId = surveyInstance.getSurveyedLocaleId();
+        if (surveyedLocaleId != null) {
             List<SurveyInstance> relatedSurveyInstances = listByProperty("surveyedLocaleId",
                     surveyedLocaleId, "Long");
 
@@ -600,9 +603,6 @@ public class SurveyInstanceDAO extends BaseDAO<SurveyInstance> {
                 queue.add(to);
             }
         }
-
-        super.delete(surveyInstance);
-
     }
 
     /**


### PR DESCRIPTION
* We delete the main entity (`SurveyInstance`) in the request thread
  and delegate the removal of child/dependent objects to a Task

Co-authored-by: Valeria Rogatchevskikh <valeria@akvo.org>

Closes #3697 
