### PR TITLE
[#3597] Registration form instance delete

### DIFF
--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2019, 2021 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
+++ b/GAE/src/org/akvo/flow/api/app/DataPointUtil.java
@@ -224,8 +224,7 @@ public class DataPointUtil {
      */
     private Map<Long, List<SurveyInstance>> getSurveyInstances(List<SurveyedLocale> dataPointList) {
         SurveyInstanceDAO surveyInstanceDAO = new SurveyInstanceDAO();
-        SurveyedLocaleDao surveyedLocaleDao = new SurveyedLocaleDao();
-        List<SurveyInstance> values = surveyInstanceDAO.getMonitoringData(dataPointList);
+        List<SurveyInstance> values = surveyInstanceDAO.getRegistrationFormData(dataPointList);
         return values.stream().collect(Collectors.groupingBy(SurveyInstance::getSurveyedLocaleId));
     }
 

--- a/GAE/src/org/akvo/flow/rest/handler/FormInstanceRequestHandler.java
+++ b/GAE/src/org/akvo/flow/rest/handler/FormInstanceRequestHandler.java
@@ -34,13 +34,18 @@ public class FormInstanceRequestHandler {
         Long surveyedLocaleId = formInstance.getSurveyedLocaleId();
         SurveyedLocale dataPoint = surveyedLocaleDao.getById(surveyedLocaleId);
         List<SurveyInstance> relatedSurveyInstances = siDao.listInstancesByLocale(surveyedLocaleId, null, null, null);
-        if (relatedSurveyInstances.size() == 1
-                && relatedSurveyInstances.get(0).getKey().getId() == formInstance.getKey().getId()) {
-            // we need to consider what happens when a registration form is deleted even when there are
-            // other existing monitoring forms. Should we delete the registration form *and* the monitoring forms
-            // i.e. all the data?
+
+        if (isRegistrationForm(dataPoint, formInstance)) {
             surveyedLocaleDao.delete(dataPoint);
+            siDao.delete(relatedSurveyInstances);
+        } else {
+            siDao.delete(formInstance);
         }
-        siDao.delete(formInstance);
+    }
+
+    private boolean isRegistrationForm(SurveyedLocale dataPoint, SurveyInstance formInstance) {
+        return dataPoint.getCreationSurveyId() != null
+                && formInstance.getSurveyId() != null
+                && dataPoint.getCreationSurveyId().equals(formInstance.getSurveyId());
     }
 }

--- a/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2015, 2017-2020 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2010-2015, 2017-2021 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
+++ b/GAE/src/org/waterforpeople/mapping/dao/SurveyInstanceDAO.java
@@ -745,7 +745,7 @@ public class SurveyInstanceDAO extends BaseDAO<SurveyInstance> {
         return null;
     }
 
-    public List<SurveyInstance> getMonitoringData(@Nonnull List<SurveyedLocale> surveyedLocales) {
+    public List<SurveyInstance> getRegistrationFormData(@Nonnull List<SurveyedLocale> surveyedLocales) {
 
         if (surveyedLocales.isEmpty()) {
             return Collections.emptyList();

--- a/GAE/test/com/gallatinsystems/surveyal/dao/SurveyInstanceDAOTest.java
+++ b/GAE/test/com/gallatinsystems/surveyal/dao/SurveyInstanceDAOTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (C) 2020,2021 Stichting Akvo (Akvo Foundation)
+ *
+ *  This file is part of Akvo FLOW.
+ *
+ *  Akvo FLOW is free software: you can redistribute it and modify it under the terms of
+ *  the GNU Affero General Public License (AGPL) as published by the Free Software Foundation,
+ *  either version 3 of the License or any later version.
+ *
+ *  Akvo FLOW is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU Affero General Public License included below for more details.
+ *
+ *  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
+ */
+
 package com.gallatinsystems.surveyal.dao;
 
 import com.gallatinsystems.surveyal.domain.SurveyedLocale;

--- a/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
+++ b/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
@@ -114,7 +114,13 @@ public class DataStoreTestUtil {
                 si.setSurveyedLocaleId(dataPoint.getKey().getId());
                 si.setSubmitterName(mockedSubmitter);
                 si.setUuid(mockedUUID);
-                si.setSurveyId(mockedTime*2);
+                if (i == 0) {
+                    long registrationFormId = mockedTime * 4;
+                    si.setSurveyId(registrationFormId);
+                } else {
+                    long monitoringFormId = mockedTime * 2;
+                    si.setSurveyId(monitoringFormId);
+                }
                 Date date = new Date();
                 date.setTime(mockedTime);
                 si.setCollectionDate(date);

--- a/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
+++ b/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2020,2021 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
+++ b/GAE/test/org/akvo/flow/api/app/DataStoreTestUtil.java
@@ -115,7 +115,7 @@ public class DataStoreTestUtil {
                 si.setSubmitterName(mockedSubmitter);
                 si.setUuid(mockedUUID);
                 if (i == 0) {
-                    long registrationFormId = mockedTime * 4;
+                    long registrationFormId = dataPoint.getCreationSurveyId();
                     si.setSurveyId(registrationFormId);
                 } else {
                     long monitoringFormId = mockedTime * 2;
@@ -131,6 +131,11 @@ public class DataStoreTestUtil {
     }
 
     public List<SurveyedLocale> createDataPoints(Long surveyId, int howMany) {
+        long defaultRegistrationForm = mockedTime*4;
+        return createDataPoints(surveyId, defaultRegistrationForm, howMany);
+    }
+
+    public List<SurveyedLocale> createDataPoints(Long surveyId, Long registrationFormId, int howMany) {
         final SurveyedLocaleDao dpDao = new SurveyedLocaleDao();
         final List<SurveyedLocale> datapoints = new ArrayList<>();
         for (int i = 0; i < howMany; i++) {
@@ -138,6 +143,7 @@ public class DataStoreTestUtil {
             dataPoint.setIdentifier("identifier-" + String.valueOf(i));
             dataPoint.setSurveyGroupId(surveyId);
             dataPoint.setDisplayName("dataPoint: " + i);
+            dataPoint.setCreationSurveyId(registrationFormId);
             datapoints.add(dataPoint);
         }
         return new ArrayList<>(dpDao.save(datapoints));

--- a/GAE/test/org/akvo/flow/api/app/FormInstanceUtilTest.java
+++ b/GAE/test/org/akvo/flow/api/app/FormInstanceUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020 Stichting Akvo (Akvo Foundation)
+ *  Copyright (C) 2020,2021 Stichting Akvo (Akvo Foundation)
  *
  *  This file is part of Akvo FLOW.
  *

--- a/GAE/test/org/akvo/flow/api/app/FormInstanceUtilTest.java
+++ b/GAE/test/org/akvo/flow/api/app/FormInstanceUtilTest.java
@@ -122,7 +122,7 @@ public class FormInstanceUtilTest {
         siDTO.setQasList(null);
         assertEquals(new FlowJsonObjectWriter().withExcludeNullValues().writeAsString(siDTO),
                 "{\"collectionDate\":"+ DataStoreTestUtil.mockedTime + ","+
-                        "\"surveyId\":"+DataStoreTestUtil.mockedTime * 2 +"," +
+                        "\"surveyId\":"+DataStoreTestUtil.mockedTime * 4 +"," +
                         "\"surveyalTime\":0," +
                         "\"uuid\":\""+DataStoreTestUtil.mockedUUID+"\"," +
                         "\"submitter\":\""+DataStoreTestUtil.mockedSubmitter+"\"}");

--- a/GAE/test/org/akvo/flow/rest/handler/FormInstanceRequestHandlerTests.java
+++ b/GAE/test/org/akvo/flow/rest/handler/FormInstanceRequestHandlerTests.java
@@ -67,7 +67,8 @@ public class FormInstanceRequestHandlerTests {
     @Test
     public void testDeleteRegistrationFormInstance() {
         Long surveyId = dataStoreTestUtil.randomId();
-        List<SurveyedLocale> singleDataPointList = dataStoreTestUtil.createDataPoints(surveyId, 1);
+        Long registrationFormId = dataStoreTestUtil.randomId();
+        List<SurveyedLocale> singleDataPointList = dataStoreTestUtil.createDataPoints(surveyId, registrationFormId, 1);
         List<SurveyInstance> formInstances = dataStoreTestUtil.createFormInstances(singleDataPointList, 3);
 
         long dataPointId = singleDataPointList.get(0).getKey().getId();

--- a/GAE/test/org/akvo/flow/rest/handler/FormInstanceRequestHandlerTests.java
+++ b/GAE/test/org/akvo/flow/rest/handler/FormInstanceRequestHandlerTests.java
@@ -68,11 +68,12 @@ public class FormInstanceRequestHandlerTests {
     public void testDeleteRegistrationFormInstance() {
         Long surveyId = dataStoreTestUtil.randomId();
         List<SurveyedLocale> singleDataPointList = dataStoreTestUtil.createDataPoints(surveyId, 1);
-        List<SurveyInstance> formInstances = dataStoreTestUtil.createFormInstances(singleDataPointList, 1);
+        List<SurveyInstance> formInstances = dataStoreTestUtil.createFormInstances(singleDataPointList, 3);
 
         long dataPointId = singleDataPointList.get(0).getKey().getId();
         FormInstanceRequestHandler requestHandler = new FormInstanceRequestHandler();
-        requestHandler.deleteFormInstance(formInstances.get(0));
+        SurveyInstance registrationFormInstance = formInstances.get(0);
+        requestHandler.deleteFormInstance(registrationFormInstance);
 
         SurveyInstanceDAO siDao = new SurveyInstanceDAO();
         List<SurveyInstance> remainingFormInstance = siDao.listInstancesByLocale(dataPointId, null, null, null);


### PR DESCRIPTION
#### The solution
* When we delete a registration form instance, the corresponding datapoint in addition to all the other monitoring form instances, are deleted.

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
