### PR TITLE
[#3729] fixed crash related to merged cells

### DIFF
--- a/GAE/src/org/waterforpeople/mapping/dataexport/SurveyFormExporter.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/SurveyFormExporter.java
@@ -223,8 +223,10 @@ public class SurveyFormExporter implements DataExporter {
                                     .getTranslationMap())
                                     + SMALL_BLANK, null);
                         }
-                        sheet.addMergedRegion(new CellRangeAddress(
-                                questionStartRow, curRow - 1, 0, 0));
+                        CellRangeAddress region = new CellRangeAddress(questionStartRow, curRow - 1, 0, 0);
+                        if (region.getNumberOfCells() > 1) {
+                            sheet.addMergedRegion(region);
+                        }
                     } else {
                         createCell(tempRow, 1, BLANK, null);
                     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
crash stacktrace:

`java.lang.IllegalArgumentException: Merged region A838 must contain 2 or more cells
  File "HSSFSheet.java", line 716, in org.apache.poi.hssf.usermodel/addMergedRegion
  File "HSSFSheet.java", line 670, in org.apache.poi.hssf.usermodel/addMergedRegion
  File "SurveyFormExporter.java", line 226, in org.waterforpeople.mapping.dataexport/writePaperSheet
  File "SurveyFormExporter.java", line 159, in org.waterforpeople.mapping.dataexport/writeSurvey
  File "SurveyFormExporter.java", line 96, in org.waterforpeople.mapping.dataexport/export
  File "exporter.clj", line 75, in akvo.flow-services.exporter/export-report
    (.export exporter criteria file base-url options)`
#### The solution

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
