### PR TITLE
[#3743] Fix issue with missing translations when copying a quesiton o…

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/SurveyUtils.java
@@ -396,7 +396,7 @@ public class SurveyUtils {
             QuestionOption newOption = qoDao.save(shallowCopyQuestionOption(qo, newQuestion.getKey().getId()));
 
             log.log(Level.INFO, "Copying question option translations");
-            copyTranslation(sourceQuestionId, newOption.getKey().getId(), newQuestion.getSurveyId(),
+            copyTranslation(qo.getKey().getId(), newOption.getKey().getId(), newQuestion.getSurveyId(),
                     newQuestion.getQuestionGroupId(), ParentType.QUESTION_OPTION);
         }
     }


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
When copying a group, translations of the options were not copied correctly
#### The solution
fix translations copy of question option
add test
#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
