### PR TITLE
[#3796] optimize variable name verification

### DIFF
--- a/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
+++ b/GAE/src/com/gallatinsystems/survey/dao/QuestionDao.java
@@ -688,6 +688,19 @@ public class QuestionDao extends BaseDAO<Question> {
         }
     }
 
+    public List<Question> getBySurveyAndVariableName(long surveyId, String variableName) {
+        PersistenceManager pm = PersistenceFilter.getManager();
+        javax.jdo.Query query = pm.newQuery(Question.class);
+        query.setFilter(" surveyId == surveyIdParam && variableName == variableNameParam");
+        query.declareParameters("Long surveyIdParam, String variableNameParam");
+        List<Question> results = (List<Question>) query.execute(surveyId, variableName);
+        if (results != null) {
+            return results;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
     /**
      * finds a question within a group by matching on the questionText passed in
      *

--- a/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
+++ b/GAE/src/org/waterforpeople/mapping/app/web/rest/QuestionRestService.java
@@ -387,7 +387,7 @@ public class QuestionRestService {
 
         boolean isMonitoringGroup = surveyGroup.getMonitoringGroup();
 
-        List<Survey> surveys = new ArrayList<Survey>();
+        List<Survey> surveys = new ArrayList<>();
 
         if (isMonitoringGroup) {
             surveys = surveyDao.listSurveysByGroup(surveyGroupId);
@@ -395,13 +395,13 @@ public class QuestionRestService {
             surveys.add(survey);
         }
 
-        List<Question> questions = new ArrayList<Question>();
+        List<Question> questions = new ArrayList<>();
 
         for (Survey s : surveys) {
-            questions.addAll(questionDao.listQuestionsBySurvey(s.getKey().getId()));
+            questions.addAll(questionDao.getBySurveyAndVariableName(s.getKey().getId(), variableName));
         }
 
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, Object> result = new HashMap<>();
 
         for (Question q : questions) {
             if (variableName.equalsIgnoreCase(q.getVariableName())


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The instances that require a mandatory variable name have call to verify its uniqueness but we fetch all the questions for the form instead of just the ones with that variable name
#### The solution

#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
