### PR TITLE
[#3689] Get the first element of a result set if present

### DIFF
--- a/scripts/data/src/org/akvo/gae/remoteapi/FixCopyDependency.java
+++ b/scripts/data/src/org/akvo/gae/remoteapi/FixCopyDependency.java
@@ -194,7 +194,10 @@ public class FixCopyDependency implements Process {
         Filter f = new Query.CompositeFilter(Query.CompositeFilterOperator.AND, Arrays.asList(surveyFilter, sourceFilter));
         query.setFilter(f);
 
-        q = ds.prepare(query).asSingleEntity();
+        List<Entity> found = ds.prepare(query).asList(FetchOptions.Builder.withDefaults());
+        if (!found.isEmpty()) {
+            q = found.get(0);
+        }
 
         dependencyCache.put(key, q);
         return q;


### PR DESCRIPTION
* In one of the instances there are more than one copy resulting on a
  `PreparedQuery$TooManyResultsException`

* This problem was produced by broken copies of a survey and the retry
  of the Task doing the copy

* Workaround the problem by using a `.asList()` and grabbing the first element