### PR TITLE
Adapt ant script to work locally with scripts/data 

### DIFF
--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -66,6 +66,12 @@ By default akvo-server-config/*/*.p12 auth files are taken from this relative pa
 ant remoteAPI -DappId=akvoflow-uat2 -Dservice=UnifyDataPointAssignment -DakvoFlowServerConfigPath=/your-path-to-akvo-flow-server-config
 ```
 
+## calling a RemoteAPIService against local env
+
+``` shell
+ant devRemoteAPI -Dservice=AddUsers -Dargs=./dev_environment_users.csv
+```
+
 
 # FAQ
 

--- a/scripts/data/build.xml
+++ b/scripts/data/build.xml
@@ -33,4 +33,13 @@
 			<arg line="${service} ${appId} ${serviceAccount} ${akvoFlowServerConfigPath}/${appId}/${appId}.p12 ${args}" />
 		</java>
 	</target>
+
+	<target name="devRemoteAPI" depends="compile">
+		<property name="service" value="" />
+		<property name="args" value="" />
+		<java classname="org.akvo.gae.remoteapi.RemoteAPI" classpathref="project.classpath" failonerror="true">
+			<arg line="${service} localhost ${args}" />
+		</java>
+	</target>
+
 </project>


### PR DESCRIPTION
so now we can call data/scripts using this approach
`cd akvo-flow/scripts/data`
`ant devRemoteAPI -Dservice=XXX -Dargs=XXX`

eg:
`ant devRemoteAPI -Dservice=AddUsers -Dargs=./dev_environment_users.csv`