### PR TITLE
[#3705] Show report error messages

### DIFF
--- a/Dashboard/app/js/lib/views/reports/export-reports-views.js
+++ b/Dashboard/app/js/lib/views/reports/export-reports-views.js
@@ -334,6 +334,10 @@ FLOW.ReportListItemView = FLOW.View.extend(template('navReports/report'), {
     return !url ? '#' : url;
   }).property('content'),
 
+  reportSuccess: Ember.computed(function() {
+    return this.content.get('state') === 'FINISHED_SUCCESS';
+  }).property('content'),
+
   surveyPath: Ember.computed(function() {
     const formId = this.content.get('formId');
     let path = '';

--- a/Dashboard/app/js/templates/navReports/report.handlebars
+++ b/Dashboard/app/js/templates/navReports/report.handlebars
@@ -1,11 +1,15 @@
 {{#if view.isNotStats}}
 <li id="list-{{unbound view.content.keyId}}" {{bindAttr class="view.reportType view.reportStatus"}}>
   <div class="exportInfo">
-    <a id="link-{{unbound view.content.keyId}}" {{bindAttr href="view.reportLink"}}>
-
       <h5>
-        {{view.reportTypeString}} - <span class="exportFileName"
-          id="filename-{{unbound view.content.keyId}}">{{view.reportFilename}}</span>
+        {{view.reportTypeString}} -
+        {{#if view.reportSuccess}}
+        <a id="link-{{unbound view.content.keyId}}" {{bindAttr href="view.reportLink"}}>
+          <span class="exportFileName" id="filename-{{unbound view.content.keyId}}">{{view.reportFilename}}</span>
+        </a>
+        {{else}}
+          <span style="color:red">{{view.content.message}}</span>
+        {{/if}}
         <span class="submissionsDate">
           {{#if view.content.lastCollectionOnly}}
           {{t _recent_submissions}}
@@ -15,8 +19,6 @@
           {{/if}}
         </span>
       </h5>
-
-    </a>
     <span class="surveyPath">{{view.surveyPath}}</span>
   </div>
   <div class="exportStatus">


### PR DESCRIPTION
When a report export fails, the system generates a `message` that is
not shown to the user.