### PR TITLE
[#3689] Fix different group dependencies are broken

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -113,12 +113,12 @@ public class SurveyUtils {
 
         log.log(Level.INFO, "Copying " + qgList.size() + " `QuestionGroup`");
 
-        List<Pair<Long, QuestionGroup>> sourceToCopiedGroupMap = shallowCopyQuestionGroups(copiedSurveyId, qgList);
+        List<Pair<Long, QuestionGroup>> listOfPairs = shallowCopyQuestionGroups(copiedSurveyId, qgList);
 
         // batch save question groups
-        new QuestionGroupDao().save(sourceToCopiedGroupMap.stream().map(pair -> pair.right).collect(Collectors.toList()));
+        new QuestionGroupDao().save(listOfPairs.stream().map(pair -> pair.right).collect(Collectors.toList()));
 
-        for(Pair<Long, QuestionGroup> entry : sourceToCopiedGroupMap) {
+        for(Pair<Long, QuestionGroup> entry : listOfPairs) {
             Long sourceGroupId = entry.left;
             QuestionGroup copyGroup = entry.right;
 

--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -16,13 +16,13 @@
 
 package com.gallatinsystems.survey.dao;
 
+import com.google.gwt.dev.util.Pair;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import java.util.stream.Collectors;
-import javafx.util.Pair;
 import org.akvo.flow.dao.MessageDao;
 import org.akvo.flow.domain.Message;
 import org.akvo.flow.domain.SecuredObject;
@@ -116,11 +116,11 @@ public class SurveyUtils {
         List<Pair<Long, QuestionGroup>> sourceToCopiedGroupMap = shallowCopyQuestionGroups(copiedSurveyId, qgList);
 
         // batch save question groups
-        new QuestionGroupDao().save(sourceToCopiedGroupMap.stream().map(pair -> pair.getValue()).collect(Collectors.toList()));
+        new QuestionGroupDao().save(sourceToCopiedGroupMap.stream().map(pair -> pair.right).collect(Collectors.toList()));
 
         for(Pair<Long, QuestionGroup> entry : sourceToCopiedGroupMap) {
-            Long sourceGroupId = entry.getKey();
-            QuestionGroup copyGroup = entry.getValue();
+            Long sourceGroupId = entry.left;
+            QuestionGroup copyGroup = entry.right;
 
             SurveyUtils.copyQuestionGroupContent(sourceGroupId, copyGroup,
                     qDependencyResolutionMap, null, copiedTranslations); //new survey, so id re-use is OK
@@ -156,7 +156,7 @@ public class SurveyUtils {
             QuestionGroup copyGroup = new QuestionGroup();
             SurveyUtils.shallowCopy(sourceGroup, copyGroup);
             copyGroup.setSurveyId(formId);
-            sourceToCopiedGroups.add(new Pair<>(sourceGroup.getKey().getId(), copyGroup));
+            sourceToCopiedGroups.add(Pair.create(sourceGroup.getKey().getId(), copyGroup));
         }
         return sourceToCopiedGroups;
     }

--- a/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
+++ b/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
@@ -192,10 +192,10 @@ public class DataStoreTestUtil {
         return question;
     }
 
-    public QuestionOption createQuestionOption(Question question) {
+    public QuestionOption createQuestionOption(Question question, String code, String text) {
         QuestionOption questionOption = new QuestionOption();
-        questionOption.setCode("1");
-        questionOption.setText("1");
+        questionOption.setCode(code);
+        questionOption.setText(text);
         questionOption.setQuestionId(question.getKey().getId());
         QuestionOption saved = new QuestionOptionDao().save(questionOption);
         return saved;


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

#### The solution
We were using a map to store copied groups so the group order was lost,
using a list now
Added a test

Co-authored-by: Juan A. Ruz <juanantonioruz@gmail.com>
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
