### PR TITLE
[#3716] fix issue when the form has only one group

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveyFormExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveyFormExporter.java
@@ -299,9 +299,11 @@ public class SurveyFormExporter implements DataExporter {
                         writeScrollingRowPart(optionStyle, qTextFromId, q, row);
                     }
                     // all rows created; merge all-group cells vertically
-                    sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 0, 0));
-                    sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 1, 1));
-                    sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 2, 2));
+                    if (qList.size() > 1) {
+                        sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 0, 0));
+                        sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 1, 1));
+                        sheet.addMergedRegion(new CellRangeAddress(firstRowInGroup, startRow + count - 1, 2, 2));
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
After upgrading poi, it is not possible to merge cells when there is only one item
#### The solution
No merging needed since only one question inside the group
#### Screenshots (if appropriate)
NA
#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
