### PR TITLE
Configure automatic scaling

### DIFF
--- a/Config/instanceConfigurator/src/org/akvo/flow/templates/appengine-web.xml.ftl
+++ b/Config/instanceConfigurator/src/org/akvo/flow/templates/appengine-web.xml.ftl
@@ -6,6 +6,12 @@
     <sessions-enabled>true</sessions-enabled>
     <threadsafe>true</threadsafe>
     <auto-id-policy>legacy</auto-id-policy>
+        <automatic-scaling>
+        <!-- Default is 20 -->
+        <max-instances>5</max-instances>
+        <!-- Default is 10 -->
+        <max-concurrent-requests>50</max-concurrent-requests>
+    </automatic-scaling>
     <static-files>
         <include path="/**.png" expiration="1000d 5h" />
         <include path="/**.jpg" expiration="1000d 5h" />


### PR DESCRIPTION
#### Before the PR (what is the issue or what needed to be done)

Related doc: https://cloud.google.com/appengine/docs/legacy/standard/java/config/appref#scaling_elements_automatic_scaling

The default max-concurrent-requests is too low and forcing more instances to spawn.
The default max instance is really high and incurring high costs.

#### The solution

Increase max-concurent-requests, lower max-instance

-----------

Related to akvo/akvo-flow-server-config#740