### PR TITLE
[#3747] Copy question group translations across instances

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionGroupDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionGroupDao.java
@@ -16,7 +16,6 @@
 
 package com.gallatinsystems.survey.dao;
 
-import com.gallatinsystems.framework.domain.BaseDomain;
 import com.gallatinsystems.survey.domain.Translation;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +42,7 @@ public class QuestionGroupDao extends BaseDAO<QuestionGroup> {
     }
 
     public void saveGroupTranslations(QuestionGroup item) {
-        HashMap<String, Translation> translations = item.getTranslationMap();
+        Map<String, Translation> translations = item.getTranslations();
         if (translations != null) {
             for (Translation t : translations.values()) {
                 t.setParentId(item.getKey().getId());
@@ -106,7 +105,7 @@ public class QuestionGroupDao extends BaseDAO<QuestionGroup> {
                         translationMap.put(t.getLanguageCode(), t);
                     }
                 }
-                group.setTranslationMap(translationMap);
+                group.setTranslations(translationMap);
                 // TODO: Hack because we seem to have questiongroups with same
                 // order key so put an arbitrary value there for now since it
                 // isn't used.

--- a/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
+++ b/GAE/src/com/gallatinsystems/survey/domain/QuestionGroup.java
@@ -17,6 +17,7 @@
 package com.gallatinsystems.survey.domain;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TreeMap;
 
 import javax.jdo.annotations.NotPersistent;
@@ -39,7 +40,7 @@ public class QuestionGroup extends BaseDomain {
     @NotPersistent
     private TreeMap<Integer, Question> questionMap;
     @NotPersistent
-    private HashMap<String, Translation> translationMap;
+    private Map<String, Translation> translations;
     private String code = null;
     private String path = null;
     private Long surveyId;
@@ -68,12 +69,12 @@ public class QuestionGroup extends BaseDomain {
         this.surveyId = surveyId;
     }
 
-    public HashMap<String, Translation> getTranslationMap() {
-        return translationMap;
+    public Map<String, Translation> getTranslations() {
+        return translations;
     }
 
-    public void setTranslationMap(HashMap<String, Translation> translationMap) {
-        this.translationMap = translationMap;
+    public void setTranslations(HashMap<String, Translation> translations) {
+        this.translations = translations;
     }
 
     public void addQuestion(Integer order, Question question) {
@@ -115,10 +116,10 @@ public class QuestionGroup extends BaseDomain {
     }
 
     public void addTranslation(Translation t) {
-        if (translationMap == null) {
-            translationMap = new HashMap<String, Translation>();
+        if (translations == null) {
+            translations = new HashMap<String, Translation>();
         }
-        translationMap.put(t.getLanguageCode(), t);
+        translations.put(t.getLanguageCode(), t);
     }
     
     public Status getStatus() {

--- a/GAE/src/org/akvo/flow/api/export/SurveyRestServlet.java
+++ b/GAE/src/org/akvo/flow/api/export/SurveyRestServlet.java
@@ -39,6 +39,7 @@ import org.waterforpeople.mapping.app.gwt.client.survey.QuestionOptionDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveyDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveyGroupDto;
 import org.waterforpeople.mapping.app.gwt.client.survey.SurveySummaryDto;
+import org.waterforpeople.mapping.app.gwt.client.survey.TranslationDto;
 import org.waterforpeople.mapping.app.gwt.client.surveyinstance.SurveyInstanceDto;
 import org.waterforpeople.mapping.app.gwt.server.survey.SurveyServiceImpl;
 import org.waterforpeople.mapping.app.util.DtoMarshaller;
@@ -297,6 +298,18 @@ public class SurveyRestServlet extends AbstractRestApiServlet {
             for (QuestionGroup q : groups.values()) {
                 QuestionGroupDto dto = new QuestionGroupDto();
                 DtoMarshaller.copyToDto(q, dto);
+                if(q.getTranslations() != null) {
+                    if(dto.getTranslationMap() == null) {
+                        dto.setTranslationMap(new HashMap<>());
+                    }
+                    for(Translation t : q.getTranslations().values()) {
+                        TranslationDto tDto = new TranslationDto();
+                        DtoMarshaller.copyToDto(t, tDto);
+                        tDto.setLangCode(t.getLanguageCode());
+                        tDto.setParentType(t.getParentType().toString());
+                        dto.getTranslationMap().put(t.getLanguageCode(), tDto);
+                    }
+                }
                 dtoList.add(dto);
             }
         }

--- a/GAE/src/org/akvo/flow/xml/XmlQuestionGroup.java
+++ b/GAE/src/org/akvo/flow/xml/XmlQuestionGroup.java
@@ -69,9 +69,9 @@ public class XmlQuestionGroup {
         order = group.getOrder();
         repeatable = group.getRepeatable();
         //Translations, if any
-        if (group.getTranslationMap() != null) {
+        if (group.getTranslations() != null) {
             altText = new ArrayList<>();
-            for (Translation t: group.getTranslationMap().values()) {
+            for (Translation t: group.getTranslations().values()) {
                 altText.add(new XmlAltText(t));
             }
         }

--- a/GAE/src/org/waterforpeople/mapping/app/util/DtoMarshaller.java
+++ b/GAE/src/org/waterforpeople/mapping/app/util/DtoMarshaller.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2012,2018 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2012,2018,2021 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *
@@ -17,6 +17,8 @@
 package org.waterforpeople.mapping.app.util;
 
 import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.ConvertUtils;
@@ -40,6 +42,8 @@ import com.google.appengine.api.datastore.Text;
 
 public class DtoMarshaller {
 
+    private static final Logger log = Logger.getLogger(DtoMarshaller.class.getSimpleName());
+
     public static <T extends BaseDomain, U extends BaseDto> void copyToCanonical(
             T canonical, U dto) {
         try {
@@ -52,7 +56,7 @@ public class DtoMarshaller {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.log(Level.SEVERE, "Unable to copy object properties: ", e);
         }
     }
 
@@ -65,7 +69,7 @@ public class DtoMarshaller {
                 dto.setKeyId(canonical.getKey().getId());
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.log(Level.SEVERE, "Unable to Dto properties: ", e);
         }
     }
 

--- a/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
@@ -591,46 +591,46 @@ public class BulkDataServiceClient {
      * @return
      * @throws Exception
      */
-    private static List<QuestionGroupDto> parseQuestionGroups(String response) throws Exception {
+    public static List<QuestionGroupDto> parseQuestionGroups(String response) {
         List<QuestionGroupDto> dtoList = new ArrayList<QuestionGroupDto>();
-        JSONArray arr = getJsonArray(response);
-        if (arr != null) {
-            for (int i = 0; i < arr.length(); i++) {
-                JSONObject json = arr.getJSONObject(i);
-                if (json != null) {
-                    QuestionGroupDto dto = new QuestionGroupDto();
-                    try {
-                        if (!json.isNull("code")) {
-                            dto.setCode(json.getString("code"));
-                        }
-                        if (!json.isNull("keyId")) {
-                            dto.setKeyId(json.getLong("keyId"));
-                        }
-                        if (!json.isNull("displayName")) {
-                            dto.setName(json.getString("displayName"));
-                        }
-                        if (!json.isNull("order")) {
-                            dto.setOrder(json.getInt("order"));
-                        }
-                        if (!json.isNull("path")) {
-                            dto.setPath(json.getString("path"));
-                        }
-                        if (!json.isNull("surveyId")) {
-                            dto.setSurveyId(json.getLong("surveyId"));
-                        }
-                        if (!json.isNull("repeatable")) {
-                            dto.setRepeatable(json.getBoolean("repeatable"));
-                        }
-                        if (!json.isNull("translationMap")) {
-                            dto.setTranslationMap(parseTranslations(json.getJSONObject("translationMap")));
-                        }
+        try {
+            JSONArray arr = getJsonArray(response);
+            if (arr != null) {
+                for (int i = 0; i < arr.length(); i++) {
+                    JSONObject json = arr.getJSONObject(i);
+                    if (json != null) {
+                        QuestionGroupDto dto = new QuestionGroupDto();
+                            if (!json.isNull("code")) {
+                                dto.setCode(json.getString("code"));
+                            }
+                            if (!json.isNull("keyId")) {
+                                dto.setKeyId(json.getLong("keyId"));
+                            }
+                            if (!json.isNull("displayName")) {
+                                dto.setName(json.getString("displayName"));
+                            }
+                            if (!json.isNull("order")) {
+                                dto.setOrder(json.getInt("order"));
+                            }
+                            if (!json.isNull("path")) {
+                                dto.setPath(json.getString("path"));
+                            }
+                            if (!json.isNull("surveyId")) {
+                                dto.setSurveyId(json.getLong("surveyId"));
+                            }
+                            if (!json.isNull("repeatable")) {
+                                dto.setRepeatable(json.getBoolean("repeatable"));
+                            }
+                            if (!json.isNull("translationMap")) {
+                                dto.setTranslationMap(parseTranslations(json.getJSONObject("translationMap")));
+                            }
 
-                        dtoList.add(dto);
-                    } catch (Exception e) {
-                        log.error("Error in json parsing: " + e.getMessage(), e);
+                            dtoList.add(dto);
                     }
                 }
             }
+        } catch (JSONException e) {
+            log.log(Level.SEVERE, "Error in json parsing: " + e.getMessage(), e);
         }
         return dtoList;
     }
@@ -1047,18 +1047,18 @@ public class BulkDataServiceClient {
                 }
             }
         } catch (Exception e) {
-            log.warn("Could not parse question options: " + response, e);
+            log.log(Level.WARNING, "Could not parse question options: " + response, e);
         }
         return dtoList;
     }
 
     @SuppressWarnings("unchecked")
     private static TreeMap<String, TranslationDto> parseTranslations(
-            JSONObject translationMapJson) throws Exception {
+            JSONObject translationMapJson) throws JSONException {
         Iterator<String> keyIter = translationMapJson.keys();
         TreeMap<String, TranslationDto> translationMap = null;
         if (keyIter != null) {
-            translationMap = new TreeMap<String, TranslationDto>();
+            translationMap = new TreeMap<>();
             //Iterate on all the languages
             while (keyIter.hasNext()) {
                 String lang = keyIter.next();
@@ -1274,7 +1274,7 @@ public class BulkDataServiceClient {
     /**
      * converts the string into a JSON array object.
      */
-    public static JSONArray getJsonArray(String response) throws Exception {
+    public static JSONArray getJsonArray(String response) throws JSONException {
         log.fine("response: " + response);
         if (response != null) {
             JSONObject json = new JSONObject(response);

--- a/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
+++ b/GAE/src/org/waterforpeople/mapping/dataexport/service/BulkDataServiceClient.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 
 import com.gallatinsystems.common.util.MD5Util;
@@ -46,7 +48,6 @@ import com.gallatinsystems.survey.domain.SurveyGroup.ProjectType;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.akvo.flow.util.FlowJsonObjectReader;
 import java.util.Base64;
-import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -73,7 +74,7 @@ import static org.waterforpeople.mapping.app.web.dto.SurveyInstanceRequest.*;
  */
 public class BulkDataServiceClient {
 
-    private static final Logger log = Logger.getLogger(BulkDataServiceClient.class);
+    private static final Logger log = Logger.getLogger(BulkDataServiceClient.class.getSimpleName());
 
     private static final String DATA_SERVLET_PATH = "/databackout";
     public static final String RESPONSE_KEY = "dtoList";
@@ -173,7 +174,7 @@ public class BulkDataServiceClient {
             try {
                 count = Long.parseLong(instanceString.trim()); //remove trailing newline
             } catch (Exception e) {
-                log.error("Unparsable instance count " + e.getMessage());
+                log.severe("Unparsable instance count " + e.getMessage());
                 // Leave it as null
             }
         }
@@ -185,10 +186,10 @@ public class BulkDataServiceClient {
             Map<String, String> results = BulkDataServiceClient
                     .fetchInstanceIds(args[1], args[0], args[2], false, null, null, null);
             if (results != null) {
-                log.info(results);
+                log.info(results.toString());
             }
         } catch (Exception e) {
-            log.error("Error: " + e.getMessage(), e);
+            log.log(Level.SEVERE, "Error: " + e.getMessage(), e);
         }
     }
 
@@ -393,7 +394,7 @@ public class BulkDataServiceClient {
             InstanceDataDto instanceData = jsonReader.readObject(instanceDataResponse, typeReference);
             return instanceData;
         } catch (IOException e) {
-            log.error("Error while parsing: ", e);
+            log.log(Level.SEVERE, "Error while parsing: ", e);
         }
 
         return new InstanceDataDto();
@@ -438,7 +439,7 @@ public class BulkDataServiceClient {
                     true,
                     apiKey);
 
-            log.debug("response: " + surveyGroupResponse);
+            log.fine("response: " + surveyGroupResponse);
 
             final FlowJsonObjectReader jsonDeserialiser = new FlowJsonObjectReader();
             final TypeReference<SurveyGroupDto> listItemTypeReference = new TypeReference<SurveyGroupDto>(){};
@@ -448,7 +449,7 @@ public class BulkDataServiceClient {
                 surveyGroupDto = surveyGroupList.get(0);
             }
         } catch (Exception e) {
-            log.error(e);
+            log.log(Level.SEVERE, e.getMessage(), e);
         }
 
         return surveyGroupDto;
@@ -690,7 +691,7 @@ public class BulkDataServiceClient {
                         }
                         dtoList.add(dto);
                     } catch (Exception e) {
-                        log.error("Error in json parsing: " + e.getMessage(), e);
+                        log.log(Level.SEVERE, "Error in json parsing: " + e.getMessage(), e);
                     }
                 }
             }
@@ -757,7 +758,7 @@ public class BulkDataServiceClient {
                         }
                         dtoList.add(dto);
                     } catch (Exception e) {
-                        log.error("Error in json parsing: " + e.getMessage(), e);
+                        log.log(Level.SEVERE, "Error in json parsing: " + e.getMessage(), e);
                     }
                 }
             }
@@ -1013,7 +1014,7 @@ public class BulkDataServiceClient {
                             }
                             dtoList.add(dto);
                         } catch (Exception e) {
-                            log.error("Error in json parsing: " + e.getMessage(), e);
+                            log.log(Level.SEVERE, "Error in json parsing: " + e.getMessage(), e);
                         }
                     }
                 }
@@ -1141,7 +1142,7 @@ public class BulkDataServiceClient {
                 queryString = "";
             }
             URL url = new URL(baseUrl);
-            log.debug("Calling: " + baseUrl + " with params: " + queryString);
+            log.fine("Calling: " + baseUrl + " with params: " + queryString);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
             conn.setConnectTimeout(30000);
@@ -1195,7 +1196,7 @@ public class BulkDataServiceClient {
         String result = null;
         try {
             URL url = new URL(fullUrl);
-            log.debug("Calling: " + url.toString());
+            log.fine("Calling: " + url.toString());
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
             conn.setConnectTimeout(30000);
@@ -1274,7 +1275,7 @@ public class BulkDataServiceClient {
      * converts the string into a JSON array object.
      */
     public static JSONArray getJsonArray(String response) throws Exception {
-        log.debug("response: " + response);
+        log.fine("response: " + response);
         if (response != null) {
             JSONObject json = new JSONObject(response);
             if (json != null) {

--- a/GAE/test/org/akvo/flow/util/FlowJsonObjectWriterTests.java
+++ b/GAE/test/org/akvo/flow/util/FlowJsonObjectWriterTests.java
@@ -143,7 +143,7 @@ class FlowJsonObjectWriterTests {
         translation.setLanguageCode("es");
         HashMap<String, Translation> translationHashMap = new HashMap<>();
         translationHashMap.put(translation.getLanguageCode(), translation);
-        qg.setTranslationMap(translationHashMap);
+        qg.setTranslations(translationHashMap);
 
         FlowJsonObjectWriter writer = new FlowJsonObjectWriter().withExcludeNullValues();
         String jsonString = null;
@@ -153,7 +153,7 @@ class FlowJsonObjectWriterTests {
             // ignoring exception
         }
 
-        String jsonStringExpected = "{\"name\":\"question group\",\"translationMap\":{\"es\":{\"languageCode\":\"es\",\"text\":\"Primer grupo\",\"parentType\":\"QUESTION_GROUP_NAME\"}},\"surveyId\":123,\"order\":0,\"immutable\":false}";
+        String jsonStringExpected = "{\"name\":\"question group\",\"translations\":{\"es\":{\"languageCode\":\"es\",\"text\":\"Primer grupo\",\"parentType\":\"QUESTION_GROUP_NAME\"}},\"surveyId\":123,\"order\":0,\"immutable\":false}";
         assertEquals(jsonStringExpected, jsonString);
     }
 

--- a/GAE/test/org/akvo/flow/xml/FlowXmlObjectWriterTests.java
+++ b/GAE/test/org/akvo/flow/xml/FlowXmlObjectWriterTests.java
@@ -539,7 +539,7 @@ class FlowXmlObjectWriterTests {
         TreeMap<Integer, QuestionGroup> gl = new TreeMap<>();
         HashMap<String, Translation> translationHashMap2 = createTranslationMap("Grupo", "es", form1.getObjectId(),
                 qg.getKey().getId(), Translation.ParentType.QUESTION_GROUP_NAME);
-        qg.setTranslationMap(translationHashMap2);
+        qg.setTranslations(translationHashMap2);
         gl.put(1, qg);
         form1.setQuestionGroupMap(gl);
         //No questions

--- a/GAE/test/org/waterforpeople/mapping/dataexport/SurveyReplicationImporterTests.java
+++ b/GAE/test/org/waterforpeople/mapping/dataexport/SurveyReplicationImporterTests.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2021 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
+package org.waterforpeople.mapping.dataexport;
+
+import com.gallatinsystems.survey.domain.QuestionGroup;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import org.akvo.flow.api.app.DataStoreTestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.waterforpeople.mapping.app.gwt.client.survey.QuestionGroupDto;
+import org.waterforpeople.mapping.app.gwt.client.survey.TranslationDto;
+import org.waterforpeople.mapping.dataexport.service.BulkDataServiceClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SurveyReplicationImporterTests {
+
+    private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+    private String DTO_QG_JSON_LIST = "{\"resultCount\":0,\"message\":null,\"code\":null,\"offset\":0,\"cursor\":null,\"url\":null,\"dtoList\":[{\"keyId\":146642013,\"questionMap\":null,\"code\":\"General\",\"surveyId\":145492013,\"order\":1,\"path\":\"\",\"name\":\"General\",\"sourceId\":null,\"repeatable\":false,\"status\":null,\"immutable\":null,\"translationMap\":{\"es\":{\"keyId\":6191349976006656,\"langCode\":\"es\",\"text\":\"General\",\"parentId\":146642013,\"parentType\":\"QUESTION_GROUP_NAME\",\"surveyId\":145492013,\"questionGroupId\":146642013}},\"displayName\":\"General\"},{\"keyId\":148442015,\"questionMap\":null,\"code\":\"Asset data\",\"surveyId\":145492013,\"order\":2,\"path\":\"\",\"name\":\"Asset data\",\"sourceId\":null,\"repeatable\":false,\"status\":null,\"immutable\":null,\"translationMap\":{\"es\":{\"keyId\":4644886871539712,\"langCode\":\"es\",\"text\":\"Datos sobre lo que sea\",\"parentId\":148442015,\"parentType\":\"QUESTION_GROUP_NAME\",\"surveyId\":145492013,\"questionGroupId\":148442015}},\"displayName\":\"Asset data\"},{\"keyId\":144682013,\"questionMap\":null,\"code\":\"Functionality\",\"surveyId\":145492013,\"order\":3,\"path\":\"\",\"name\":\"Functionality\",\"sourceId\":null,\"repeatable\":false,\"status\":null,\"immutable\":null,\"translationMap\":{\"es\":{\"keyId\":5770786778382336,\"langCode\":\"es\",\"text\":\"Funcionalidad\",\"parentId\":144682013,\"parentType\":\"QUESTION_GROUP_NAME\",\"surveyId\":145492013,\"questionGroupId\":144682013}},\"displayName\":\"Functionality\"},{\"keyId\":147442013,\"questionMap\":null,\"code\":\"Service level\",\"surveyId\":145492013,\"order\":4,\"path\":\"\",\"name\":\"Service level\",\"sourceId\":null,\"repeatable\":false,\"status\":null,\"immutable\":null,\"translationMap\":{\"es\":{\"keyId\":5207836824961024,\"langCode\":\"es\",\"text\":\"Nivel servicio\",\"parentId\":147442013,\"parentType\":\"QUESTION_GROUP_NAME\",\"surveyId\":145492013,\"questionGroupId\":147442013}},\"displayName\":\"Service level\"}]}";
+
+    @BeforeEach
+    public void setUp() {
+        helper.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    @Test
+    void testCopyAndCreateDtosToCanonical() throws Exception {
+        List<QuestionGroupDto> qgDtoList = BulkDataServiceClient.parseQuestionGroups(DTO_QG_JSON_LIST);
+        List<QuestionGroup> qgList = new ArrayList<QuestionGroup>();
+        List<QuestionGroup> qgs = SurveyReplicationImporter.copyAndCreateList(qgList, qgDtoList, QuestionGroup.class);
+
+        assertNotEquals(null, qgList);
+        assertEquals(4, qgList.size());
+
+        QuestionGroupDto qgWithTranslations =  qgDtoList.get(1);
+        Map<String, TranslationDto> translationDtoMap = qgWithTranslations.getTranslationMap();
+
+        assertTrue(translationDtoMap.containsKey("es"));
+
+        TranslationDto translationDto = translationDtoMap.get("es");
+        assertEquals("Datos sobre lo que sea", translationDto.getText());
+    }
+}


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
Question group translations were not copying across instances 

#### The solution

* Renamed the translations map for Question domain object to prevent conflict during calls of BeanUtils.copyProperties()
* Convert transation map in QuestionGroupDto to a TranslationDto map to enable correct parsing when received on the other end of the copying
* Surround parseQuestionGroups() logic with outer try-catch statement rather than having it within a for loop.
* More precise exceptions thrown and caught
* Add test cases for importer class


#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
