### PR TITLE
[#3597] disable ok button while number of items is still loading

### DIFF
--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -170,13 +170,11 @@ FLOW.dialogControl = Ember.Object.create({
         this.set('message', undefined);
 
         if (this.isRegistrationFormInstance(event.contexts[1])) {
-          this.set('showOK', false);
           this.set('showOKDisabled', true);
           const self = this;
           const instanceDeleted = event.contexts[1];
           const submissions = FLOW.SurveyInstance.find({surveyedLocaleId: instanceDeleted.get('surveyedLocaleId')});
           submissions.on('didLoad', () => {
-            self.set('showOK', true);
             this.set('showOKDisabled', false);
             const numberOfSubmissions = submissions.get('content').length;
             const numberMonitoringSubmissions = numberOfSubmissions - 1;

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -112,6 +112,7 @@ FLOW.dialogControl = Ember.Object.create({
   activeAction: null,
   showOK: true,
   showCANCEL: true,
+  showOKDisabled: false,
 
   confirm(event) {
     this.set('activeView', event.view);
@@ -170,11 +171,13 @@ FLOW.dialogControl = Ember.Object.create({
 
         if (this.isRegistrationFormInstance(event.contexts[1])) {
           this.set('showOK', false);
+          this.set('showOKDisabled', true);
           const self = this;
           const instanceDeleted = event.contexts[1];
           const submissions = FLOW.SurveyInstance.find({surveyedLocaleId: instanceDeleted.get('surveyedLocaleId')});
           submissions.on('didLoad', () => {
             self.set('showOK', true);
+            this.set('showOKDisabled', false);
             const numberOfSubmissions = submissions.get('content').length;
             const numberMonitoringSubmissions = numberOfSubmissions - 1;
             if (numberMonitoringSubmissions > 0) {

--- a/Dashboard/app/js/lib/controllers/permissions.js
+++ b/Dashboard/app/js/lib/controllers/permissions.js
@@ -169,13 +169,15 @@ FLOW.dialogControl = Ember.Object.create({
         this.set('message', undefined);
 
         if (this.isRegistrationFormInstance(event.contexts[1])) {
+          this.set('showOK', false);
           const self = this;
           const instanceDeleted = event.contexts[1];
           const submissions = FLOW.SurveyInstance.find({surveyedLocaleId: instanceDeleted.get('surveyedLocaleId')});
           submissions.on('didLoad', () => {
+            self.set('showOK', true);
             const numberOfSubmissions = submissions.get('content').length;
             const numberMonitoringSubmissions = numberOfSubmissions - 1;
-            if(numberMonitoringSubmissions > 0) {
+            if (numberMonitoringSubmissions > 0) {
               self.set('message', Ember.String.loc('_delete_all_monitoring_forms', [numberMonitoringSubmissions]));
             }
           });

--- a/Dashboard/app/js/templates/application/application.handlebars
+++ b/Dashboard/app/js/templates/application/application.handlebars
@@ -28,8 +28,7 @@
       <br/><br/>
       <div class="buttons menuCentre">
         <ul>
-          {{#if FLOW.dialogControl.showOK}} <li><a {{action "doOK" target="FLOW.dialogControl"}} class="ok smallBtn">{{t _ok}}</a></li>{{/if}}
-          {{#if FLOW.dialogControl.showOKDisabled}} <li><a class="ok smallBtn disabled">{{t _ok}}</a></li>{{/if}}
+          {{#if FLOW.dialogControl.showOK}} <li><a {{bindAttr class="FLOW.dialogControl.showOKDisabled:disabled :ok :smallBtn"}} {{action "doOK" target="FLOW.dialogControl"}}>{{t _ok}}</a></li>{{/if}}
           {{#if FLOW.dialogControl.showCANCEL}} <li><a {{action "doCANCEL" target="FLOW.dialogControl"}} class="cancel">{{t _cancel}}</a></li>{{/if}}
         </ul>
       </div>

--- a/Dashboard/app/js/templates/application/application.handlebars
+++ b/Dashboard/app/js/templates/application/application.handlebars
@@ -29,6 +29,7 @@
       <div class="buttons menuCentre">
         <ul>
           {{#if FLOW.dialogControl.showOK}} <li><a {{action "doOK" target="FLOW.dialogControl"}} class="ok smallBtn">{{t _ok}}</a></li>{{/if}}
+          {{#if FLOW.dialogControl.showOKDisabled}} <li><a class="ok smallBtn disabled">{{t _ok}}</a></li>{{/if}}
           {{#if FLOW.dialogControl.showCANCEL}} <li><a {{action "doCANCEL" target="FLOW.dialogControl"}} class="cancel">{{t _cancel}}</a></li>{{/if}}
         </ul>
       </div>


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)
The dialog appears but users can accept before knowing that monitoring instances will also be deleted
#### The solution
while loading:
![Screenshot from 2021-05-21 13-42-44](https://user-images.githubusercontent.com/923280/119136823-66c82c80-ba40-11eb-8c0a-deb3eb47cf70.png)

when loading completed:
![Screenshot from 2021-05-21 13-42-46](https://user-images.githubusercontent.com/923280/119136818-662f9600-ba40-11eb-93b4-27954d11e1a7.png)


#### Screenshots (if appropriate)

#### Reviewer Checklist
* [ ] Added an explanation about the work done
* [ ] Connected the PR and the issue on Zenhub
* [ ] Added a test plan to the issue
* [ ] Updated the copyright header (when relevant)
* [ ] Formatted the code
* [ ] Added a documentation (if relevant)
* [ ] Added some unit tests (if relevant)
