### PR TITLE
[#3715] Refactor the question group listing section

### DIFF
--- a/Dashboard/app/js/lib/controllers/survey-controllers.js
+++ b/Dashboard/app/js/lib/controllers/survey-controllers.js
@@ -871,13 +871,11 @@ FLOW.questionGroupControl = Ember.ArrayController.create(observe({
 
 FLOW.questionControl = Ember.ArrayController.create(observe({
   'FLOW.selectedControl.selectedSurvey': ['populateAllQuestions', 'allQuestionsFilter'],
-  'FLOW.selectedControl.selectedQuestionGroup': 'setQGcontent',
   'FLOW.selectedControl.selectedQuestion': 'setEarlierOptionQuestions',
 }), {
   content: null,
   OPTIONcontent: null,
   earlierOptionQuestions: null,
-  QGcontent: null,
   filterContent: null,
   sortProperties: ['order'],
   sortAscending: true,
@@ -940,12 +938,13 @@ FLOW.questionControl = Ember.ArrayController.create(observe({
     }
   },
 
-  setQGcontent() {
+  visibleQuestions: Ember.computed(() => {
     if (FLOW.selectedControl.get('selectedQuestionGroup') && FLOW.selectedControl.selectedSurvey.get('keyId') > 0) {
-      const qId = FLOW.selectedControl.selectedQuestionGroup.get('keyId');
-      this.set('content', FLOW.store.filter(FLOW.Question, item => item.get('questionGroupId') == qId));
+      const qgId = FLOW.selectedControl.selectedQuestionGroup.get('keyId');
+      return FLOW.store.filter(FLOW.Question, item => item.get('questionGroupId') === qgId);
     }
-  },
+    return [];
+  }).property('FLOW.selectedControl.selectedQuestionGroup'),
 
   geoshapeContent: Ember.computed(() => {
     const selectedSurvey = FLOW.selectedControl.get('selectedSurvey');

--- a/Dashboard/app/js/templates/navSurveys/edit-questions.handlebars
+++ b/Dashboard/app/js/templates/navSurveys/edit-questions.handlebars
@@ -84,7 +84,7 @@
           {{#if view.amVisible}}
             <div class="questionSetContent">
               {{view FLOW.QuestionView zeroItemQuestion=true}}
-              {{#each question in FLOW.questionControl}}
+              {{#each question in FLOW.questionControl.visibleQuestions}}
                 {{view FLOW.QuestionView contentBinding="question" zeroItemQuestion=false}}
               {{/each}}
             </div>


### PR DESCRIPTION
Co-authored-by: Valeria Rogatchevskikh <valeria@akvo.org>

* We have been using the questionControl to load questions for the entire survey but also to filter questions based on what is visible in the question group. A new computed property has been added to filter the list of questions whenever a group of questions is selected.

#### Before the PR (what is the issue or what needed to be done)

#### The solution

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
